### PR TITLE
Implement Scheduled Issue Triage for Jules

### DIFF
--- a/.github/workflows/scheduled-jules.yml
+++ b/.github/workflows/scheduled-jules.yml
@@ -1,0 +1,26 @@
+name: Scheduled Jules Maintenance
+on:
+  schedule:
+    - cron: '0 0,8,16 * * *' # Runs 3 times a day (00:00, 08:00, 16:00 UTC)
+  workflow_dispatch:
+
+jobs:
+  jules-watch:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run Jules Issue Watcher
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/jules_issue_watcher.py

--- a/docs/architecture/automated_contributions.md
+++ b/docs/architecture/automated_contributions.md
@@ -16,46 +16,15 @@ The system allows the repository to self-improve by assigning tasks to the Jules
 - Ensure the label `jules` (case-insensitive) is created in the repository.
 
 ### 3. Scheduled Tasks Configuration
-To run Jules in scheduled mode (e.g., several times each day to pick up new issues):
-- **GitHub Action**: Create a workflow that uses a cron schedule.
-- **CLI Interaction**: Use `jules-tools` (npm) in the action to list and assign tasks.
+The repository utilizes an autonomous watcher (`.github/workflows/scheduled-jules.yml`) that runs periodically to find new tasks.
 
-#### Example GitHub Action (`.github/workflows/scheduled-jules.yml`):
-```yaml
-name: Scheduled Jules Maintenance
-on:
-  schedule:
-    - cron: '0 0,8,16 * * *' # Runs 3 times a day (00:00, 08:00, 16:00 UTC)
-  workflow_dispatch:
+### 1. Issue Watcher Logic
+The watcher searches for any open issues mentioning "jules" that do not yet have the `jules` label.
+- **Labeling**: It automatically adds the `jules` label to trigger the agent.
+- **Default Intent**: If no specific action verbs (e.g., "refactor", "fix", "add") are found in the issue, it assumes the issue provides new information to be organized. In this case, it adds a guiding comment for Jules.
 
-jobs:
-  run-jules:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Run Jules Tasks
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-        run: |
-          # Use GH CLI to find issues with label 'jules' and no assignee
-          ISSUES=$(gh issue list --label "jules" --json number,title --jq '.[] | "\(.number): \(.title)"')
-
-          if [ -z "$ISSUES" ]; then
-            echo "No new Jules tasks found."
-            exit 0
-          fi
-
-          echo "Processing issues: $ISSUES"
-          # Automation logic to pipe to jules-tools would go here
-```
+### 2. Manual Triggering
+You can also manually trigger Jules by adding the `jules` label to any issue.
 
 ## Task Lifecycle
 1.  **Discovery**: Human or script adds `jules` label to an issue.

--- a/docs/tools/ai_knowledge/jules.md
+++ b/docs/tools/ai_knowledge/jules.md
@@ -5,6 +5,8 @@ Jules is an extremely skilled software engineer agent (that's me!).
 ## Description
 Jules assists users by completing coding tasks, solving bugs, implementing features, and writing tests. It is resourceful and uses various tools to accomplish its goals.
 
+In this repository, Jules also performs autonomous maintenance by watching for issues that mention its name and either executing requested tasks or organizing new information provided in the issue.
+
 ## Links
 - [Internal System Documentation](../../architecture/automated_contributions.md) ([Jules Info](https://github.com/google-jules))
 

--- a/scripts/jules_issue_watcher.py
+++ b/scripts/jules_issue_watcher.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Jules Issue Watcher
+Searches for issues mentioning "jules" and ensures they are labeled for processing.
+If no specific instructions are found, it directs Jules to organize the information.
+"""
+
+import subprocess
+import json
+import sys
+import re
+
+def run_gh_command(args):
+    """Runs a gh command and returns the output."""
+    try:
+        result = subprocess.run(['gh'] + args, capture_output=True, text=True, check=True)
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        print(f"Error running gh command {' '.join(args)}: {e.stderr}")
+        return None
+    except FileNotFoundError:
+        print("Error: 'gh' CLI not found. This script requires the GitHub CLI.")
+        return None
+
+def has_explicit_instructions(title, body):
+    """
+    Checks if the issue contains explicit instructions for Jules.
+    Uses a list of action verbs commonly used in Jules prompts.
+    """
+    action_verbs = [
+        'refactor', 'add', 'fix', 'create', 'update', 'remove', 'delete',
+        'implement', 'write', 'generate', 'upgrade', 'check', 'setup',
+        'analyze', 'identify', 'find', 'convert', 'initialize', 'bootstrap',
+        'diagnose', 'trace', 'why'
+    ]
+
+    content = (title + " " + body).lower()
+
+    # Check for keywords
+    for verb in action_verbs:
+        if re.search(r'\b' + verb + r'\b', content):
+            return True
+
+    # Check for direct mentions with a command-like structure (e.g. "@jules do X")
+    if re.search(r'@jules\s+\w+', content):
+        return True
+
+    return False
+
+def main():
+    # Search for issues mentioning "jules" that are open and don't have the "jules" label.
+    # We use -label:jules to avoid re-processing issues we've already labeled.
+    # The search API is used to find "jules" in title, body, or comments.
+    search_query = "jules -label:jules is:open"
+
+    print(f"Searching for issues with query: {search_query}")
+    issues_json = run_gh_command(['issue', 'list', '--search', search_query, '--json', 'number,title,body'])
+
+    if issues_json is None:
+        sys.exit(1)
+
+    try:
+        issues = json.loads(issues_json)
+    except json.JSONDecodeError:
+        print("Failed to decode JSON from gh output.")
+        sys.exit(1)
+
+    if not issues:
+        print("No new issues found mentioning 'jules'.")
+        return
+
+    for issue in issues:
+        number = issue['number']
+        title = issue['title']
+        body = issue['body'] or ""
+
+        print(f"Processing issue #{number}: {title}")
+
+        # Fetch comments to include in the heuristic
+        comments_json = run_gh_command(['issue', 'view', str(number), '--json', 'comments'])
+        full_content = body
+        if comments_json:
+            try:
+                comments_data = json.loads(comments_json)
+                for comment in comments_data.get('comments', []):
+                    full_content += " " + (comment.get('body') or "")
+            except json.JSONDecodeError:
+                pass
+
+        # 1. Add 'jules' label to trigger the agent
+        print(f"Adding 'jules' label to issue #{number}...")
+        run_gh_command(['issue', 'edit', str(number), '--add-label', 'jules'])
+
+        # 2. If no explicit instructions, add a guiding comment
+        if not has_explicit_instructions(title, full_content):
+            print(f"No explicit instructions detected for issue #{number}. Adding organizational guidance.")
+            comment = (
+                "@jules This issue mentions you but doesn't seem to have a specific command. "
+                "Per the repository's automated maintenance policy, please assume this issue "
+                "is providing new information to be organized. Review the content and update "
+                "the repository's documentation or data files (e.g., data/all_tools.json, docs/services/) "
+                "accordingly."
+            )
+            run_gh_command(['issue', 'comment', str(number), '--body', comment])
+        else:
+            print(f"Explicit instructions detected for issue #{number}. Jules will follow them.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change implements a scheduled maintenance job as requested. It consists of a Python script that searches for GitHub issues mentioning 'jules', applies the 'jules' label to trigger the agent, and analyzes the content (including comments) for explicit instructions. If no specific instructions are found, it assumes the intent is to organize information and adds a guiding comment for the agent. The system is scheduled via a GitHub Action to run every 8 hours.

---
*PR created automatically by Jules for task [10261173789384810557](https://jules.google.com/task/10261173789384810557) started by @joanmarcriera*