### PR TITLE
feat: autonomous growth system for 4-week KB expansion

### DIFF
--- a/.github/issue-templates/category-gap-filler.md
+++ b/.github/issue-templates/category-gap-filler.md
@@ -1,0 +1,19 @@
+## Category Gap Fill
+
+The target category is underdeveloped and needs more tool documentation.
+
+### Instructions
+1. Research and identify **up to 8 tools** that belong in the target category
+2. For each tool, create a doc using `docs/templates/tool_template.md`
+3. Place in the appropriate `docs/tools/<category>/` directory
+4. Add to `data/all_tools.json` and `mkdocs.yml` navigation
+5. Add an intake row to today's `docs/new-sources/YYYY-MM-DD.md` with `Status: integrated`
+6. Do NOT create stub pages — every doc must have substantive content
+
+### Deduplication
+Before creating any page, search the repo for the tool name and common aliases.
+If it already exists elsewhere, update the existing page instead.
+
+### Quality checks
+- Verify: `python3 -c "import yaml; yaml.safe_load(open('mkdocs.yml')); print('OK')"`
+- Run: `python3 scripts/validate_new_sources.py`

--- a/.github/issue-templates/weekly-deepen-docs.md
+++ b/.github/issue-templates/weekly-deepen-docs.md
@@ -1,0 +1,21 @@
+## Weekly Doc Deepening
+
+The following docs are the shallowest in the knowledge base and need practical content.
+
+### Target docs
+<!-- GENERATED_LIST placeholder — weekly_planner.py fills this -->
+
+### Instructions
+For each doc above:
+1. Read the tool's official website/GitHub from its **Sources / References** section
+2. Add a `## Getting started` section after `## When not to use it` with:
+   - Installation command (`pip install`, `npm install`, `docker pull`, or equivalent)
+   - A minimal working example in a fenced code block (Python, CLI, or config as appropriate)
+3. If the tool has a CLI, add `## CLI examples` with 2-3 common commands
+4. If the tool has an API/SDK, add `## API examples` with a Python or curl snippet
+5. Keep all existing content unchanged
+6. Update `- Last reviewed:` in the Contribution Metadata section
+
+### Quality checks
+- Verify: `python3 -c "import yaml; yaml.safe_load(open('mkdocs.yml')); print('OK')"`
+- Ensure all code examples are complete and runnable (no placeholder `...` blocks)

--- a/.github/workflows/digest-to-intake.yml
+++ b/.github/workflows/digest-to-intake.yml
@@ -1,0 +1,44 @@
+name: Digest to Intake Bridge
+
+on:
+  schedule:
+    - cron: "0 1 * * *"  # 01:00 UTC, 1 hour after daily digest
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  bridge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install openai
+
+      - name: Run bridge script
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: python scripts/digest_to_intake.py
+
+      - name: Commit and push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/new-sources/
+          if git diff --staged --quiet; then
+            echo "No new intake items."
+          else
+            git commit -m "chore(intake): bridge digest sources for $(date +'%Y-%m-%d')"
+            git push origin main
+          fi

--- a/.github/workflows/weekly-planner.yml
+++ b/.github/workflows/weekly-planner.yml
@@ -1,0 +1,51 @@
+name: Weekly Growth Planner
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"  # Monday 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install openai
+
+      - name: Run growth tracker
+        run: python scripts/growth_tracker.py
+
+      - name: Update source scores
+        run: python scripts/update_source_scores.py
+
+      - name: Create weekly issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/weekly_planner.py
+
+      - name: Commit metrics
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/growth-metrics.json data/source-scores.json
+          if git diff --staged --quiet; then
+            echo "No metrics changes."
+          else
+            git commit -m "chore: weekly growth snapshot $(date +'%Y-%m-%d')"
+            git push origin main
+          fi

--- a/ai-daily-digest/sources.yaml
+++ b/ai-daily-digest/sources.yaml
@@ -47,3 +47,40 @@
   type: rss
   url: https://rockwotj.com/rss.xml
   tags: [security, llm, engineering]
