### PR TITLE
Update development tool docs with practical examples

### DIFF
--- a/docs/tools/development_ops/aider.md
+++ b/docs/tools/development_ops/aider.md
@@ -54,21 +54,21 @@ aider
 
 ## CLI examples
 
-### Hello World
+### aider hello-world
 Ask Aider to create a new file with a simple script:
 ```bash
 aider hello-world.py
 # In the chat: "Create a hello world script in python"
 ```
 
-### Using Local Models (Ollama)
+### aider with ollama
 Aider supports local models via Ollama or LiteLLM:
 ```bash
 # Run with a local Llama 3 model
 aider --model ollama/llama3
 ```
 
-### Commit Workflow
+### aider commit workflow
 Aider automatically commits changes with descriptive messages:
 ```bash
 # Start aider and it will track your session
@@ -95,5 +95,5 @@ aider
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/development_ops/claude-code.md
+++ b/docs/tools/development_ops/claude-code.md
@@ -48,20 +48,20 @@ claude
 
 ## CLI examples
 
-### Initializing a Project
+### claude-code init
 Create a `CLAUDE.md` file to give Claude persistent context about your repository:
 ```bash
 claude /init
 ```
 
-### Useful Slash Commands
+### slash commands
 Inside an active `claude` session, use these commands for quick actions:
 - `/help`: Show available commands and skills.
 - `/compact`: Summarize conversation history to save tokens.
 - `/config`: Interactively configure settings (model, theme, etc.).
 - `/review`: (If skill exists) Trigger a code review of staged changes.
 
-### MCP Setup
+### MCP setup
 Configure Model Context Protocol servers to extend Claude's capabilities:
 ```bash
 # List configured MCP servers
@@ -82,5 +82,5 @@ claude mcp add my-server npx -y @modelcontextprotocol/server-everything
 - [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control)
 
 ## Contribution Metadata
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/development_ops/codex.md
+++ b/docs/tools/development_ops/codex.md
@@ -48,7 +48,7 @@ codex "Create a python function to scrape a website"
 
 ## CLI examples
 
-### Local Model Configuration
+### codex with local models
 Some wrappers allow redirecting Codex-style requests to local inference servers:
 ```bash
 # Configure CLI to point to a local Ollama instance instead of OpenAI
@@ -56,7 +56,7 @@ codex config set base_url http://localhost:11434/v1
 codex config set model codellama
 ```
 
-### Sandboxed Execution
+### sandboxed execution
 Run generated code in a restricted environment to prevent system damage:
 ```bash
 # Execute with sandboxing flags (if supported by the CLI tool)
@@ -75,5 +75,5 @@ interpreter --local --model codellama --sandbox
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/development_ops/continue_dev.md
+++ b/docs/tools/development_ops/continue_dev.md
@@ -41,7 +41,7 @@ Continue is available as an extension for VS Code and JetBrains.
 
 ## Usage examples
 
-### config.json with Ollama
+### config.json with Ollama provider
 Configure Continue to use a local model via Ollama:
 ```json
 {
@@ -60,7 +60,7 @@ Configure Continue to use a local model via Ollama:
 }
 ```
 
-### Custom Slash Commands
+### custom slash commands
 Add custom behavior by defining slash commands in `config.json`:
 ```json
 {
@@ -84,5 +84,5 @@ Add custom behavior by defining slash commands in `config.json`:
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/development_ops/cursor.md
+++ b/docs/tools/development_ops/cursor.md
@@ -41,7 +41,7 @@ Download Cursor from the official website and sign in. On first run, it will ind
 
 ## Usage examples
 
-### .cursorrules setup
+### .cursorrules file
 Create a `.cursorrules` file in your root directory to enforce coding standards:
 ```markdown
 # Coding Standards
@@ -51,7 +51,7 @@ Create a `.cursorrules` file in your root directory to enforce coding standards:
 - Ensure all functions have JSDoc comments.
 ```
 
-### AI Keyboard Shortcuts
+### keyboard shortcuts for AI features
 | Action | Shortcut (Mac) | Shortcut (Windows/Linux) |
 | :--- | :--- | :--- |
 | **Edit code in place** | `Cmd + K` | `Ctrl + K` |
@@ -67,5 +67,5 @@ Create a `.cursorrules` file in your root directory to enforce coding standards:
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/development_ops/github_copilot.md
+++ b/docs/tools/development_ops/github_copilot.md
@@ -41,13 +41,13 @@ GitHub Copilot is available as an extension for VS Code, Visual Studio, JetBrain
 
 ## Usage examples
 
-### Chat Commands
+### copilot chat commands
 Use slash commands in the chat sidebar to perform specific tasks:
 - `/explain`: Get an explanation of the selected code.
 - `/fix`: Propose a fix for bugs in the selected code.
 - `/tests`: Generate unit tests for the current file.
 
-### Workspace Agent
+### workspace agent
 Use the `@workspace` participant to ask questions about your entire project:
 ```text
 @workspace How are the API routes structured in this project?
@@ -63,5 +63,5 @@ Use the `@workspace` participant to ask questions about your entire project:
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-02-28
 - Confidence: medium


### PR DESCRIPTION
Updated 6 existing development tool documentation files in the `docs/tools/development_ops/` directory. For each file, I:
1. Verified the presence of the `## Getting started` section.
2. Updated or added subheaders in the `## CLI examples` or `## Usage examples` sections to match the user's request (e.g., `### aider hello-world`, `### .cursorrules file`, `### claude-code init`).
3. Updated the `Last reviewed:` date in the `Contribution Metadata` section to today's date (2026-02-28).
4. Validated the `mkdocs.yml` configuration and ensured all files pass the KnowledgeOps contract check.

---
*PR created automatically by Jules for task [5006069441533647107](https://jules.google.com/task/5006069441533647107) started by @joanmarcriera*