### PR TITLE
Fix relative link to non-markdown file in component_map.md

### DIFF
--- a/docs/architecture/component_map.md
+++ b/docs/architecture/component_map.md
@@ -56,7 +56,7 @@ This map categorizes all tools in the stack based on their primary function in t
 ## Sources / References
 
 - [Stack Overview](https://home-toolset.riera.co.uk)
-- [Component Map Source Data](../../data/all_tools.json)
+- [Component Map Source Data](https://github.com/joanmarcriera/Home-office-automations/blob/main/data/all_tools.json)
 
 ## Contribution Metadata
 


### PR DESCRIPTION
Fixed a broken relative link in `docs/architecture/component_map.md` that was causing `mkdocs build --strict` to fail. The link was changed to an absolute GitHub URL as per the repository's strict link compliance standards.

---
*PR created automatically by Jules for task [3816455920336920284](https://jules.google.com/task/3816455920336920284) started by @joanmarcriera*