### PR TITLE
Add practical examples to dev tool documentation

### DIFF
--- a/docs/tools/development_ops/aider.md
+++ b/docs/tools/development_ops/aider.md
@@ -37,6 +37,49 @@ CLI tool that runs locally. It manages the context by selecting relevant files t
 - For massive, multi-step architectural changes that require a higher level of autonomy.
 - When you need the agent to browse the web or interact with non-file system tools.
 
+## Getting started
+
+Install Aider via pip and run it in your git repository:
+
+```bash
+# Install Aider
+pip install aider-chat
+
+# Set your API key (optional if using local models)
+export ANTHROPIC_API_KEY=your-key-here
+
+# Start Aider in your project
+aider
+```
+
+## CLI examples
+
+### Hello World
+Ask Aider to create a new file with a simple script:
+```bash
+aider hello-world.py
+# In the chat: "Create a hello world script in python"
+```
+
+### Using Local Models (Ollama)
+Aider supports local models via Ollama or LiteLLM:
+```bash
+# Run with a local Llama 3 model
+aider --model ollama/llama3
+```
+
+### Commit Workflow
+Aider automatically commits changes with descriptive messages:
+```bash
+# Start aider and it will track your session
+aider
+
+# After making changes via chat, aider will:
+# 1. Show you the diff
+# 2. Ask for confirmation (or auto-commit if configured)
+# 3. Create a git commit: "feat: add login route to express app"
+```
+
 ## Security considerations
 - **File Access**: Aider has the same permissions as the user running it.
 - **Commit History**: Review automated commits to ensure no secrets were accidentally added.
@@ -52,5 +95,5 @@ CLI tool that runs locally. It manages the context by selecting relevant files t
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-27
 - Confidence: medium

--- a/docs/tools/development_ops/claude-code.md
+++ b/docs/tools/development_ops/claude-code.md
@@ -31,6 +31,46 @@ It reduces the friction of context-switching between an AI chat interface and a 
 - Not necessary for simple coding questions or single-file edits.
 - Not for users who prefer a fully visual GUI-based coding experience.
 
+## Getting started
+
+Install Claude Code globally via npm and authenticate with your Anthropic account:
+
+```bash
+# Install Claude Code
+npm install -g @anthropic-ai/claude-code
+
+# Authenticate
+claude auth login
+
+# Start a session in your current directory
+claude
+```
+
+## CLI examples
+
+### Initializing a Project
+Create a `CLAUDE.md` file to give Claude persistent context about your repository:
+```bash
+claude /init
+```
+
+### Useful Slash Commands
+Inside an active `claude` session, use these commands for quick actions:
+- `/help`: Show available commands and skills.
+- `/compact`: Summarize conversation history to save tokens.
+- `/config`: Interactively configure settings (model, theme, etc.).
+- `/review`: (If skill exists) Trigger a code review of staged changes.
+
+### MCP Setup
+Configure Model Context Protocol servers to extend Claude's capabilities:
+```bash
+# List configured MCP servers
+claude mcp list
+
+# Add a new MCP server
+claude mcp add my-server npx -y @modelcontextprotocol/server-everything
+```
+
 ## Related tools / concepts
 - [Aider](./aider.md)
 - [Droid](./droid.md)
@@ -42,5 +82,5 @@ It reduces the friction of context-switching between an AI chat interface and a 
 - [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control)
 
 ## Contribution Metadata
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-27
 - Confidence: medium

--- a/docs/tools/development_ops/codex.md
+++ b/docs/tools/development_ops/codex.md
@@ -31,6 +31,41 @@ Provides a specialized language model for code generation, enabling tools like G
 - When you need a self-hosted or open-source code model
 - When newer models (GPT-4o, Llama 3) better fit your requirements
 
