### PR TITLE
Integrate LangSmith and OpenPipe from 2026-02-28 Source Log

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -899,6 +899,18 @@
       "name": "Agno",
       "category": "Agents",
       "doc_path": "docs/tools/agents/agno.md"
+    },
+    {
+      "id": "langsmith",
+      "name": "LangSmith",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/langsmith.md"
+    },
+    {
+      "id": "openpipe",
+      "name": "OpenPipe",
+      "category": "Infrastructure",
+      "doc_path": "docs/tools/infrastructure/openpipe.md"
     }
   ]
 }

--- a/docs/architecture/component_map.md
+++ b/docs/architecture/component_map.md
@@ -19,6 +19,7 @@ This map categorizes all tools in the stack based on their primary function in t
 - **Calendars/Contacts**: [Radicale](../services/radicale.md), [Google Calendar](../tools/calendar_tasks/google_calendar.md)
 - **Media/Projects**: [Jellyfin](../services/jellyfin.md), [Focalboard](../services/focalboard.md)
 - **Distributed**: [Storj Node](../services/storj.md)
+- **Fine-tuning**: [OpenPipe](../tools/infrastructure/openpipe.md)
 
 ## 3. Understand (Reasoning Engines)
 *The brains of the stack that process and reason over information.*
@@ -51,7 +52,7 @@ This map categorizes all tools in the stack based on their primary function in t
 
 ## 7. Benchmark
 *Tools for evaluating model performance and reasoning.*
