### PR TITLE
Add documentation for 7 LLM providers

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -141,8 +141,44 @@
     {
       "id": "anthropic",
       "name": "Anthropic Claude",
-      "category": "AI Assistants & Knowledge",
-      "doc_path": "docs/tools/ai_knowledge/anthropic.md"
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/anthropic.md"
+    },
+    {
+      "id": "cohere",
+      "name": "Cohere",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/cohere.md"
+    },
+    {
+      "id": "mistral-ai",
+      "name": "Mistral AI",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/mistral.md"
+    },
+    {
+      "id": "together-ai",
+      "name": "Together AI",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/together.md"
+    },
+    {
+      "id": "groq",
+      "name": "Groq",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/groq.md"
+    },
+    {
+      "id": "fireworks-ai",
+      "name": "Fireworks AI",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/fireworks.md"
+    },
+    {
+      "id": "replicate",
+      "name": "Replicate",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/replicate.md"
     },
     {
       "id": "deepseek",

--- a/docs/architecture/component_map.md
+++ b/docs/architecture/component_map.md
@@ -22,7 +22,7 @@ This map categorizes all tools in the stack based on their primary function in t
 
 ## 3. Understand (Reasoning Engines)
 *The brains of the stack that process and reason over information.*
-- **Proprietary APIs**: [OpenAI](../tools/ai_knowledge/openai.md), [Anthropic](../tools/ai_knowledge/anthropic.md), [DeepSeek](../tools/ai_knowledge/deepseek.md), [Google Gemini](../tools/ai_knowledge/google-gemini.md)
+- **Proprietary APIs**: [OpenAI](../tools/ai_knowledge/openai.md), [Anthropic](../tools/providers/anthropic.md), [DeepSeek](../tools/ai_knowledge/deepseek.md), [Google Gemini](../tools/ai_knowledge/google-gemini.md)
 - **Local Models**: [Ollama](../services/ollama.md), [Local LLMs (MLX, llama.cpp)](../tools/ai_knowledge/local_llms.md), [ansigpt](../tools/ai_knowledge/ansigpt.md), [ZSE](../tools/infrastructure/zse.md)
 - **Aggregators**: [OpenRouter](../tools/ai_knowledge/openrouter.md), [Perplexity](../tools/ai_knowledge/perplexity.md), [Valyu](../tools/ai_knowledge/valyu.md)
 - **Semantic Search**: [Paperless-AI](../services/paperless-ai.md), [RAGFlow](../tools/process_understanding/ragflow.md), [PageIndex](../tools/process_understanding/pageindex.md)

--- a/docs/knowledge_base/patterns/claude-tool-search.md
+++ b/docs/knowledge_base/patterns/claude-tool-search.md
@@ -33,7 +33,7 @@ Naive tool-calling can fail when many tools overlap or when tool descriptions ar
 - When ultra-low-latency responses are the main constraint
 
 ## Related tools / concepts
-- [Anthropic Claude](../../tools/ai_knowledge/anthropic.md)
+- [Anthropic Claude](../../tools/providers/anthropic.md)
 - [Agent Protocols](../agent_protocols.md)
 - [Patterns Index](index.md)
 

--- a/docs/new-sources/2026-02-27.md
+++ b/docs/new-sources/2026-02-27.md
@@ -22,3 +22,10 @@
 | CrewAI | [https://github.com/joaomdmoura/crewAI](https://github.com/joaomdmoura/crewAI) | tool, framework | integrated | [tools/frameworks/crewai.md](../tools/frameworks/crewai.md) | Multi-agent orchestration framework. |
 | AutoGen | [https://github.com/microsoft/autogen](https://github.com/microsoft/autogen) | tool, framework | integrated | [tools/frameworks/autogen.md](../tools/frameworks/autogen.md) | Microsoft's multi-agent conversation framework. |
 | Smolagents | [https://github.com/huggingface/smolagents](https://github.com/huggingface/smolagents) | tool, framework | integrated | [tools/frameworks/smolagents.md](../tools/frameworks/smolagents.md) | Hugging Face's lightweight agent framework. |
+| Anthropic | [https://www.anthropic.com/](https://www.anthropic.com/) | provider | integrated | [tools/providers/anthropic.md](../tools/providers/anthropic.md) | AI safety company, creator of Claude LLMs. |
+| Cohere | [https://cohere.com/](https://cohere.com/) | provider | integrated | [tools/providers/cohere.md](../tools/providers/cohere.md) | Enterprise AI platform for RAG and embeddings. |
+| Mistral AI | [https://mistral.ai/](https://mistral.ai/) | provider | integrated | [tools/providers/mistral.md](../tools/providers/mistral.md) | European AI company specializing in open-weight models. |
+| Together AI | [https://www.together.ai/](https://www.together.ai/) | provider | integrated | [tools/providers/together.md](../tools/providers/together.md) | Cloud platform for open-source model inference. |
+| Groq | [https://groq.com/](https://groq.com/) | provider | integrated | [tools/providers/groq.md](../tools/providers/groq.md) | High-speed LPU inference infrastructure. |
+| Fireworks AI | [https://fireworks.ai/](https://fireworks.ai/) | provider | integrated | [tools/providers/fireworks.md](../tools/providers/fireworks.md) | Fast inference and fine-tuning for open models. |
+| Replicate | [https://replicate.com/](https://replicate.com/) | provider | integrated | [tools/providers/replicate.md](../tools/providers/replicate.md) | API for running a wide variety of open-source models. |

--- a/docs/services/litellm.md
+++ b/docs/services/litellm.md
@@ -49,7 +49,7 @@ It eliminates the complexity of managing different SDKs and authentication metho
 ## Links to related pages
 - [OpenRouter](../tools/ai_knowledge/openrouter.md)
 - [OpenAI](../tools/ai_knowledge/openai.md)
-- [Anthropic](../tools/ai_knowledge/anthropic.md)
+- [Anthropic](../tools/providers/anthropic.md)
 - [Local LLMs](../tools/ai_knowledge/local_llms.md)
 
 ## Sources / References

--- a/docs/tools/ai_knowledge/deepseek.md
+++ b/docs/tools/ai_knowledge/deepseek.md
@@ -41,7 +41,7 @@ Available via their own API (DeepSeek Platform) or can be self-hosted using the 
 
 ## Links to related pages
 - [OpenAI](openai.md)
-- [Anthropic](anthropic.md)
+- [Anthropic](../providers/anthropic.md)
 - [Local LLMs](local_llms.md)
 
 ## Sources / References

--- a/docs/tools/ai_knowledge/google-gemini.md
+++ b/docs/tools/ai_knowledge/google-gemini.md
@@ -41,7 +41,7 @@ It provides state-of-the-art reasoning across text, code, images, audio, and vid
 
 ## Related tools / concepts
 - [OpenAI](./openai.md)
-- [Anthropic](./anthropic.md)
+- [Anthropic](../providers/anthropic.md)
 - [DeepSeek](./deepseek.md)
 - [OpenRouter](./openrouter.md)
 

--- a/docs/tools/ai_knowledge/index.md
+++ b/docs/tools/ai_knowledge/index.md
@@ -1,7 +1,7 @@
 # Ai & Knowledge
 
 - [ansigpt](ansigpt.md)
-- [Anthropic Claude](anthropic.md)
+- [Anthropic Claude](../providers/anthropic.md)
 - [ChatGPT](chatgpt.md)
 - [DeepSeek](deepseek.md)
 - [Dify](dify.md)

--- a/docs/tools/ai_knowledge/openai.md
+++ b/docs/tools/ai_knowledge/openai.md
@@ -44,7 +44,7 @@ Cloud-hosted API service. Agents send prompts (context + instructions) to OpenAI
 - **Prompt Injection**: Be aware that models can be manipulated via input; implement output validation.
 
 ## Links to related pages
-- [Anthropic](anthropic.md)
+- [Anthropic](../providers/anthropic.md)
 - [OpenRouter](openrouter.md)
 - [Aider](../development_ops/aider.md)
 - [OpenHands](../development_ops/openhands.md)

--- a/docs/tools/ai_knowledge/openrouter.md
+++ b/docs/tools/ai_knowledge/openrouter.md
@@ -44,7 +44,7 @@ Proxy service. Your agent sends requests to OpenRouter, which then routes them t
 ## Links to related pages
 - [LiteLLM](../../services/litellm.md)
 - [OpenAI](openai.md)
-- [Anthropic](anthropic.md)
+- [Anthropic](../providers/anthropic.md)
 
 ## Integration ecosystem and technical signal feeds
 

--- a/docs/tools/development_ops/aider.md
+++ b/docs/tools/development_ops/aider.md
@@ -44,7 +44,7 @@ CLI tool that runs locally. It manages the context by selecting relevant files t
 ## Links to related pages
 - [OpenHands](openhands.md)
 - [OpenAI](../ai_knowledge/openai.md)
-- [Anthropic](../ai_knowledge/anthropic.md)
+- [Anthropic](../providers/anthropic.md)
 
 ## Sources / References
 

--- a/docs/tools/development_ops/openswarm.md
+++ b/docs/tools/development_ops/openswarm.md
@@ -38,7 +38,7 @@ It simplifies the coordination of multiple AI agents performing complex, interde
 
 ## Related tools / concepts
 - [Claude Code](./claude-code.md)
-- [Anthropic](../ai_knowledge/anthropic.md)
+- [Anthropic](../providers/anthropic.md)
 - [Multi-Agent Systems](../../knowledge_base/agent_protocols.md)
 
 ## Sources / References

--- a/docs/tools/providers/anthropic.md
+++ b/docs/tools/providers/anthropic.md
@@ -7,15 +7,34 @@ Anthropic is an AI safety and research company that produces the Claude family o
 Offers a high-performance alternative to OpenAI with a focus on "Constitutional AI" (safety) and exceptional performance in coding and long-form document analysis.
 
 ## Where it fits in the stack
-**LLM / Reasoning Engine**. Often used as the primary engine for coding agents due to its high accuracy in code generation and refactoring.
+**LLM / Reasoning Engine / Provider**. Often used as the primary engine for coding agents due to its high accuracy in code generation and refactoring.
 
-## Architecture overview
-Cloud-hosted API service (via Anthropic Console or Amazon Bedrock/Google Vertex AI).
-
-## Typical workflows
+## Typical use cases
 - **Pair Programming**: Claude 3.5 Sonnet is currently a top choice for tools like Aider.
 - **Complex Analysis**: Summarizing long technical documentation or legal files.
 - **Strict Adherence**: Workflows requiring close following of complex formatting rules.
+
+## Getting started
+Install the SDK:
+```bash
+pip install anthropic
+```
+
+Basic API call:
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+message = client.messages.create(
+    model="claude-3-5-sonnet-20240620",
+    max_tokens=1024,
+    messages=[
+        {"role": "user", "content": "Hello, Claude"}
+    ]
+)
+print(message.content)
+```
 
 ## Strengths
 - **Coding Excellence**: Claude 3.5 Sonnet is widely regarded as one of the best models for software engineering.
@@ -37,20 +56,21 @@ Cloud-hosted API service (via Anthropic Console or Amazon Bedrock/Google Vertex 
 - When a local/offline solution is required.
 - If already deeply integrated into another provider's ecosystem with significant credits.
 
-## Security considerations
-- **Key Safety**: Protect Anthropic API keys.
-- **Shared Responsibility**: Ensure data sent to the API complies with your organization's privacy standards.
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Paid (Usage-based pricing; free tier available via console for testing)
+- **Self-hostable**: No (Cloud service)
 
-## Links to related pages
-- [OpenAI](openai.md)
-- [OpenRouter](openrouter.md)
+## Related tools / concepts
+- [OpenAI](../ai_knowledge/openai.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
 - [Aider](../development_ops/aider.md)
 
 ## Sources / References
-
-- [Reference](https://www.anthropic.com/news)
+- [Official Website](https://www.anthropic.com/)
+- [Anthropic News](https://www.anthropic.com/news)
+- [API Documentation](https://docs.anthropic.com/)
 
 ## Contribution Metadata
-
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-02-27
+- Confidence: high

--- a/docs/tools/providers/cohere.md
+++ b/docs/tools/providers/cohere.md
@@ -1,0 +1,72 @@
+# Cohere
+
+## What it is
+Cohere is an enterprise-focused AI platform providing large language models for text generation, embeddings, and reranking.
+
+## What problem it solves
+Provides high-performance, enterprise-grade models specifically optimized for Retrieval-Augmented Generation (RAG) and multilingual applications.
+
+## Where it fits in the stack
+**Provider / Embedding / Reranking**. It provides the reasoning and retrieval components of an AI pipeline.
+
+## Typical use cases
+- **Enterprise RAG**: Using Command R+ for complex retrieval-augmented generation.
+- **Multilingual Search**: Using Cohere Embed for cross-language semantic search.
+- **Search Optimization**: Using Cohere Rerank to improve the relevance of search results.
+
+## Getting started
+Install the SDK:
+```bash
+pip install cohere
+```
+
+Basic API call (Chat):
+```python
+import cohere
+
+co = cohere.Client('YOUR_API_KEY')
+
+response = co.chat(
+    model="command-r-plus",
+    message="Explain quantum computing in simple terms."
+)
+print(response.text)
+```
+
+## Strengths
+- **RAG Optimization**: Command R series is specifically designed for RAG workflows with high tool-use accuracy.
+- **Multilingual Support**: Industry-leading multilingual embedding and reranking models.
+- **Enterprise Ready**: Strong focus on data privacy and deployment flexibility (Cloud, VPC, On-prem).
+- **Pricing**: Clear usage-based pricing. Free "Trial" tier for development; "Production" tier for scaled usage.
+
+## Limitations
+- **Focus**: Less focused on creative or multi-modal tasks compared to OpenAI or Anthropic.
+- **Ecosystem**: While growing, the community ecosystem is smaller than OpenAI's.
+
+## When to use it
+- When building production-grade RAG systems.
+- When multilingual support is a core requirement.
+- For enterprise applications requiring strict data sovereignty.
+
+## When not to use it
+- For simple hobbyist projects where a generic model like GPT-4o-mini might be cheaper/easier.
+- When requiring native multi-modal capabilities (e.g., image generation) in the same API.
+
+## Licensing and cost
+- **Open Source**: No (Proprietary models, but some are open-weights like Command R).
+- **Cost**: Paid (Usage-based), Freemium (Trial tier available).
+- **Self-hostable**: Yes (via private cloud or VPC deployments).
+
+## Related tools / concepts
+- [OpenAI](../ai_knowledge/openai.md)
+- [Anthropic](anthropic.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
+
+## Sources / References
+- [Official Website](https://cohere.com/)
+- [Cohere Documentation](https://docs.cohere.com/)
+- [Cohere Blog](https://cohere.com/blog)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-27
+- Confidence: high

--- a/docs/tools/providers/fireworks.md
+++ b/docs/tools/providers/fireworks.md
@@ -1,0 +1,74 @@
+# Fireworks AI
+
+## What it is
+Fireworks AI is an inference platform providing a high-performance API for running and fine-tuning open-source generative AI models.
+
+## What problem it solves
+Provides ultra-fast, reliable, and cost-effective access to the latest open-source models with optimizations that exceed standard GPU deployments.
+
+## Where it fits in the stack
+**Inference Provider**. Similar to Together AI and Groq, it provides the backend for LLM-powered applications.
+
+## Typical use cases
+- **High-Throughput Applications**: Apps requiring many concurrent LLM requests.
+- **Function Calling**: Using their optimized models for structured data extraction.
+- **Custom Model Deployment**: Deploying fine-tuned models on dedicated infrastructure.
+
+## Getting started
+Install the SDK:
+```bash
+pip install fireworks-ai
+```
+
+Basic API call:
+```python
+import fireworks.client
+
+fireworks.client.api_key = "YOUR_API_KEY"
+
+response = fireworks.client.ChatCompletion.create(
+    model="accounts/fireworks/models/llama-v3-70b-instruct",
+    messages=[
+        {"role": "user", "content": "How do I optimize LLM inference?"}
+    ]
+)
+print(response.choices[0].message.content)
+```
+
+## Strengths
+- **Speed**: Optimized inference engine (FireAttention) provides high tokens per second.
+- **Developer Experience**: OpenAI-compatible API makes migration simple.
+- **Fine-tuning**: Excellent support for LoRA fine-tuning and deployment.
+- **Pricing**: Usage-based, very competitive. Separate tiers for serverless and dedicated deployments.
+
+## Limitations
+- **Model Variety**: While broad, they focus on a curated set of high-performance models rather than everything available.
+- **Brand Awareness**: Less known than Together or Groq in the enthusiast space.
+
+## When to use it
+- When you need high-speed inference for Llama 3 or other top open models.
+- For production applications requiring high reliability and uptime.
+- When deploying custom LoRA adapters.
+
+## When not to use it
+- If you require proprietary "frontier" models.
+- For extremely niche or obscure models not in their curated list.
+
+## Licensing and cost
+- **Open Source**: No (Proprietary platform).
+- **Cost**: Paid (Usage-based).
+- **Self-hostable**: No (Cloud service).
+
+## Related tools / concepts
+- [Together AI](together.md)
+- [Groq](groq.md)
+- [vLLM](../infrastructure/vllm.md)
+
+## Sources / References
+- [Official Website](https://fireworks.ai/)
+- [Fireworks AI Docs](https://docs.fireworks.ai/)
+- [Model Directory](https://fireworks.ai/models)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-27
+- Confidence: high

--- a/docs/tools/providers/groq.md
+++ b/docs/tools/providers/groq.md
@@ -1,0 +1,78 @@
+# Groq
+
+## What it is
+Groq is an AI infrastructure company that developed the Language Processing Unit (LPU), a new type of processor designed specifically for the high-speed requirements of LLMs.
+
+## What problem it solves
+Solves the "bottleneck" of slow LLM inference, providing near-instantaneous responses that enable real-time applications and highly interactive agents.
+
+## Where it fits in the stack
+**Inference Provider / Infrastructure**. It provides a high-speed API for popular open-source models.
+
+## Typical use cases
+- **Real-time Agents**: Voice assistants or chatbots that require sub-second response times.
+- **High-Volume Processing**: Summarizing or analyzing large quantities of text quickly.
+- **Interactive Coding**: Powering coding assistants where immediate feedback is essential.
+
+## Getting started
+Install the SDK:
+```bash
+pip install groq
+```
+
+Basic API call:
+```python
+from groq import Groq
+
+client = Groq()
+
+chat_completion = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Explain the importance of low latency in AI.",
+        }
+    ],
+    model="llama3-70b-8192",
+)
+
+print(chat_completion.choices[0].message.content)
+```
+
+## Strengths
+- **Extreme Speed**: Often 10x+ faster than traditional GPU-based providers.
+- **Open Model Support**: Focuses on the best open-weights models like Llama 3 and Mixtral.
+- **Low Latency**: Unmatched time-to-first-token (TTFT) and tokens per second.
+- **Pricing**: Very competitive token-based pricing. Offers a generous free tier for developers to experiment.
+
+## Limitations
+- **Model Selection**: Limited to the open models they have optimized for their LPU hardware.
+- **Context Window**: Historically had smaller context windows than some cloud providers, though this is expanding.
+
+## When to use it
+- When speed is the absolute priority.
+- For "agentic" workflows where an agent makes many sequential LLM calls.
+- When using Llama or Mistral models and looking for the fastest possible response.
+
+## When not to use it
+- If you need proprietary models like GPT-4 or Claude.
+- For extremely large context tasks (e.g., 200k tokens) that exceed their LPU memory limits.
+
+## Licensing and cost
+- **Open Source**: No (Proprietary hardware/platform).
+- **Cost**: Paid (Usage-based), Free tier available.
+- **Self-hostable**: No (Cloud service).
+
+## Related tools / concepts
+- [Together AI](together.md)
+- [Fireworks AI](fireworks.md)
+- [vLLM](../infrastructure/vllm.md)
+
+## Sources / References
+- [Official Website](https://groq.com/)
+- [Groq Cloud Console](https://console.groq.com/)
+- [Groq Documentation](https://docs.groq.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-27
+- Confidence: high

--- a/docs/tools/providers/index.md
+++ b/docs/tools/providers/index.md
@@ -7,5 +7,12 @@ Companies and platforms that offer LLM inference, APIs, or managed AI services.
 | Provider | What it offers |
 | :--- | :--- |
 | [ChatGPT / OpenAI](../ai_knowledge/chatgpt.md) | GPT model family, API, ChatGPT product |
+| [Anthropic](anthropic.md) | Claude model family, API, safety-focused |
+| [Cohere](cohere.md) | Enterprise LLMs, Command R, Embed, Rerank |
+| [Mistral AI](mistral.md) | Open-weight and commercial models |
+| [Together AI](together.md) | Inference platform for open models |
+| [Groq](groq.md) | Ultra-low-latency LPU inference |
+| [Fireworks AI](fireworks.md) | Fast inference API for open models |
+| [Replicate](replicate.md) | Run open-source models via API |
 
 <!-- New provider pages are added here by Jules -->

--- a/docs/tools/providers/mistral.md
+++ b/docs/tools/providers/mistral.md
@@ -1,0 +1,81 @@
+# Mistral AI
+
+## What it is
+Mistral AI is a European AI company that develops both open-weight and commercial large language models, including the Mistral, Mixtral, and Codestral families.
+
+## What problem it solves
+Provides a high-performance, efficient alternative to American providers, offering some of the best-performing open-weight models for self-hosting.
+
+## Where it fits in the stack
+**LLM Provider**. Offers both a hosted API and models that can be run locally via tools like Ollama or vLLM.
+
+## Typical use cases
+- **Local Deployment**: Running Mixtral 8x7B or Mistral Nemo on-premises for privacy.
+- **Code Assistance**: Using Codestral for specialized programming tasks.
+- **Efficient Inference**: Using small but capable models for high-volume tasks.
+
+## Getting started
+Install the SDK:
+```bash
+pip install mistralai
+```
+
+Basic API call:
+```python
+from mistralai import Mistral
+import os
+
+api_key = os.environ["MISTRAL_API_KEY"]
+model = "mistral-large-latest"
+
+client = Mistral(api_key=api_key)
+
+chat_response = client.chat.complete(
+    model=model,
+    messages=[
+        {
+            "role": "user",
+            "content": "What is the best French cheese?",
+        },
+    ]
+)
+print(chat_response.choices[0].message.content)
+```
+
+## Strengths
+- **Efficiency**: Known for "punching above their weight" in terms of parameter count vs performance.
+- **Open Weights**: Many models are released under Apache 2.0 or Mistral Research License, allowing local hosting.
+- **Codestral**: Highly capable model specifically for code generation and FIM (Fill-In-the-Middle).
+- **Pricing**: Very competitive API pricing via "La Plateforme". Multiple tiers from cheap (Ministral) to premium (Mistral Large).
+
+## Limitations
+- **API Maturity**: While improving, the API featureset (e.g., fine-tuning, complex tool use) has historically trailed OpenAI.
+- **Safety Tuning**: Generally less "preachy" but may require more careful prompting for alignment depending on the model.
+
+## When to use it
+- When you want to avoid vendor lock-in with open-weight models.
+- For high-performance European-hosted AI.
+- For specialized coding tasks with Codestral.
+
+## When not to use it
+- If you require deeply integrated multi-modal (vision/audio) native support in a single API.
+- If your workflow is already heavily reliant on OpenAI-specific features like GPTs or Assistants API.
+
+## Licensing and cost
+- **Open Source**: Yes (Mistral 7B, Mixtral 8x7B/8x22B are Apache 2.0; others vary).
+- **Cost**: Free (Self-hosted) / Paid (API).
+- **Self-hostable**: Yes.
+
+## Related tools / concepts
+- [Ollama](../../services/ollama.md)
+- [vLLM](../infrastructure/vllm.md)
+- [DeepSeek](../ai_knowledge/deepseek.md)
+
+## Sources / References
+- [Official Website](https://mistral.ai/)
+- [Mistral Documentation](https://docs.mistral.ai/)
+- [Mistral News](https://mistral.ai/news)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-27
+- Confidence: high

--- a/docs/tools/providers/replicate.md
+++ b/docs/tools/providers/replicate.md
@@ -1,0 +1,71 @@
+# Replicate
+
+## What it is
+Replicate is a cloud platform that makes it easy to run open-source machine learning models via a simple API, covering everything from LLMs to image generation and audio processing.
+
+## What problem it solves
+Eliminates the complexity of managing GPU infrastructure, Docker containers, and model deployment for a vast library of open-source AI models.
+
+## Where it fits in the stack
+**Inference Provider / Multi-modal Hub**. It is an "everything store" for running AI models in the cloud.
+
+## Typical use cases
+- **Multi-modal Pipelines**: Combining an LLM with an image generator (like SDXL) in one workflow.
+- **Rapid Prototyping**: Testing niche or research models without local setup.
+- **Scaling Niche Models**: Moving from a local experiment to a production API instantly.
+
+## Getting started
+Install the SDK:
+```bash
+pip install replicate
+```
+
+Basic API call (Llama 3):
+```python
+import replicate
+
+output = replicate.run(
+    "meta/meta-llama-3-70b-instruct",
+    input={"prompt": "Write a poem about a robot learning to feel."}
+)
+for item in output:
+    print(item, end="")
+```
+
+## Strengths
+- **Unrivaled Variety**: Hosts thousands of models for text, image, video, audio, and more.
+- **Simplicity**: Extremely easy-to-use API and web interface.
+- **Cog**: Their open-source tool (Cog) allows you to package your own models for deployment on Replicate.
+- **Pricing**: Mostly per-second billing based on the GPU hardware used. Very transparent for intermittent usage.
+
+## Limitations
+- **Cold Starts**: Models not in constant use may experience "cold starts" (delay while the container spins up).
+- **Cost at Scale**: For 24/7 high-volume LLM usage, dedicated providers like Together or Groq might be cheaper.
+
+## When to use it
+- When you need a "swiss army knife" of models.
+- For image, video, or audio generation tasks.
+- When you want to deploy your own custom models without managing servers.
+
+## When not to use it
+- For high-volume, low-latency LLM applications where serverless providers like Groq or Together excel.
+- If you need the extreme reasoning of proprietary models like GPT-4o.
+
+## Licensing and cost
+- **Open Source**: The platform is proprietary; Cog is open-source; most hosted models are open-weights.
+- **Cost**: Paid (Per-second/Usage-based).
+- **Self-hostable**: No (Cloud service), but Cog can be used for local deployment.
+
+## Related tools / concepts
+- [Hugging Face](https://huggingface.co/)
+- [Together AI](together.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
+
+## Sources / References
+- [Official Website](https://replicate.com/)
+- [Replicate Documentation](https://replicate.com/docs)
+- [Model Explorer](https://replicate.com/explore)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-27
+- Confidence: high

--- a/docs/tools/providers/together.md
+++ b/docs/tools/providers/together.md
@@ -1,0 +1,72 @@
+# Together AI
+
+## What it is
+Together AI is a cloud platform for building and running generative AI, offering high-performance inference for a wide range of open-source models.
+
+## What problem it solves
+Simplifies the deployment of open-source models by providing a fast, serverless API, eliminating the need to manage infrastructure for models like Llama, Qwen, and Mistral.
+
+## Where it fits in the stack
+**Inference Provider**. It acts as the backend for applications using open-weights models.
+
+## Typical use cases
+- **Multi-Model Testing**: Quickly switching between different open models to find the best fit.
+- **Cost Optimization**: Using Together's efficient inference to lower API costs compared to proprietary providers.
+- **Fine-Tuning**: Training custom versions of open models on proprietary data.
+
+## Getting started
+Install the SDK:
+```bash
+pip install together
+```
+
+Basic API call:
+```python
+from together import Together
+
+client = Together()
+
+response = client.chat.completions.create(
+    model="meta-llama/Llama-3-70b-chat-hf",
+    messages=[{"role": "user", "content": "What are the benefits of open source AI?"}],
+)
+print(response.choices[0].message.content)
+```
+
+## Strengths
+- **Model Variety**: Supports hundreds of open-source models across text, image, and code.
+- **Speed**: One of the fastest inference providers on the market.
+- **Features**: Offers serverless API, dedicated clusters, and fine-tuning.
+- **Pricing**: Extremely low costs for serverless inference. Pricing is usage-based (per 1M tokens) and generally much cheaper than proprietary alternatives.
+
+## Limitations
+- **Third-Party Dependency**: You are relying on their platform for uptime and security of the open models.
+- **Complexity**: Navigating hundreds of models can be overwhelming compared to providers with a few flagship models.
+
+## When to use it
+- When you want to use open-source models without the hassle of self-hosting.
+- When low latency and high throughput are critical.
+- For scaling applications that require fine-tuned open models.
+
+## When not to use it
+- If you require the specific reasoning capabilities of proprietary models like Claude 3.5 Sonnet or GPT-4o.
+- If you have strict requirements to keep all data within your own on-premise hardware.
+
+## Licensing and cost
+- **Open Source**: The platform is proprietary; the models it hosts are mostly open-weights.
+- **Cost**: Paid (Usage-based).
+- **Self-hostable**: No (Cloud service), but the models can be hosted elsewhere.
+
+## Related tools / concepts
+- [OpenRouter](../ai_knowledge/openrouter.md)
+- [Groq](groq.md)
+- [Fireworks AI](fireworks.md)
+
+## Sources / References
+- [Official Website](https://www.together.ai/)
+- [Together AI Docs](https://docs.together.ai/)
+- [Together AI Models](https://www.together.ai/models)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-27
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,6 @@ nav:
     - Overview: tools/README.md
     - AI & Knowledge:
       - Overview: tools/ai_knowledge/index.md
-      - Anthropic Claude: tools/ai_knowledge/anthropic.md
       - Chatgpt: tools/ai_knowledge/chatgpt.md
       - DeepSeek: tools/ai_knowledge/deepseek.md
       - Dify: tools/ai_knowledge/dify.md
@@ -217,6 +216,13 @@ nav:
       - Smolagents: tools/frameworks/smolagents.md
     - Providers:
       - Overview: tools/providers/index.md
+      - Anthropic: tools/providers/anthropic.md
+      - Cohere: tools/providers/cohere.md
+      - Mistral AI: tools/providers/mistral.md
+      - Together AI: tools/providers/together.md
+      - Groq: tools/providers/groq.md
+      - Fireworks AI: tools/providers/fireworks.md
+      - Replicate: tools/providers/replicate.md
     - Agents:
       - Overview: tools/agents/index.md
     - Orchestration:

--- a/scripts/backfill_docs_metadata.py
+++ b/scripts/backfill_docs_metadata.py
@@ -27,7 +27,7 @@ DEFAULT_SOURCES = {
     "docs/tools/ai_knowledge/openai.md": ["https://openai.com/index/"],
     "docs/architecture/ssh_execution_patterns.md": ["https://man.openbsd.org/ssh"],
     "docs/services/litellm.md": ["https://docs.litellm.ai/"],
-    "docs/tools/ai_knowledge/anthropic.md": ["https://www.anthropic.com/news"],
+    "docs/tools/providers/anthropic.md": ["https://www.anthropic.com/news"],
     "docs/tools/ai_knowledge/openrouter.md": ["https://openrouter.ai/docs/overview/introduction"],
 }
 


### PR DESCRIPTION
This change curates and standardizes documentation for major LLM API providers. It centralizes these providers in `docs/tools/providers/` for better categorization. All new pages include 'What it is', 'Typical use cases', 'Getting started' (with SDK examples), 'Strengths/Limitations' (including pricing), and 'Contribution Metadata'. Cross-references were thoroughly updated to maintain repository integrity.

---
*PR created automatically by Jules for task [1022735560079883298](https://jules.google.com/task/1022735560079883298) started by @joanmarcriera*