### PR TITLE
Add taxonomy, templates, and staging inbox for Jules daily ingestion

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,6 +11,14 @@ Thank you for your interest in improving the Home-Office Automation & AI Hub! We
 ## Automated Contributions via Google Jules
 This repository uses **Google Jules**, an autonomous AI coding agent, to help with maintenance and feature development.
 
+### Daily Ingestion Job
+Jules runs a **scheduled daily job** that:
+
+1. **Scans** high-signal sources (Hacker News, Reddit, arXiv, GitHub Trending, engineering blogs, etc.)
+2. **Stages** qualifying items in [`docs/new-sources.md`](new-sources.md) with title, URL, summary, and tags
+3. **Integrates** staged items into canonical pages or creates new pages using the [tool template](templates/tool_template.md) or [article template](templates/article_template.md)
+4. **Deduplicates** against existing content before adding anything
+
 ### Assigning a Task to Jules
 You can request Jules to perform a task by:
 1.  **Opening an Issue**: Describe the task clearly (e.g., "Add documentation for Tool X" or "Fix broken link in README").
@@ -21,6 +29,9 @@ You can request Jules to perform a task by:
 ## Contribution Standards
 - **Precise & Technical**: Avoid marketing language; focus on implementation details.
 - **Cross-Link**: Always link to related tools, playbooks, or architectural docs.
+- **One canonical page per tool/framework/provider**: All mentions elsewhere must link to the canonical page.
+- **Use templates**: [Tool template](templates/tool_template.md) for tools/frameworks/providers. [Article template](templates/article_template.md) for papers and articles.
+- **No stub pages**: Only create a page if you have enough information to fill the template meaningfully.
 - **JSON Metadata**: If adding a tool, ensure you also update `data/all_tools.json`.
 
 ---

--- a/docs/knowledge_base/patterns/index.md
+++ b/docs/knowledge_base/patterns/index.md
@@ -1,0 +1,16 @@
+# Patterns
+
+Recurring architectural and design patterns in AI/LLM systems — RAG, tool calling, routing, guardrails, and more.
+
+## Contents
+
+<!-- New pattern pages are added here by Jules -->
+
+## Common Patterns
+
+- **RAG (Retrieval-Augmented Generation)** — Grounding LLM output with retrieved context
+- **Tool Calling / Function Calling** — LLMs invoking external tools via structured schemas
+- **Routing** — Directing queries to specialised models or agents
+- **Guardrails** — Input/output validation and safety filtering
+- **Chain-of-Thought** — Structured reasoning prompts
+- **Multi-Agent Collaboration** — Multiple agents coordinating on a task

--- a/docs/new-sources.md
+++ b/docs/new-sources.md
@@ -1,0 +1,32 @@
+# New Sources — Staging Inbox
+
+This file is the daily ingestion inbox maintained by [Jules](tools/ai_knowledge/jules.md). Each entry is discovered, classified, and staged here before being integrated into canonical pages.
+
+## How This Works
+
+1. **Jules scans** multiple high-signal sources daily (Hacker News, Reddit, arXiv, GitHub Trending, engineering blogs, etc.)
+2. **Qualifying items** are appended below with metadata and a short summary.
+3. **Integration** moves items into canonical pages or marks them as duplicates.
+4. Items stay here until they are either integrated or flagged as needing more info.
+
+## Status Legend
+
+| Status | Meaning |
+| :--- | :--- |
+| `new` | Discovered, not yet integrated |
+| `integrated` | Merged into a canonical page |
+| `duplicate` | Already exists in the repo (with link to existing page) |
+| `needs-more-info` | Insufficient information to create a full page |
+| `low-confidence` | Source quality uncertain; do not integrate yet |
+
+## Tags
+
+Items are classified with one or more of:
+
+`tool` · `framework` · `provider` · `paper/article` · `tutorial/guide` · `benchmark/eval` · `infrastructure` · `analysis`
+
+---
+
+## Entries
+
+<!-- New entries are appended below this line by Jules. Do not remove this comment. -->

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -2,6 +2,34 @@
 
 This document defines the technical standards for tools to interoperate within this automation stack.
 