+
+# --- Tool & framework discovery feeds ---
+
+- name: The Changelog
+  type: rss
+  url: https://changelog.com/feed
+  tags: [open-source, tools]
+
+- name: Latent Space
+  type: rss
+  url: https://www.latent.space/feed
+  tags: [llm, tools, engineering]
+
+- name: The New Stack
+  type: rss
+  url: https://thenewstack.io/feed/
+  tags: [infrastructure, devops]
+
+- name: r/ollama
+  type: reddit
+  url: https://www.reddit.com/r/ollama/.rss
+  tags: [llm, local, tools]
+
+- name: r/n8n
+  type: reddit
+  url: https://www.reddit.com/r/n8n/.rss
+  tags: [automation, orchestration]
+
+- name: r/selfhosted
+  type: reddit
+  url: https://www.reddit.com/r/selfhosted/.rss
+  tags: [infrastructure, self-hosted]
+
+- name: r/LLMDevs
+  type: reddit
+  url: https://www.reddit.com/r/LLMDevs/.rss
+  tags: [llm, tools, development]

--- a/data/growth-metrics.json
+++ b/data/growth-metrics.json
@@ -1,0 +1,49 @@
+{
+  "snapshot_date": "2026-02-26",
+  "total_docs": 126,
+  "tool_docs": 79,
+  "service_docs": 47,
+  "by_category": {
+    "ai_knowledge": 18,
+    "automation_orchestration": 8,
+    "benchmarking": 14,
+    "calendar_tasks": 1,
+    "development_ops": 29,
+    "frameworks": 1,
+    "infrastructure": 2,
+    "intake_storage": 1,
+    "process_understanding": 5
+  },
+  "docs_with_code_examples": 4,
+  "docs_without_code_examples": 122,
+  "shallow_docs": [
+    "docs/services/focalboard.md",
+    "docs/services/storj.md",
+    "docs/services/homebox.md",
+    "docs/services/qbittorrent.md",
+    "docs/services/diskover.md",
+    "docs/services/minecraft.md",
+    "docs/services/tika.md",
+    "docs/services/tailscale.md",
+    "docs/services/kiwix.md",
+    "docs/services/plex.md",
+    "docs/services/portracker.md",
+    "docs/services/vikunja.md",
+    "docs/services/metube.md",
+    "docs/services/authentik.md",
+    "docs/services/gitea.md",
+    "docs/services/speedtest.md",
+    "docs/services/jackett.md",
+    "docs/services/mealie.md",
+    "docs/services/excalidraw.md",
+    "docs/services/grocy.md"
+  ],
+  "underdeveloped_categories": [
+    "calendar_tasks",
+    "frameworks",
+    "infrastructure",
+    "intake_storage",
+    "process_understanding"
+  ],
+  "weekly_additions": 0
+}

--- a/data/source-scores.json
+++ b/data/source-scores.json
@@ -1,0 +1,130 @@
+{
+  "sources": {
+    "anthropic.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "app.teamout.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "arxiv.org": {
+      "discovered": 3,
+      "integrated": 3,
+      "score": 1.0
+    },
+    "ben-evans.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "blog.cloudflare.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "code.claude.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "gist.github.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "github.blog": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "github.com": {
+      "discovered": 13,
+      "integrated": 13,
+      "score": 1.0
+    },
+    "kanyilmaz.me": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "linum.ai": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "mcpservers.org": {
+      "discovered": 2,
+      "integrated": 2,
+      "score": 1.0
+    },
+    "medium.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "modelcontextprotocol.info": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "news.microsoft.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "npmjs.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "rockwotj.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "saewitz.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "si.inc": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "simonlermen.substack.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "stackone.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "trufflesecurity.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "valyu.ai": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "vibrantlabs.com": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    },
+    "yogthos.net": {
+      "discovered": 1,
+      "integrated": 1,
+      "score": 1.0
+    }
+  },
+  "updated": "2026-02-26"
+}