-- **Reasoning**: [Humanity's Last Exam (HLE)](../tools/benchmarking/humanitys-last-exam.md), [LM Evaluation Harness](../tools/benchmarking/lm-evaluation-harness.md), [DREAM Benchmark](../tools/benchmarking/dream.md)
+- **Reasoning**: [Humanity's Last Exam (HLE)](../tools/benchmarking/humanitys-last-exam.md), [LangSmith](../tools/benchmarking/langsmith.md), [LM Evaluation Harness](../tools/benchmarking/lm-evaluation-harness.md), [DREAM Benchmark](../tools/benchmarking/dream.md)
 - **Agentic**: [Terminal-Bench](../tools/benchmarking/terminal-bench.md), [SWE-bench](../tools/benchmarking/swe-bench.md), [LongCLI-Bench](../tools/benchmarking/longcli-bench.md), [PA-bench](../tools/benchmarking/pa-bench.md)
 - **Local Performance**: [Ollama Benchmark CLI](../tools/benchmarking/ollama-benchmark-cli.md), [LLMPerf](../tools/benchmarking/llmperf.md)
 

--- a/docs/new-sources/2026-02-28.md
+++ b/docs/new-sources/2026-02-28.md
@@ -27,3 +27,7 @@
 | Groq | [https://groq.com/](https://groq.com/) | provider | integrated | [tools/providers/groq.md](../tools/providers/groq.md) | High-speed LPU inference infrastructure. |
 | Fireworks AI | [https://fireworks.ai/](https://fireworks.ai/) | provider | integrated | [tools/providers/fireworks.md](../tools/providers/fireworks.md) | Fast inference and fine-tuning for open models. |
 | Replicate | [https://replicate.com/](https://replicate.com/) | provider | integrated | [tools/providers/replicate.md](../tools/providers/replicate.md) | API for running a wide variety of open-source models. |
+| DeepSeek | [https://www.deepseek.com/](https://www.deepseek.com/) | tool, provider | duplicate | [tools/ai_knowledge/deepseek.md](../tools/ai_knowledge/deepseek.md) | Open-source LLM provider from China. |
+| Ollama | [https://ollama.com/](https://ollama.com/) | tool, infrastructure | duplicate | [services/ollama.md](../services/ollama.md) | Local LLM runner for macOS, Linux, and Windows. |
+| LangSmith | [https://www.langchain.com/langsmith](https://www.langchain.com/langsmith) | tool, benchmarking | integrated | [tools/benchmarking/langsmith.md](../tools/benchmarking/langsmith.md) | Unified platform for debugging, testing, and monitoring LLM applications. |
+| OpenPipe | [https://openpipe.ai/](https://openpipe.ai/) | tool, infrastructure | integrated | [tools/infrastructure/openpipe.md](../tools/infrastructure/openpipe.md) | Data-driven fine-tuning platform for replacing generic LLMs with smaller, faster models. |

--- a/docs/tools/benchmarking/index.md
+++ b/docs/tools/benchmarking/index.md
@@ -6,6 +6,7 @@
 - [Gsm8k](gsm8k.md)
 - [Human Eval](human-eval.md)
 - [Humanitys Last Exam](humanitys-last-exam.md)
+- [LangSmith](langsmith.md)
 - [Llmperf](llmperf.md)
 - [Lm Evaluation Harness](lm-evaluation-harness.md)
 - [LongCLI-Bench](longcli-bench.md)

--- a/docs/tools/benchmarking/langsmith.md
+++ b/docs/tools/benchmarking/langsmith.md
@@ -1,0 +1,54 @@
+# LangSmith
+
+## What it is
+LangSmith is a unified platform for debugging, testing, evaluating, and monitoring LLM applications. It is part of the LangChain ecosystem but can be used with any LLM framework.
+
+## What problem it solves
+It addresses the "black box" nature of LLMs by providing full visibility into the execution traces of complex chains and agents. It also provides tools for creating evaluation datasets, running automated tests, and monitoring production performance.
+
+## Where it fits in the stack
+Benchmarking / Observability
+
+## Typical use cases
+- Debugging complex agentic workflows by inspecting intermediate steps and tool calls.
+- Creating "golden" datasets for regression testing.
+- Monitoring production applications for cost, latency, and quality.
+- Collaborative prompt engineering and testing.
+
+## Strengths
+- Deep integration with LangChain and LangGraph.
+- Powerful trace visualization and filtering.
+- Supports manual and automated evaluation.
+- Hub for sharing and versioning prompts.
+
+## Limitations
+- Proprietary SaaS (though self-hosting is available for enterprise).
+- Can add latency if not configured correctly (though usually negligible).
+- Learning curve for advanced evaluation features.
+
+## When to use it
+- When building complex LLM applications that require tracing for debugging.
+- When transitioning from prototype to production and needing reliability metrics.
+- When collaborating with a team on prompt engineering.
+
+## When not to use it
+- For very simple, single-call LLM scripts where a full observability platform is overkill.
+- If strict data privacy requirements forbid sending traces to a third-party SaaS (and enterprise self-hosting is not feasible).
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Freemium (Free tier available, paid tiers for higher volume/enterprise)
+- **Self-hostable**: Yes (Enterprise only)
+
+## Related tools / concepts
+- [LangChain](../ai_knowledge/langchain.md)
+- [LangGraph](../agents/langgraph.md)
+- [Benchmarking](./index.md)
+
+## Sources / References
+- [Official Website](https://www.langchain.com/langsmith)
+- [Docs](https://docs.smith.langchain.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-28
+- Confidence: high

--- a/docs/tools/infrastructure/index.md
+++ b/docs/tools/infrastructure/index.md
@@ -11,6 +11,7 @@ Inference engines, serving stacks, quantisation tools, vector databases, and dep
 | [llama.cpp](llama-cpp.md) | Lightweight local inference runtime for quantized LLMs |
 | [LiteLLM](../../services/litellm.md) | Unified LLM API proxy |
 | [MLX](mlx.md) | Optimized machine learning framework for Apple Silicon |
+| [OpenPipe](openpipe.md) | Data-driven fine-tuning platform |
 | [Ollama](../../services/ollama.md) | Local LLM inference server |
 | [SGLang](sglang.md) | Fast structured generation and prefix caching runtime |
 | [Text Generation Inference (TGI)](tgi.md) | Hugging Face production inference server |

--- a/docs/tools/infrastructure/openpipe.md
+++ b/docs/tools/infrastructure/openpipe.md
@@ -1,0 +1,53 @@
+# OpenPipe
+
+## What it is
+OpenPipe is a data-driven fine-tuning platform that allows developers to replace generic, expensive LLMs (like GPT-4) with smaller, faster, and cheaper specialized models. It works by capturing requests and completions from existing models and using them to train custom models.
+
+## What problem it solves
+It lowers the cost and latency of LLM applications without sacrificing quality by automating the process of distillation and fine-tuning. It simplifies the pipeline from data collection to model deployment.
+
+## Where it fits in the stack
+Infrastructure / Fine-tuning
+
+## Typical use cases
+- Distilling GPT-4 level performance into a specialized Mistral or Llama-based model.
+- Reducing costs for high-volume LLM tasks like classification or extraction.
+- Improving latency for real-time applications by using smaller models.
+
+## Strengths
+- Easy "drop-in" replacement for OpenAI's SDK.
+- Automated data collection and curation for fine-tuning.
+- Integrated evaluation to compare fine-tuned models against base models.
+- Support for multiple base models (Mistral, Llama 3, etc.).
+
+## Limitations
+- Requires an initial "teacher" model to generate data.
+- Performance depends on the quality and variety of captured data.
+- Primarily focused on specialized tasks rather than general-purpose chat.
+
+## When to use it
+- When you have a stable production task and want to reduce costs or latency.
+- When you want to own your weights but start with OpenAI-grade performance.
+
+## When not to use it
+- For highly exploratory tasks where the prompt is changing frequently.
+- If you don't have enough volume to justify the fine-tuning effort or cost.
+
+## Licensing and cost
+- **Open Source**: Yes (Client SDK and some components)
+- **Cost**: Paid (Usage-based pricing for training and hosting)
+- **Self-hostable**: Partial (SDK is open, training platform is managed)
+
+## Related tools / concepts
+- [Infrastructure](./index.md)
+- [Mistral AI](../providers/mistral.md)
+- [Together AI](../providers/together.md)
+
+## Sources / References
+- [Official Website](https://openpipe.ai/)
+- [GitHub](https://github.com/openpipe/openpipe)
+- [Docs](https://docs.openpipe.ai/)
+
+## Contribution Metadata
+- Last reviewed: 2026-02-28
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
   - New Sources:
     - Overview: new-sources.md
     - Daily Logs:
+      - 2026-02-28: new-sources/2026-02-28.md
       - 2026-02-27: new-sources/2026-02-27.md
       - 2026-02-26: new-sources/2026-02-26.md
       - 2026-02-25: new-sources/2026-02-25.md
@@ -160,6 +161,7 @@ nav:
       - Gsm8K: tools/benchmarking/gsm8k.md
       - Human Eval: tools/benchmarking/human-eval.md
       - Humanitys Last Exam: tools/benchmarking/humanitys-last-exam.md
+      - LangSmith: tools/benchmarking/langsmith.md
       - LLMperf: tools/benchmarking/llmperf.md
       - Lm Evaluation Harness: tools/benchmarking/lm-evaluation-harness.md
       - LongCLI-Bench: tools/benchmarking/longcli-bench.md
@@ -239,6 +241,7 @@ nav:
       - ExLlamaV2: tools/infrastructure/exllamav2.md
       - llama.cpp: tools/infrastructure/llama-cpp.md
       - MLX: tools/infrastructure/mlx.md
+      - OpenPipe: tools/infrastructure/openpipe.md
       - SGLang: tools/infrastructure/sglang.md
       - Text Generation Inference (TGI): tools/infrastructure/tgi.md
       - vLLM: tools/infrastructure/vllm.md


### PR DESCRIPTION
This change processes the 'new' entries in the latest source log (2026-02-28). It integrates LangSmith and OpenPipe by creating their documentation pages, registering them in the tool registry and site navigation, and updating relevant architectural maps. It also marks DeepSeek and Ollama as duplicates as they already exist in the catalog. All changes have been verified through contract checks, YAML validation, and visual inspection of the generated documentation site.

---
*PR created automatically by Jules for task [14500974209088284576](https://jules.google.com/task/14500974209088284576) started by @joanmarcriera*