+## Taxonomy
+
+The knowledge base uses a stable set of top-level categories. Do not create new top-level sections unless strictly necessary.
+
+| Category | Location | What belongs here |
+| :--- | :--- | :--- |
+| **AI & Knowledge** | `tools/ai_knowledge/` | General AI tools, knowledge management, LLM products |
+| **Frameworks** | `tools/frameworks/` | Libraries for building LLM apps (LangChain, LlamaIndex, etc.) |
+| **Providers** | `tools/providers/` | Companies offering LLM APIs or managed AI services |
+| **Agents** | `tools/agents/` | Agent frameworks and autonomous AI tools |
+| **Orchestration** | `tools/orchestration/` | Workflow automation, multi-agent routing, pipeline tools |
+| **Infrastructure** | `tools/infrastructure/` | Inference engines, vector DBs, serving stacks, quantisation |
+| **Benchmarking** | `tools/benchmarking/` | Eval frameworks, benchmarks, leaderboards |
+| **Development & Ops** | `tools/development_ops/` | AI-assisted coding tools and IDEs |
+| **Patterns** | `knowledge_base/patterns/` | Recurring design patterns (RAG, tool calling, routing, etc.) |
+| **Playbooks** | `playbooks/` | Step-by-step workflow guides |
+
+### Deduplication Rules
+
+- **One canonical page per tool/framework/provider.** All other mentions must link to that canonical page.
+- Before creating a new page, search the repo for the tool name, URL, and common aliases.
+- If a source maps to an existing page, update that page rather than creating a new one.
+- Merge duplicates rather than creating parallel pages.
+
+### Source Classification Tags
+
+Items in `new-sources.md` use these tags: `tool` · `framework` · `provider` · `paper/article` · `tutorial/guide` · `benchmark/eval` · `infrastructure` · `analysis`
+
 ## Naming Conventions
 - **Tags (Paperless)**: `kebab-case`. Lowercase only. Prefix status tags with `s:` and category tags with `c:`.
 - **Workflows (n8n)**: `[Trigger Source] -> [Primary Action]`. Example: `IMAP -> Paperless Intake`.

--- a/docs/templates/article_template.md
+++ b/docs/templates/article_template.md
@@ -1,0 +1,21 @@
+# [Article / Paper Title]
+
+## Summary
+[3–5 line neutral technical summary]
+
+## Key contributions
+- [Contribution 1]
+- [Contribution 2]
+
+## Where it fits in the stack
+[Which area does this advance: LLMs / Agents / RAG / Inference / Evaluation / Infrastructure / Orchestration]
+
+## Relevance to this knowledge base
+[Why this matters for the tools and patterns tracked here]
+
+## Related tools / concepts
+- [Related page](relative-link.md)
+
+## Sources / References
+- [Original paper / article](URL)
+- [Code / implementation](URL)

--- a/docs/templates/tool_template.md
+++ b/docs/templates/tool_template.md
@@ -6,32 +6,36 @@
 ## What problem it solves
 [Specific problems addressed]
 
-## Where it fits in the pipeline
-[ingest / process / reason / act / sync]
+## Where it fits in the stack
+[Provider / Router / Agent / Tool / Framework / Infra / Eval / Pattern]
 
-## Typical use cases (in this homelab / family automation context)
-[Practical examples: school docs, family calendar, coding, etc.]
+## Typical use cases
+- [Use case 1]
+- [Use case 2]
 
-## Integration points
-- [Point 1]
-- [Point 2]
+## Strengths
+- [Strength 1]
+- [Strength 2]
+
+## Limitations
+- [Limitation 1]
+- [Limitation 2]
+
+## When to use it
+- [Scenario 1]
+
+## When not to use it
+- [Scenario 1]
 
 ## Licensing and cost
 - **Open Source**: [Yes/No]
 - **Cost**: [Free / Paid / Freemium]
-- **Free tier**: [Yes/No (details)]
 - **Self-hostable**: [Yes/No]
 
-## Strengths
-- [Strength 1]
+## Related tools / concepts
+- [Related tool 1](relative-link.md)
 
-## Limitations
-- [Limitation 1]
-
-## Alternatives / Related tools
-- [Related tool 1]
-
-## Links
-- [Official Website]
-- [GitHub]
-- [Docs]
+## Sources / References
+- [Official Website](URL)
+- [GitHub](URL)
+- [Docs](URL)

--- a/docs/tools/agents/index.md
+++ b/docs/tools/agents/index.md
@@ -1,0 +1,18 @@
+# Agents & Agent Frameworks
+
+Tools and frameworks for building, running, and orchestrating autonomous AI agents.
+
+## Contents
+
+| Agent / Framework | What it does |
+| :--- | :--- |
+| [OpenHands](../development_ops/openhands.md) | Autonomous software development agent |
+| [Jules](../ai_knowledge/jules.md) | Google's autonomous coding agent |
+| [Dify](../ai_knowledge/dify.md) | LLM app development platform with agent workflows |
+
+<!-- New agent pages are added here by Jules -->
+
+## Related
+
+- [Agent Protocols (MCP & ACP)](../../knowledge_base/agent_protocols.md)
+- [Orchestration](../orchestration/index.md)