--- a/scripts/digest_to_intake.py
+++ b/scripts/digest_to_intake.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Digest-to-Intake Bridge
+
+Reads the latest AI daily digest, extracts tool/library/framework mentions,
+deduplicates against existing catalog, and appends new rows to today's
+intake log in docs/new-sources/YYYY-MM-DD.md.
+
+Runs daily at 01:00 UTC, one hour after the digest workflow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DIGEST_DIR = Path("ai-daily-digest/daily")
+NEW_SOURCES_DIR = Path("docs/new-sources")
+NEW_SOURCES_INDEX = Path("docs/new-sources.md")
+ALL_TOOLS_PATH = Path("data/all_tools.json")
+SOURCE_SCORES_PATH = Path("data/source-scores.json")
+
+MODEL_STRING = os.environ.get(
+    "OPENROUTER_MODEL",
+    "meta-llama/llama-3.3-70b-instruct:free,deepseek/deepseek-r1:free,qwen/qwen-2-7b-instruct:free",
+)
+MODELS = [m.strip() for m in MODEL_STRING.split(",")]
+
+MAX_ITEMS_PER_DAY = 15  # cap to avoid overwhelming Jules
+
+LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)]+)\)")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def load_existing_urls() -> set[str]:
+    """Collect all URLs already in intake logs and the tool catalog."""
+    urls: set[str] = set()
+
+    # From all_tools.json
+    if ALL_TOOLS_PATH.exists():
+        data = json.loads(ALL_TOOLS_PATH.read_text(encoding="utf-8"))
+        for tool in data.get("tools", []):
+            name_lower = tool.get("name", "").lower()
+            urls.add(name_lower)
+
+    # From existing daily logs
+    for log_file in NEW_SOURCES_DIR.glob("*.md"):
+        for line in log_file.read_text(encoding="utf-8").splitlines():
+            match = re.search(r"https?://[^\s)]+", line)
+            if match:
+                urls.add(match.group(0).rstrip("|").strip())
+
+    return urls
+
+
+def load_source_scores() -> dict:
+    """Load source prioritisation scores."""
+    if SOURCE_SCORES_PATH.exists():
+        return json.loads(SOURCE_SCORES_PATH.read_text(encoding="utf-8"))
+    return {"sources": {}, "updated": ""}
+
+
+def extract_links_from_digest(digest_path: Path) -> list[dict]:
+    """Extract all markdown links from a digest file."""
+    text = digest_path.read_text(encoding="utf-8")
+    items = []
+    for title, url in LINK_RE.findall(text):
+        # Skip reddit discussion links and generic blog homepages
+        if "/comments/" in url and "reddit.com" in url:
+            # Keep reddit links — they sometimes point to tools
+            pass
+        items.append({"title": title.strip(), "url": url.strip()})
+    return items
+
+
+def classify_with_llm(items: list[dict]) -> list[dict]:
+    """Call OpenRouter to classify which items are tools/frameworks/providers."""
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        print("Warning: OPENROUTER_API_KEY not set; skipping LLM classification.")
+        return []
+
+    from openai import OpenAI
+
+    client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
+
+    system_prompt = """You are an AI tools curator. Given a list of items from a daily AI digest,
+identify ONLY items that are specific, named tools, libraries, frameworks, platforms, or providers
+in the AI/LLM/ML space. Exclude: general news articles, opinion pieces, discussions, job posts,
+hardware announcements without a software tool, and generic blog posts.
+
+For each qualifying item, output a JSON array of objects:
+{"title": "Tool Name", "url": "https://...", "tags": "tool, framework", "notes": "One-line description"}
+
+Tags must be from: tool, framework, provider, paper/article, benchmark/eval, infrastructure, analysis
+If nothing qualifies, return an empty array: []
+Return ONLY valid JSON. No markdown wrapping."""
+
+    items_text = "\n".join(f"- [{it['title']}]({it['url']})" for it in items)
+    user_prompt = f"Classify these items:\n\n{items_text}"
+
+    for model in MODELS:
+        try:
+            print(f"Classifying with {model}...")
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.1,
+                max_tokens=1500,
+            )
+            content = response.choices[0].message.content.strip()
+            # Strip markdown code fences if present
+            content = re.sub(r"^```(?:json)?\s*", "", content)
+            content = re.sub(r"\s*```$", "", content)
+            return json.loads(content)
+        except json.JSONDecodeError as e:
+            print(f"JSON parse error from {model}: {e}")
+            continue
+        except Exception as e:
+            if "429" in str(e).lower() or "rate limit" in str(e).lower():
+                print(f"Rate limited on {model}, trying next...")
+                continue
+            print(f"Error with {model}: {e}")
+            return []
+
+    print("All models failed.")
+    return []
+
+
+def prioritise(items: list[dict], scores: dict) -> list[dict]:
+    """If too many items, prioritise by source score. Keep all if under threshold."""
+    if len(items) <= MAX_ITEMS_PER_DAY:
+        return items
+
+    source_data = scores.get("sources", {})
+    scored = []
+    for item in items:
+        # Try to match source from URL domain
+        domain = re.search(r"https?://(?:www\.)?([^/]+)", item.get("url", ""))
+        domain_key = domain.group(1) if domain else "unknown"
+        score_entry = source_data.get(domain_key, {})
+        source_score = score_entry.get("score", 0.5)  # new sources get 0.5
+        scored.append((source_score, item))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [item for _, item in scored[:MAX_ITEMS_PER_DAY]]
+
+
+def format_intake_row(item: dict) -> str:
+    """Format a single item as a table row matching the required schema."""
+    title = item.get("title", "Unknown").replace("|", "/")
+    url = item.get("url", "")
+    tags = item.get("tags", "tool").replace("|", ",")
+    notes = item.get("notes", "").replace("|", ",")
+    return f"| {title} | [{url}]({url}) | {tags} | new | - | {notes} |"
+
+
+def ensure_daily_file(date_str: str) -> Path:
+    """Create or return the daily log file with required header."""
+    NEW_SOURCES_DIR.mkdir(parents=True, exist_ok=True)
+    daily_path = NEW_SOURCES_DIR / f"{date_str}.md"
+    if not daily_path.exists():
+        daily_path.write_text(
+            f"# New Sources Log — {date_str}\n\n"
+            "| Title | URL | Tags | Status | Canonical Page | Notes |\n"
+            "| :--- | :--- | :--- | :--- | :--- | :--- |\n",
+            encoding="utf-8",
+        )
+    return daily_path
+
+
+def update_index(date_str: str) -> None:
+    """Add today's date to the index if not already present."""
+    if not NEW_SOURCES_INDEX.exists():
+        return
+
+    text = NEW_SOURCES_INDEX.read_text(encoding="utf-8")
+    link_marker = f"[{date_str}](/new-sources/{date_str}/)"
+    if date_str in text:
+        return
+
+    # Insert a new row after the table header separator
+    lines = text.splitlines()
+    insert_idx = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith("| :---"):
+            insert_idx = i + 1
+            break
+
+    if insert_idx is None:
+        return
+
+    new_row = f"| {date_str} | {link_marker} | 0 | 0 | Bridge auto-discovery |"
+    lines.insert(insert_idx, new_row)
+    NEW_SOURCES_INDEX.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    # Find the latest digest file
+    if not DIGEST_DIR.exists():
+        print(f"Digest directory {DIGEST_DIR} not found.")
+        return 1
+
+    digest_files = sorted(DIGEST_DIR.glob("*.md"), reverse=True)
+    if not digest_files:
+        print("No digest files found.")
+        return 0
+
+    latest_digest = digest_files[0]
+    print(f"Processing digest: {latest_digest}")
+
+    # Extract links
+    raw_items = extract_links_from_digest(latest_digest)
+    print(f"Extracted {len(raw_items)} links from digest.")
+
+    if not raw_items:
+        print("No links found. Nothing to do.")
+        return 0
+
+    # Classify with LLM
+    classified = classify_with_llm(raw_items)
+    print(f"LLM classified {len(classified)} items as tools/frameworks/providers.")
+
+    if not classified:
+        print("No qualifying items after classification.")
+        return 0
+
+    # Deduplicate against existing catalog
+    existing_urls = load_existing_urls()
+    new_items = []
+    for item in classified:
+        url = item.get("url", "")
+        title_lower = item.get("title", "").lower()
+        if url not in existing_urls and title_lower not in existing_urls:
+            new_items.append(item)
+        else:
+            print(f"  Skipping duplicate: {item.get('title')}")
+
+    print(f"{len(new_items)} new items after deduplication.")
+
+    if not new_items:
+        print("All items already exist. Nothing to add.")
+        return 0
+
+    # Prioritise if too many
+    scores = load_source_scores()
+    new_items = prioritise(new_items, scores)
+
+    # Write to daily log
+    daily_path = ensure_daily_file(today)
+    rows = "\n".join(format_intake_row(item) for item in new_items)
+    with open(daily_path, "a", encoding="utf-8") as f:
+        f.write(rows + "\n")
+
+    # Update index
+    update_index(today)
+
+    print(f"Added {len(new_items)} new items to {daily_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/growth_tracker.py
+++ b/scripts/growth_tracker.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Growth Metrics Tracker
+
+Scans the knowledge base and produces data/growth-metrics.json with:
+- Total tool docs and count per category
+- Docs with/without code examples
+- Shallow docs (< 1500 chars)
+- Underdeveloped categories (< 8 docs)
+- Weekly additions delta (compared to previous snapshot)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+TOOLS_DIR = Path("docs/tools")
+SERVICES_DIR = Path("docs/services")
+KB_DIR = Path("docs/knowledge_base")
+OUTPUT_PATH = Path("data/growth-metrics.json")
+
+
+def count_docs(base: Path) -> dict[str, list[str]]:
+    """Return {category: [file_paths]} for all .md files (excluding index files)."""
+    result: dict[str, list[str]] = {}
+    if not base.exists():
+        return result
+    for category_dir in sorted(base.iterdir()):
+        if not category_dir.is_dir():
+            continue
+        category = category_dir.name
+        docs = []
+        for md in sorted(category_dir.glob("*.md")):
+            if md.name in ("index.md", "README.md"):
+                continue
+            docs.append(str(md))
+        if docs:
+            result[category] = docs
+    return result
+
+
+def has_code_examples(path: str) -> bool:
+    """Check if a doc contains fenced code blocks."""
+    text = Path(path).read_text(encoding="utf-8")
+    return "```" in text
+
+
+def is_shallow(path: str, threshold: int = 1500) -> bool:
+    """Check if a doc is shorter than threshold characters."""
+    text = Path(path).read_text(encoding="utf-8")
+    return len(text) < threshold
+
+
+def load_previous() -> dict:
+    """Load previous snapshot for delta calculation."""
+    if OUTPUT_PATH.exists():
+        return json.loads(OUTPUT_PATH.read_text(encoding="utf-8"))
+    return {}
+
+
+def main() -> int:
+    by_category = count_docs(TOOLS_DIR)
+
+    all_docs: list[str] = []
+    for docs in by_category.values():
+        all_docs.extend(docs)
+
+    # Also count services
+    service_docs = [str(p) for p in SERVICES_DIR.glob("*.md") if p.name not in ("README.md", "inventory.md")]
+    all_docs.extend(service_docs)
+
+    docs_with_code = [d for d in all_docs if has_code_examples(d)]
+    docs_without_code = [d for d in all_docs if not has_code_examples(d)]
+    shallow = [d for d in all_docs if is_shallow(d)]
+
+    category_counts = {cat: len(docs) for cat, docs in by_category.items()}
+    underdeveloped = [cat for cat, count in category_counts.items() if count < 8]
+
+    # Sort shallow docs by file size (smallest first) for prioritisation
+    shallow.sort(key=lambda p: Path(p).stat().st_size)
+
+    previous = load_previous()
+    prev_total = previous.get("total_docs", len(all_docs))
+
+    snapshot = {
+        "snapshot_date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "total_docs": len(all_docs),
+        "tool_docs": len(all_docs) - len(service_docs),
+        "service_docs": len(service_docs),
+        "by_category": category_counts,
+        "docs_with_code_examples": len(docs_with_code),
+        "docs_without_code_examples": len(docs_without_code),
+        "shallow_docs": shallow[:20],  # top 20 shallowest
+        "underdeveloped_categories": underdeveloped,
+        "weekly_additions": len(all_docs) - prev_total,
+    }
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
+    print(f"Growth snapshot: {len(all_docs)} total docs, {len(docs_with_code)} with code, {len(shallow)} shallow.")
+    print(f"Underdeveloped categories: {', '.join(underdeveloped) or 'none'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_source_scores.py
+++ b/scripts/update_source_scores.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Update source prioritisation scores.
+
+Reads all docs/new-sources/*.md files, tallies per-source discovery and
+integration counts, computes a score (integrated/discovered ratio), and
+writes data/source-scores.json.
+
+Sources with higher integration ratios are prioritised by the bridge script.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOG_DIR = Path("docs/new-sources")
+OUTPUT_PATH = Path("data/source-scores.json")
+
+URL_RE = re.compile(r"https?://(?:www\.)?([^/]+)")
+
+
+def extract_domain(url: str) -> str:
+    """Extract domain from a URL."""
+    match = URL_RE.search(url)
+    return match.group(1) if match else "unknown"
+
+
+def main() -> int:
+    if not LOG_DIR.exists():
+        print(f"{LOG_DIR} not found.")
+        return 1
+
+    # Tally per-domain: discovered vs integrated
+    stats: dict[str, dict[str, int]] = defaultdict(lambda: {"discovered": 0, "integrated": 0})
+
+    for log_file in sorted(LOG_DIR.glob("*.md")):
+        for line in log_file.read_text(encoding="utf-8").splitlines():
+            if not line.strip().startswith("|") or line.strip().startswith("| :"):
+                continue
+            if line.strip().startswith("| Title"):
+                continue
+
+            cols = [c.strip() for c in line.strip().strip("|").split("|")]
+            if len(cols) < 4:
+                continue
+
+            url_cell = cols[1]
+            status = cols[3].strip().lower()
+
+            # Extract URL from markdown link or bare URL
+            url_match = re.search(r"https?://[^\s)]+", url_cell)
+            if not url_match:
+                continue
+
+            domain = extract_domain(url_match.group(0))
+            stats[domain]["discovered"] += 1
+            if status == "integrated":
+                stats[domain]["integrated"] += 1
+
+    # Compute scores
+    sources = {}
+    for domain, counts in sorted(stats.items()):
+        discovered = counts["discovered"]
+        integrated = counts["integrated"]
+        score = round(integrated / discovered, 2) if discovered > 0 else 0.0
+        sources[domain] = {
+            "discovered": discovered,
+            "integrated": integrated,
+            "score": score,
+        }
+
+    output = {
+        "sources": sources,
+        "updated": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+    }
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    print(f"Updated {OUTPUT_PATH} with {len(sources)} source scores.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/weekly_planner.py
+++ b/scripts/weekly_planner.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Weekly Growth Planner
+
+Reads data/growth-metrics.json and creates targeted GitHub issues for Jules:
+1. A deepening issue: add code examples to the 5 shallowest docs
+2. A gap-filling issue: discover tools for the most underdeveloped category
+
+Runs Monday 02:00 UTC via weekly-planner.yml.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+METRICS_PATH = Path("data/growth-metrics.json")
+
+# Category display names and search hints for gap-filling
+CATEGORY_HINTS = {
+    "frameworks": "LLM application frameworks (Haystack, Semantic Kernel, Spring AI, DSPy, etc.)",
+    "providers": "LLM API providers (Anthropic, Cohere, Mistral, Together AI, Fireworks, Groq, etc.)",
+    "agents": "AI agent frameworks (AutoGen, CrewAI, LangGraph, Smolagents, Agency Swarm, etc.)",
+    "orchestration": "AI workflow orchestration (Temporal, Prefect, Dagster, Airflow ML, etc.)",
+    "infrastructure": "LLM inference infrastructure (vLLM, TGI, SGLang, ExLlamaV2, Aphrodite, etc.)",
+    "benchmarking": "AI evaluation (MMLU, HellaSwag, TruthfulQA, BigBench, AgentBench, etc.)",
+    "ai_knowledge": "AI knowledge tools (Notion AI, Mem, Khoj, Quivr, AnythingLLM, etc.)",
+    "process_understanding": "Document processing (Unstructured, Docling, Marker, Surya, etc.)",
+}
+
+
+def create_issue(title: str, body: str, labels: list[str]) -> bool:
+    """Create a GitHub issue using gh CLI."""
+    cmd = ["gh", "issue", "create", "--title", title, "--body", body]
+    for label in labels:
+        cmd.extend(["--label", label])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode == 0:
+        print(f"Created issue: {result.stdout.strip()}")
+        return True
+    else:
+        print(f"Failed to create issue: {result.stderr}")
+        return False
+
+
+def build_deepening_body(shallow_docs: list[str]) -> str:
+    """Build the issue body for doc deepening."""
+    targets = shallow_docs[:5]
+    file_list = "\n".join(f"- `{doc}`" for doc in targets)
+
+    return f"""## Weekly Doc Deepening
+
+The following {len(targets)} docs are the shallowest in the knowledge base and need practical content added.
+
+### Target docs
+{file_list}
+
+### Instructions
+For each doc above:
+1. Read the tool's official website/GitHub from its **Sources / References** section
+2. Add a `## Getting started` section after `## When not to use it` with:
+   - Installation command (`pip install`, `npm install`, `docker pull`, or equivalent)
+   - A minimal working example in a fenced code block (Python, CLI, or config as appropriate)
+3. If the tool has a CLI, add `## CLI examples` with 2-3 common commands
+4. If the tool has an API/SDK, add `## API examples` with a Python or curl snippet
+5. Keep all existing content unchanged
+6. Update `- Last reviewed: {_today()}` in the Contribution Metadata section
+
+### Quality checks
+- Verify: `python3 -c "import yaml; yaml.safe_load(open('mkdocs.yml')); print('OK')"`
+- Ensure all code examples are complete and runnable (no placeholder `...` blocks)
+"""
+
+
+def build_gap_filling_body(category: str, current_count: int) -> str:
+    """Build the issue body for category gap filling."""
+    hints = CATEGORY_HINTS.get(category, f"tools in the {category} category")
+
+    return f"""## Category Gap Fill: {category}
+
+The **{category}** category currently has only **{current_count} docs**, making it underdeveloped.
+
+### Instructions
+1. Research and identify **up to 8 tools** that belong in this category. Consider: {hints}
+2. For each tool, create a doc using `docs/templates/tool_template.md`
+3. Place in `docs/tools/{category}/`
+4. Add to `data/all_tools.json` and `mkdocs.yml` navigation
+5. Add an intake row to today's `docs/new-sources/YYYY-MM-DD.md` with `Status: integrated`
+6. Do NOT create stub pages — every doc must have substantive content in all required sections
+
+### Deduplication
+Before creating any page, search the repo for the tool name and common aliases.
+If it already exists elsewhere, update the existing page instead.
+
+### Quality checks
+- Verify: `python3 -c "import yaml; yaml.safe_load(open('mkdocs.yml')); print('OK')"`
+- Run: `python3 scripts/validate_new_sources.py`
+"""
+
+
+def _today() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def main() -> int:
+    if not METRICS_PATH.exists():
+        print(f"{METRICS_PATH} not found. Run growth_tracker.py first.")
+        return 1
+
+    metrics = json.loads(METRICS_PATH.read_text(encoding="utf-8"))
+    shallow_docs = metrics.get("shallow_docs", [])
+    underdeveloped = metrics.get("underdeveloped_categories", [])
+    by_category = metrics.get("by_category", {})
+
+    created = 0
+
+    # Issue 1: Deepen shallow docs
+    if shallow_docs:
+        body = build_deepening_body(shallow_docs)
+        title = f"Weekly deepening: add code examples to {min(5, len(shallow_docs))} docs"
+        if create_issue(title, body, ["jules"]):
+            created += 1
+
+    # Issue 2: Fill the most underdeveloped category
+    if underdeveloped:
+        # Pick the category with fewest docs
+        worst = min(underdeveloped, key=lambda c: by_category.get(c, 0))
+        count = by_category.get(worst, 0)
+        body = build_gap_filling_body(worst, count)
+        title = f"Category gap fill: expand {worst} (currently {count} docs)"
+        if create_issue(title, body, ["jules"]):
+            created += 1
+
+    print(f"Created {created} issue(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds **digest-to-intake bridge** (`scripts/digest_to_intake.py` + workflow at 01:00 UTC) that reads the daily AI digest, classifies tool mentions via OpenRouter LLM, deduplicates against the catalog, and appends `new` rows to the intake log
- Adds **weekly growth planner** (`scripts/weekly_planner.py` + workflow Monday 02:00 UTC) that creates targeted Jules issues: deepening the 5 shallowest docs with code examples, and filling the most underdeveloped category
- Adds **source scoring** (`scripts/update_source_scores.py`) to learn which RSS feeds yield the most integrated items and prioritise them over time
- Adds **growth tracker** (`scripts/growth_tracker.py`) to snapshot doc counts, code example coverage, and shallow docs
- Expands `ai-daily-digest/sources.yaml` with 7 new feeds (The Changelog, Latent Space, The New Stack, r/ollama, r/n8n, r/selfhosted, r/LLMDevs)
- Adds issue templates for weekly deepening and category gap-filling

## Architecture
```
00:00 UTC  [Daily Digest]  ──▶  ai-daily-digest/daily/YYYY-MM-DD.md
01:00 UTC  [Bridge]        ──▶  docs/new-sources/YYYY-MM-DD.md (new rows)
07:00 UTC  [Jules]         ──▶  processes new rows → tool docs + PRs
Mon 02:00  [Weekly Planner] ──▶ creates Jules issues (deepen + gap-fill)
```

## Test plan
- [ ] Run `python scripts/growth_tracker.py` — verify `data/growth-metrics.json` generated
- [ ] Run `python scripts/update_source_scores.py` — verify `data/source-scores.json` generated
- [ ] Trigger `digest-to-intake.yml` via `workflow_dispatch` — verify new rows in intake log
- [ ] Trigger `weekly-planner.yml` via `workflow_dispatch` — verify Jules issues created
- [ ] Confirm all existing CI quality gates still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)