+## Getting started
+
+While Codex is primarily an API-based model, it can be used via CLI tools like `codex-cli` or similar wrappers.
+
+```bash
+# Install a Codex-compatible CLI wrapper
+npm install -g codex-cli
+
+# Set your OpenAI API Key
+export OPENAI_API_KEY=your-key-here
+
+# Run a simple query
+codex "Create a python function to scrape a website"
+```
+
+## CLI examples
+
+### Local Model Configuration
+Some wrappers allow redirecting Codex-style requests to local inference servers:
+```bash
+# Configure CLI to point to a local Ollama instance instead of OpenAI
+codex config set base_url http://localhost:11434/v1
+codex config set model codellama
+```
+
+### Sandboxed Execution
+Run generated code in a restricted environment to prevent system damage:
+```bash
+# Execute with sandboxing flags (if supported by the CLI tool)
+codex --execute --sandbox=docker "Calculate the first 1000 prime numbers"
+
+# Use with Open Interpreter for more advanced sandboxed execution
+interpreter --local --model codellama --sandbox
+```
+
 ## Related tools / concepts
 - [Llama 3 (Fine-tuned for code)](https://ollama.com/library/llama3)
 - [StarCoder](https://github.com/bigcode-project/starcoder)
@@ -40,5 +75,5 @@ Provides a specialized language model for code generation, enabling tools like G
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-27
 - Confidence: medium

--- a/docs/tools/development_ops/continue_dev.md
+++ b/docs/tools/development_ops/continue_dev.md
@@ -31,6 +31,49 @@ Gives developers flexibility to choose their own LLM backend (including local mo
 - When you prefer a turnkey, zero-configuration AI editor experience
 - When you need a fully integrated AI-native editor (consider Cursor or Zed)
 
+## Getting started
+
+Continue is available as an extension for VS Code and JetBrains.
+
+1. **Install**: Search for "Continue" in your IDE's extension marketplace.
+2. **Configure**: Click the gear icon in the Continue sidebar to open `config.json`.
+3. **Select Model**: Choose a provider (e.g., Ollama, Anthropic, OpenAI) to start chatting.
+
+## Usage examples
+
+### config.json with Ollama
+Configure Continue to use a local model via Ollama:
+```json
+{
+  "models": [
+    {
+      "title": "Ollama Llama 3",
+      "provider": "ollama",
+      "model": "llama3"
+    }
+  ],
+  "tabAutocompleteModel": {
+    "title": "Starcoder 2",
+    "provider": "ollama",
+    "model": "starcoder2:3b"
+  }
+}
+```
+
+### Custom Slash Commands
+Add custom behavior by defining slash commands in `config.json`:
+```json
+{
+  "customCommands": [
+    {
+      "name": "test",
+      "description": "Write a unit test for the selected code",
+      "prompt": "Write a comprehensive unit test for this code using Jest: {{{ input }}}"
+    }
+  ]
+}
+```
+
 ## Related tools / concepts
 - [Cursor](cursor.md)
 - [Zed](zed.md)
@@ -41,5 +84,5 @@ Gives developers flexibility to choose their own LLM backend (including local mo
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-27
 - Confidence: medium

--- a/docs/tools/development_ops/cursor.md
+++ b/docs/tools/development_ops/cursor.md
@@ -31,6 +31,33 @@ Provides a deeply integrated AI coding experience where the editor itself unders
 - When you prefer a fully open-source editor
 - When you want to use only local LLMs without cloud dependencies
 
+## Getting started
+
+Download Cursor from the official website and sign in. On first run, it will index your codebase for AI context.
+
+1. **Install**: Download for your OS (Windows/Mac/Linux).
+2. **Index**: Let Cursor index your repository (check the status in the bottom right corner).
+3. **Configure**: Add your custom instructions in `.cursorrules` to guide the AI.
+
+## Usage examples
+
+### .cursorrules setup
+Create a `.cursorrules` file in your root directory to enforce coding standards:
+```markdown
+# Coding Standards
+- Use TypeScript for all new files.
+- Prefer functional components over classes.
+- Use Tailwind CSS for styling.
+- Ensure all functions have JSDoc comments.
+```
+
+### AI Keyboard Shortcuts
+| Action | Shortcut (Mac) | Shortcut (Windows/Linux) |
+| :--- | :--- | :--- |
+| **Edit code in place** | `Cmd + K` | `Ctrl + K` |
+| **Chat with codebase** | `Cmd + L` | `Ctrl + L` |
+| **Open Composer** | `Cmd + I` | `Ctrl + I` |
+
 ## Related tools / concepts
 - [VS Code](vscode.md) + [Continue](continue_dev.md)
 - [Zed](zed.md)
@@ -40,5 +67,5 @@ Provides a deeply integrated AI coding experience where the editor itself unders
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-27
 - Confidence: medium

--- a/docs/tools/development_ops/github_copilot.md
+++ b/docs/tools/development_ops/github_copilot.md
@@ -31,6 +31,29 @@ Speeds up coding by generating inline code suggestions, reducing the time spent 
 - When strict local-only code processing is required
 - When you prefer a free alternative (consider Codeium)
 
+## Getting started
+
+GitHub Copilot is available as an extension for VS Code, Visual Studio, JetBrains, and Neovim.
+
+1. **Install**: Install the "GitHub Copilot" and "GitHub Copilot Chat" extensions.
+2. **Auth**: Sign in to your GitHub account with an active Copilot subscription.
+3. **Use**: Start typing to see inline suggestions, or press `Cmd+I` (Mac) / `Ctrl+I` (Windows) to open the chat.
+
+## Usage examples
+
+### Chat Commands
+Use slash commands in the chat sidebar to perform specific tasks:
+- `/explain`: Get an explanation of the selected code.
+- `/fix`: Propose a fix for bugs in the selected code.
+- `/tests`: Generate unit tests for the current file.
+
+### Workspace Agent
+Use the `@workspace` participant to ask questions about your entire project:
+```text
+@workspace How are the API routes structured in this project?
+@workspace Where is the database connection initialized?
+```
+
 ## Related tools / concepts
 - [Codeium](codeium.md)
 - [Tabnine](tabnine.md)
@@ -40,5 +63,5 @@ Speeds up coding by generating inline code suggestions, reducing the time spent 
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-27
 - Confidence: medium


### PR DESCRIPTION
This submission adds practical code examples and getting started guides to six key development tool documentation pages: Aider, Cursor, Claude Code, Continue.dev, GitHub Copilot, and OpenAI Codex. Each page now features installation instructions, common CLI commands or configuration snippets, and updated metadata. The changes have been verified against the repository's documentation contract and YAML schema.

---
*PR created automatically by Jules for task [14249794062582692337](https://jules.google.com/task/14249794062582692337) started by @joanmarcriera*