--- a/docs/tools/frameworks/index.md
+++ b/docs/tools/frameworks/index.md
@@ -1,0 +1,12 @@
+# Frameworks
+
+Libraries and frameworks for building AI/LLM-powered applications — orchestration, retrieval, agent construction, and inference pipelines.
+
+## Contents
+
+| Framework | What it does |
+| :--- | :--- |
+| [LangChain](../ai_knowledge/langchain.md) | LLM application framework with chains, agents, and tool use |
+| [LlamaIndex](../ai_knowledge/llamaindex.md) | Data framework for LLM apps — indexing, retrieval, RAG |
+
+<!-- New framework pages are added here by Jules -->

--- a/docs/tools/infrastructure/index.md
+++ b/docs/tools/infrastructure/index.md
@@ -1,0 +1,19 @@
+# Infrastructure
+
+Inference engines, serving stacks, quantisation tools, vector databases, and deployment infrastructure for AI/LLM workloads.
+
+## Contents
+
+| Tool | What it does |
+| :--- | :--- |
+| [Ollama](../../services/ollama.md) | Local LLM inference server |
+| [LiteLLM](../../services/litellm.md) | Unified LLM API proxy |
+
+<!-- New infrastructure pages are added here by Jules -->
+
+## Sub-categories
+
+- **Inference engines** — vLLM, TGI, llama.cpp, MLX, etc.
+- **Vector databases** — Pinecone, Weaviate, Milvus, Qdrant, etc.
+- **Serving & routing** — Load balancers, model routers, API gateways
+- **Quantisation & optimisation** — GGUF, GPTQ, AWQ, etc.

--- a/docs/tools/orchestration/index.md
+++ b/docs/tools/orchestration/index.md
@@ -1,0 +1,18 @@
+# Orchestration
+
+Tools and patterns for orchestrating LLM workflows, multi-agent systems, routing, and pipeline management.
+
+## Contents
+
+| Tool | What it does |
+| :--- | :--- |
+| [n8n](../../services/n8n.md) | Visual workflow automation with AI nodes |
+| [Make](../automation_orchestration/make.md) | Cloud-based workflow automation |
+| [Zapier](../automation_orchestration/zapier.md) | No-code automation platform |
+
+<!-- New orchestration pages are added here by Jules -->
+
+## Related
+
+- [Agent Protocols (MCP & ACP)](../../knowledge_base/agent_protocols.md)
+- [Agents](../agents/index.md)

--- a/docs/tools/providers/index.md
+++ b/docs/tools/providers/index.md
@@ -1,0 +1,11 @@
+# Providers
+
+Companies and platforms that offer LLM inference, APIs, or managed AI services.
+
+## Contents
+
+| Provider | What it offers |
+| :--- | :--- |
+| [ChatGPT / OpenAI](../ai_knowledge/chatgpt.md) | GPT model family, API, ChatGPT product |
+
+<!-- New provider pages are added here by Jules -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - New Sources: new-sources.md
   - Playbooks:
     - Overview: playbooks/index.md
     - Dev Workflow AI Assisted: playbooks/dev-workflow-ai-assisted.md
@@ -169,6 +170,16 @@ nav:
     - Intake & Storage:
       - Overview: tools/intake_storage/index.md
       - Caldav: tools/intake_storage/caldav.md
+    - Frameworks:
+      - Overview: tools/frameworks/index.md
+    - Providers:
+      - Overview: tools/providers/index.md
+    - Agents:
+      - Overview: tools/agents/index.md
+    - Orchestration:
+      - Overview: tools/orchestration/index.md
+    - Infrastructure:
+      - Overview: tools/infrastructure/index.md
     - Process & Understanding:
       - Overview: tools/process_understanding/index.md
       - OCRmypdf: tools/process_understanding/ocrmypdf.md
@@ -182,6 +193,8 @@ nav:
     - Overview: knowledge_base/README.md
     - Agent Protocols: knowledge_base/agent_protocols.md
     - Model Classes: knowledge_base/model_classes.md
+    - Patterns:
+      - Overview: knowledge_base/patterns/index.md
   - Reference Implementations:
     - Overview: reference-implementations/index.md
     - Calendar:


### PR DESCRIPTION
## Summary
- Adds `docs/new-sources.md` as the staging inbox for Jules' daily ingestion job (with status legend and tag definitions)
- Creates new taxonomy categories (frameworks, providers, agents, orchestration, infrastructure, patterns) with index pages
- Updates tool template to match Jules' expected page format (adds "when to use/not use", "sources/references")
- Adds article/paper template for research content integration
- Updates `standards.md` with taxonomy table, deduplication rules, and classification tags
- Updates `CONTRIBUTING.md` and `mkdocs.yml` navigation

## Test plan
- [ ] Verify MkDocs builds without errors (`mkdocs build`)
- [ ] Confirm all new nav links resolve correctly
- [ ] Verify new-sources.md renders properly on the site
- [ ] Run Jules daily job against the new structure and confirm it stages entries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)