### PR TITLE
Add practical code examples to AI knowledge tools

### DIFF
--- a/docs/tools/ai_knowledge/dify.md
+++ b/docs/tools/ai_knowledge/dify.md
@@ -36,11 +36,36 @@ AI & Knowledge — serves as a visual platform for building and deploying LLM ap
 - [Flowise](flowise.md)
 - [LangFlow](https://github.com/langflow-ai/langflow)
 
+## Getting started
+
+Dify is typically deployed via Docker. Once running, you can access its features through the web UI or via its REST API.
+
+To use the API, you first need to create an application in the Dify dashboard and generate an API Key.
+
+## API examples
+
+### Calling a Dify Workflow API
+
+Workflows in Dify can be triggered via a POST request.
+
+```bash
+curl -X POST 'https://api.dify.ai/v1/workflows/run' \
+--header 'Authorization: Bearer {YOUR_API_KEY}' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "inputs": {
+        "query": "What are the benefits of self-hosting LLMs?"
+    },
+    "response_mode": "blocking",
+    "user": "unique_user_id_123"
+}'
+```
+
 ## Sources / references
 - [Official Website](https://dify.ai/)
 - [GitHub Repository](https://github.com/langgenius/dify)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/ai_knowledge/flowise.md
+++ b/docs/tools/ai_knowledge/flowise.md
@@ -36,11 +36,39 @@ AI & Knowledge — provides a no-code visual builder for LLM pipelines that can 
 - [Dify](dify.md)
 - [LangFlow](https://github.com/langflow-ai/langflow)
 
+## Getting started
+
+Install Flowise globally via npm and start it:
+
+```bash
+npm install -g flowise
+npx flowise start
+```
+
+Once running, you can access the UI at `http://localhost:3000`.
+
+## API examples
+
+### Calling a Flowise Chatflow via REST
+
+You can interact with your deployed chatflows using the Prediction API.
+
+```bash
+curl -X POST "http://localhost:3000/api/v1/prediction/{your-chatflow-id}" \
+     -H "Content-Type: application/json" \
+     -d '{
+            "question": "How do I set up a vector store in Flowise?",
+            "overrideConfig": {
+                "returnSourceDocuments": true
+            }
+         }'
+```
+
 ## Sources / references
 - [Official Website](https://flowiseai.com/)
 - [GitHub Repository](https://github.com/FlowiseAI/Flowise)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/ai_knowledge/langchain.md
+++ b/docs/tools/ai_knowledge/langchain.md
@@ -36,11 +36,57 @@ AI & Knowledge — serves as a foundational framework that other tools in the st
 - [LlamaIndex](llamaindex.md)
 - [Haystack](https://github.com/deepset-ai/haystack)
 
+## Getting started
+
+Install the core LangChain package and the OpenAI integration:
+
+```bash
+pip install langchain langchain-openai
+```
+
+Minimal example to call an LLM:
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(model="gpt-4o")
+response = llm.invoke("Hello, how are you?")
+print(response.content)
+```
+
+## API examples
+
+### Simple Chain with Prompt Template, LLM, and Output Parser
+
+This example demonstrates the recommended way to compose components using LangChain Expression Language (LCEL).
+
+```python
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+# 1. Define the Prompt Template
+prompt = ChatPromptTemplate.from_template("Tell me a short joke about {topic}")
+
+# 2. Initialize the Model
+model = ChatOpenAI(model="gpt-4o")
+
+# 3. Initialize the Output Parser
+output_parser = StrOutputParser()
+
+# 4. Compose the Chain using LCEL
+chain = prompt | model | output_parser
+
+# 5. Invoke the Chain
+response = chain.invoke({"topic": "bears"})
+print(response)
+```
+
 ## Sources / references
 - [Official Website](https://www.langchain.com/)
 - [GitHub Repository](https://github.com/langchain-ai/langchain)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/ai_knowledge/llamaindex.md
+++ b/docs/tools/ai_knowledge/llamaindex.md
@@ -36,11 +36,69 @@ AI & Knowledge — serves as a data-centric framework for building RAG pipelines
 - [LangChain](langchain.md)
 - [Haystack](https://github.com/deepset-ai/haystack)
 
+## Getting started
+
+Install LlamaIndex:
+
+```bash
+pip install llama-index
+```
+
+Minimal example to query a directory of documents:
+
+```python
+from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+
+documents = SimpleDirectoryReader("data").load_data()
+index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
+response = query_engine.query("What did the author do growing up?")
+print(response)
+```
+
+## API examples
+
+### Load Documents, Create Index, and Query
+
+This example shows how to load data from a local directory, create a searchable index, and execute a query.
+
+```python
+import os
+from llama_index.core import (
+    VectorStoreIndex,
+    SimpleDirectoryReader,
+    StorageContext,
+    load_index_from_storage
+)
+
+# 1. Load data from a directory
+# Assumes you have a folder named 'docs_folder' with text files
+reader = SimpleDirectoryReader(input_dir="./docs_folder")
+documents = reader.load_data()
+
+# 2. Create an index from the documents
+index = VectorStoreIndex.from_documents(documents)
+
+# 3. Create a query engine
+query_engine = index.as_query_engine()
+
+# 4. Query the index
+response = query_engine.query("Summarize the main points of the documentation.")
+print(f"Response: {response}")
+
+# 5. (Optional) Persist the index to disk
+index.storage_context.persist(persist_dir="./storage")
+
+# 6. (Optional) Load the index later
+storage_context = StorageContext.from_defaults(persist_dir="./storage")
+index = load_index_from_storage(storage_context)
+```
+
 ## Sources / references
 - [Official Website](https://www.llamaindex.ai/)
 - [GitHub Repository](https://github.com/run-llama/llama_index)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/ai_knowledge/openrouter.md
+++ b/docs/tools/ai_knowledge/openrouter.md
@@ -84,6 +84,44 @@ Use this matrix for quarterly integration reviews:
 | Zapier | Low | Low | Medium | No-code automation | Fast to ship, less control |
 | Xcode | Medium | Low | Medium | Apple-native tooling | Useful for iOS/macOS pipelines |
 
+## Getting started
+
+OpenRouter is an OpenAI-compatible API. You can use the standard OpenAI Python client by pointing the `base_url` to OpenRouter.
+
+```bash
+pip install openai
+```
+
+## API examples
+
+### Using OpenAI SDK with OpenRouter
+
+```python
+from openai import OpenAI
+
+# Initialize the client with OpenRouter's base URL and your API key
+client = OpenAI(
+  base_url="https://openrouter.ai/api/v1",
+  api_key="sk-or-v1-xxxxxx...",
+)
+
+completion = client.chat.completions.create(
+  extra_headers={
+    "HTTP-Referer": "https://your-site-url.com", # Optional, for including your app on openrouter.ai rankings.
+    "X-Title": "Your App Name", # Optional. Shows in rankings on openrouter.ai.
+  },
+  model="anthropic/claude-3.5-sonnet",
+  messages=[
+    {
+      "role": "user",
+      "content": "What is the best way to implement a multi-agent system?"
+    }
+  ]
+)
+
+print(completion.choices[0].message.content)
+```
+
 ## Sources / References
 
 - [OpenRouter overview](https://openrouter.ai/docs/overview/introduction)
@@ -104,5 +142,5 @@ Use this matrix for quarterly integration reviews:
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-28
 - Confidence: medium

--- a/docs/tools/ai_knowledge/perplexity.md
+++ b/docs/tools/ai_knowledge/perplexity.md
@@ -36,10 +36,61 @@ AI & Knowledge — used as a research and information retrieval tool when up-to-
 - [Google Search](https://www.google.com)
 - [Genspark](https://www.genspark.ai/)
 
+## Getting started
+
+Perplexity provides an OpenAI-compatible API. You can use the standard OpenAI Python client to interact with it.
+
+```bash
+pip install openai
+```
+
+## API examples
+
+### Calling Perplexity API with Python
+
+```python
+from openai import OpenAI
+
+YOUR_API_KEY = "pplx-xxxxxxxx"
+
+client = OpenAI(api_key=YOUR_API_KEY, base_url="https://api.perplexity.ai")
+
+# Chat completion without streaming
+response = client.chat.completions.create(
+    model="sonar-reasoning-pro",
+    messages=[
+        {
+            "role": "system",
+            "content": "Be precise and concise.",
+        },
+        {
+            "role": "user",
+            "content": "What are the latest developments in MCP (Model Context Protocol)?",
+        },
+    ],
+)
+print(response.choices[0].message.content)
+```
+
+### Calling Perplexity API with curl
+
+```bash
+curl -X POST https://api.perplexity.ai/chat/completions \
+  -H "Authorization: Bearer {YOUR_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "sonar-reasoning-pro",
+    "messages": [
+      {"role": "system", "content": "Be precise and concise."},
+      {"role": "user", "content": "How many stars are in the Milky Way?"}
+    ]
+  }'
+```
+
 ## Sources / references
 - [Official Website](https://www.perplexity.ai/)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
+- Last reviewed: 2026-02-28
 - Confidence: medium


### PR DESCRIPTION
This change adds practical code examples and "Getting started" instructions to six major AI knowledge tools in the documentation. Each update follows the repository's template for tool documentation, providing runnable snippets (Python or curl) while preserving all existing content. The changes were validated against the KnowledgeOps contract and mkdocs.yml integrity checks.

---
*PR created automatically by Jules for task [8855588943365157188](https://jules.google.com/task/8855588943365157188) started by @joanmarcriera*