### PR TITLE
Create AI Tooling Landscape — 2026 Overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hide:
 
     ---
 
-    New here? Explore the [AI Tooling Landscape](knowledge_base/ai_tooling_landscape.md) to see how it all fits together, or follow the [Maturity Ladder](#maturity-ladder).
+    New here? Explore the [**AI Tooling Landscape — 2026 Overview**](knowledge_base/ai_tooling_landscape.md) to see how the entire ecosystem fits together, or follow the [Maturity Ladder](#maturity-ladder).
 
 -   :material-tools:{ .lg .middle } **126 Tools & Services**
 

--- a/docs/knowledge_base/README.md
+++ b/docs/knowledge_base/README.md
@@ -3,7 +3,7 @@
 This section contains deep dives into the technologies, protocols, and conceptual frameworks that power the AI Hub.
 
 ## 📖 Contents
-- [**AI Tooling Landscape**](ai_tooling_landscape.md) - **Start Here.** A high-level map of the entire AI tooling ecosystem.
+- [**AI Tooling Landscape — 2026 Overview**](ai_tooling_landscape.md) - **Start Here.** A high-level map of the entire AI tooling ecosystem as documented in this repository.
 - [**Model Classes**](model_classes.md) - Understanding the different types of LLMs (MoE, Reasoning, Multimodal, etc.).
 - [**Agent Protocols**](agent_protocols.md) - Deep dive into MCP (Model Context Protocol) and ACP (Agent Control Protocol).
 - [**AI Signal Sources**](ai_signal_sources.md) - Curated company and independent technical blogs worth monitoring.

--- a/docs/knowledge_base/ai_tooling_landscape.md
+++ b/docs/knowledge_base/ai_tooling_landscape.md
@@ -7,6 +7,26 @@ A living overview that maps the AI tooling landscape into layers, showing how to
 
 ## The Stack (Layered View)
 
+```text
+┌───────────────────────────────────────────────────────────────────────────┐
+│ Layer 7: Applications (ChatGPT, Perplexity, Open WebUI, Cursor)           │
+├───────────────────────────────────────────────────────────────────────────┤
+│ Layer 6: Agents & Orchestration (CrewAI, AutoGen, LangGraph, n8n)         │
+├───────────────────────────────────────────────────────────────────────────┤
+│ Layer 5: Frameworks (LangChain, LlamaIndex, Haystack, DSPy)               │
+├───────────────────────────────────────────────────────────────────────────┤
+│ Layer 4: Protocols & Standards (MCP, Tool Calling, A2A)                   │
+├───────────────────────────────────────────────────────────────────────────┤
+│ Layer 3: Inference & Serving (vLLM, TGI, Ollama, SGLang)                  │
+├───────────────────────────────────────────────────────────────────────────┤
+│ Layer 2: Models (GPT-4, Claude, Llama, Mistral, Gemini, Qwen)             │
+├───────────────────────────────────────────────────────────────────────────┤
+│ Layer 1: Providers (OpenAI, Anthropic, Google, Meta, Mistral, OpenRouter) │
+├───────────────────────────────────────────────────────────────────────────┤
+│ Layer 0: Infrastructure (GPUs, quantization, vector DBs)                  │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
 | Layer | Category | Description |
 | :--- | :--- | :--- |
 | **Layer 7** | **Applications** | User-facing interfaces and platforms where humans interact with AI. |
@@ -18,67 +38,79 @@ A living overview that maps the AI tooling landscape into layers, showing how to
 | **Layer 1** | **Providers** | Companies and platforms that host models and provide them as-a-service. |
 | **Layer 0** | **Infrastructure** | The underlying hardware, storage, and low-level optimizations that power everything. |
 
+---
+
 ### Layer 7: Applications
-The top of the stack where AI meets the end-user. These tools provide polished interfaces for chat, search, and specialized tasks.
-- **Tools**: [ChatGPT](../tools/ai_knowledge/chatgpt.md), [Perplexity](../tools/ai_knowledge/perplexity.md), [Open WebUI](../services/open-webui.md), [Claude Code](../tools/development_ops/claude-code.md), [Cursor](../tools/development_ops/cursor.md), [Aider](../tools/development_ops/aider.md).
-- **Trends**: Consolidation of "chat" into multimodal workspaces and the rise of agentic IDEs.
+The top of the stack where AI meets the end-user. These tools provide polished interfaces for chat, search, and specialized tasks like coding or knowledge management. They abstract the underlying complexity, allowing non-technical users to leverage model capabilities directly in their workflows.
+- **Relevant Pages**: [ChatGPT](../tools/ai_knowledge/chatgpt.md), [Perplexity](../tools/ai_knowledge/perplexity.md), [Open WebUI](../services/open-webui.md), [Claude Code](../tools/development_ops/claude-code.md), [Cursor](../tools/development_ops/cursor.md), [Aider](../tools/development_ops/aider.md), [Zed](../tools/development_ops/zed.md), [Obsidian](../tools/ai_knowledge/obsidian.md).
+- **Key Trends**: Consolidation of "chat" into multimodal workspaces and the rapid rise of agentic IDEs that can execute code autonomously.
 
 ### Layer 6: Agents & Orchestration
-Systems that move beyond single prompts to autonomous or semi-autonomous execution of workflows.
-- **Tools**: [CrewAI](../tools/frameworks/crewai.md), [AutoGen](../tools/frameworks/autogen.md), [LangGraph](../tools/agents/langgraph.md), [n8n](../services/n8n.md), [Agency Swarm](../tools/agents/agency-swarm.md), [Agno](../tools/agents/agno.md), [Bee Agent Framework](../tools/agents/bee-agent-framework.md), [Composio](../tools/agents/composio.md), [Phidata](../tools/agents/phidata.md), [OpenHands](../tools/development_ops/openhands.md), [Droid](../tools/development_ops/droid.md).
-- **Trends**: Shift from linear chains to graph-based agentic workflows with long-term memory.
+Systems that move beyond single prompts to autonomous or semi-autonomous execution of complex workflows. These agents use reasoning to plan, use tools, and iterate until a goal is achieved. This layer is responsible for maintaining state and managing long-running tasks that require multiple model interactions.
+- **Relevant Pages**: [CrewAI](../tools/frameworks/crewai.md), [AutoGen](../tools/frameworks/autogen.md), [LangGraph](../tools/agents/langgraph.md), [n8n](../services/n8n.md), [Agency Swarm](../tools/agents/agency-swarm.md), [Agno](../tools/agents/agno.md), [Bee Agent Framework](../tools/agents/bee-agent-framework.md), [Composio](../tools/agents/composio.md), [Phidata](../tools/agents/phidata.md), [OpenHands](../tools/development_ops/openhands.md), [Droid](../tools/development_ops/droid.md), [Browser Use](../tools/automation_orchestration/browser-use.md).
+- **Key Trends**: Shift from linear chains to graph-based agentic workflows with long-term memory and human-in-the-loop confirmation.
 
 ### Layer 5: Frameworks
-The building blocks for AI developers. These libraries abstract provider APIs and provide tools for RAG and chain-of-thought.
-- **Tools**: [LangChain](../tools/ai_knowledge/langchain.md), [LlamaIndex](../tools/ai_knowledge/llamaindex.md), [Haystack](../tools/frameworks/haystack.md), [DSPy](../tools/frameworks/dspy.md), [Semantic Kernel](../tools/frameworks/semantic-kernel.md), [Smolagents](../tools/frameworks/smolagents.md).
-- **Trends**: Frameworks are becoming more lightweight, focusing on "un-opinionated" orchestration.
+The building blocks for AI developers. These libraries abstract provider APIs and provide standardized tools for RAG, prompt engineering, and evaluation. Frameworks allow developers to swap models easily and build complex logic that bridges the gap between raw models and agentic behavior.
+- **Relevant Pages**: [LangChain](../tools/ai_knowledge/langchain.md), [LlamaIndex](../tools/ai_knowledge/llamaindex.md), [Haystack](../tools/frameworks/haystack.md), [DSPy](../tools/frameworks/dspy.md), [Semantic Kernel](../tools/frameworks/semantic-kernel.md), [Smolagents](../tools/frameworks/smolagents.md), [Dify](../tools/ai_knowledge/dify.md), [Flowise](../tools/ai_knowledge/flowise.md).
+- **Key Trends**: Frameworks are moving toward "un-opinionated" orchestration, focusing on observability and better integration with production monitoring.
 
 ### Layer 4: Protocols & Standards
-Ensuring interoperability between models and the environments they operate in.
-- **Tools**: [Model Context Protocol (MCP)](agent_protocols.md), [Claude Tool Search](patterns/claude-tool-search.md), [Agent Protocols](agent_protocols.md).
-- **Trends**: MCP is rapidly becoming the standard for connecting LLMs to local and remote data sources.
+Ensuring interoperability between models, the tools they use, and the environments they operate in. These standards allow a single tool to be used across multiple different agents or platforms without rewriting integration logic. They provide the common language that defines how data and capabilities are exchanged.
+- **Relevant Pages**: [Model Context Protocol (MCP)](agent_protocols.md), [Tool Calling & MCP Patterns](patterns/tool-calling-and-mcp.md), [Agent Client Protocol (ACP)](agent_protocols.md).
+- **Key Trends**: MCP is rapidly becoming the industry standard for connecting any LLM to any local or remote data source or tool.
 
 ### Layer 3: Inference & Serving
-How we run models, either locally or in self-hosted environments.
-- **Tools**: [vLLM](../tools/infrastructure/vllm.md), [Text Generation Inference (TGI)](../tools/infrastructure/tgi.md), [Ollama](../services/ollama.md), [SGLang](../tools/infrastructure/sglang.md), [Aphrodite Engine](../tools/infrastructure/aphrodite-engine.md), [ExLlamaV2](../tools/infrastructure/exllamav2.md), [llama.cpp](../tools/infrastructure/llama-cpp.md), [MLX](../tools/infrastructure/mlx.md).
-- **Trends**: Layer 3 is consolidating around vLLM and SGLang for high-throughput serving.
+How we run model weights, either in the cloud or on local consumer hardware. This layer handles the conversion of model parameters into a functional API that can process tokens at scale. It includes optimizations for throughput, latency, and memory efficiency to make running models cost-effective.
+- **Relevant Pages**: [vLLM](../tools/infrastructure/vllm.md), [Text Generation Inference (TGI)](../tools/infrastructure/tgi.md), [Ollama](../services/ollama.md), [SGLang](../tools/infrastructure/sglang.md), [Aphrodite Engine](../tools/infrastructure/aphrodite-engine.md), [ExLlamaV2](../tools/infrastructure/exllamav2.md), [llama.cpp](../tools/infrastructure/llama-cpp.md), [MLX](../tools/infrastructure/mlx.md), [LiteLLM](../services/litellm.md).
+- **Key Trends**: Layer 3 is consolidating around vLLM and SGLang for high-throughput enterprise serving, while Ollama dominates local developer use.
 
 ### Layer 2: Models
-The reasoning engines themselves.
-- **Tools**: [OpenAI GPT-4](../tools/ai_knowledge/openai.md), [Anthropic Claude](../tools/providers/anthropic.md), [Meta Llama](../tools/ai_knowledge/local_llms.md), [Mistral](../tools/providers/mistral.md), [Google Gemini](../tools/ai_knowledge/google-gemini.md), [DeepSeek](../tools/ai_knowledge/deepseek.md).
-- **Trends**: Rapid advancement in reasoning-specialized models (e.g., DeepSeek-R1, OpenAI o1).
+The core reasoning engines themselves, categorized by their capabilities and training objectives. These models are the "brains" of the entire operation, trained on vast datasets to understand and generate human language, code, and images. They are increasingly specialized into different classes, from general-purpose assistants to deep-reasoning experts.
+- **Relevant Pages**: [OpenAI Models](../tools/ai_knowledge/openai.md), [Anthropic Claude](../tools/providers/anthropic.md), [Meta Llama](../tools/ai_knowledge/local_llms.md), [Mistral](../tools/providers/mistral.md), [Google Gemini](../tools/ai_knowledge/google-gemini.md), [DeepSeek](../tools/ai_knowledge/deepseek.md), [Model Classes](model_classes.md).
+- **Key Trends**: Rapid advancement in reasoning-specialized models (e.g., DeepSeek-R1, OpenAI o1) that use test-time compute.
 
 ### Layer 1: Providers
-The platforms that make models accessible via API.
-- **Tools**: [OpenRouter](../tools/ai_knowledge/openrouter.md), [Groq](../tools/providers/groq.md), [Fireworks AI](../tools/providers/fireworks.md), [Together AI](../tools/providers/together.md), [Replicate](../tools/providers/replicate.md), [Mistral AI](../tools/providers/mistral.md), [Cohere](../tools/providers/cohere.md).
-- **Trends**: Providers are competing on speed (Groq) and breadth of model access (OpenRouter).
+The platforms and marketplaces that make models accessible via unified APIs. These providers manage the infrastructure and scaling required to serve models to millions of users simultaneously. They offer additional services like fine-tuning, monitoring, and safety filtering alongside raw model access.
+- **Relevant Pages**: [OpenRouter](../tools/ai_knowledge/openrouter.md), [Groq](../tools/providers/groq.md), [Fireworks AI](../tools/providers/fireworks.md), [Together AI](../tools/providers/together.md), [Replicate](../tools/providers/replicate.md), [Mistral AI](../tools/providers/mistral.md), [Cohere](../tools/providers/cohere.md).
+- **Key Trends**: Providers are competing on inference speed (LPUs) and breadth of access to both open and closed models.
 
 ### Layer 0: Infrastructure
-The foundation of the lab.
-- **Tools**: [Home Lab Architecture](../architecture/infrastructure.md), [TrueNAS SCALE](../architecture/infrastructure.md), [Tailscale](../services/tailscale.md).
-- **Components**: GPUs (NVIDIA/Apple Silicon), quantization techniques, and vector databases (integrated into RAG patterns).
+The foundation of the lab: hardware, storage, and networking optimizations. This layer includes the physical GPUs and CPUs that perform the computations, as well as the storage systems for model weights and vector data. It also covers the networking protocols that ensure low-latency communication between services.
+- **Relevant Pages**: [Home Lab Architecture](../architecture/infrastructure.md), [TrueNAS SCALE](../architecture/infrastructure.md), [Tailscale](../services/tailscale.md), [OpenPipe (Fine-tuning)](../tools/infrastructure/openpipe.md).
+- **Key Trends**: Move toward hybrid local/cloud setups using tools like Tailscale to securely bridge home-lab resources with cloud providers.
+
+---
 
 ## Key Patterns
 Common architectural blueprints used across the stack:
-- **[RAG (Retrieval-Augmented Generation)](patterns/rag.md)**: Grounding models with external data.
-- **[Tool Calling & MCP](patterns/claude-tool-search.md)**: Standardized ways for LLMs to use external functions.
-- **[LLM Trust Boundaries](patterns/llm-trust-boundaries.md)**: Security and privacy considerations in agentic systems.
-- **[Agent Skills Best Practices](patterns/skills-best-practices.md)**: Optimizing agent performance.
+- **[Retrieval-Augmented Generation (RAG)](patterns/rag.md)**: Grounding models with external data to improve accuracy and reduce hallucinations.
+- **[Tool Calling & MCP](patterns/tool-calling-and-mcp.md)**: Standardized ways for LLMs to use external functions and interact with data sources.
+- **[LLM Trust Boundaries](patterns/llm-trust-boundaries.md)**: Security and privacy considerations in agentic systems, defining where data can flow.
+- **[Agent Skills Best Practices](patterns/skills-best-practices.md)**: Optimizing agent performance through better tool descriptions and execution patterns.
+- **[Claude Tool Search](patterns/claude-tool-search.md)**: Specific patterns for maximizing the effectiveness of Anthropic's tool-calling capabilities.
+
+---
 
 ## How to use this repo
 
 ### Personas Guide
-- **"I want to run LLMs locally"** → Start with [Ollama](../services/ollama.md) and [Open WebUI](../services/open-webui.md). Explore [llama.cpp](../tools/infrastructure/llama-cpp.md) or [MLX](../tools/infrastructure/mlx.md) for more control.
-- **"I want to build an AI agent"** → Look at [CrewAI](../tools/frameworks/crewai.md) or [LangGraph](../tools/agents/langgraph.md). Use [MCP](agent_protocols.md) to give them tools.
-- **"I want to add AI to my app"** → Start with [LangChain](../tools/ai_knowledge/langchain.md) or [LlamaIndex](../tools/ai_knowledge/llamaindex.md) and connect to a [Provider](../tools/providers/index.md).
-- **"I want to evaluate models"** → Check the [Benchmarking](../tools/benchmarking/index.md) section for tools like [Chatbot Arena](../tools/benchmarking/chatbot-arena.md) or [LM Evaluation Harness](../tools/benchmarking/lm-evaluation-harness.md).
-- **"I want to stay current"** → Follow the [Reading List](ai_reading_list.md) and monitor the [Daily Ingestion Logs](../new-sources.md).
+- **"I want to run LLMs locally"** → Start with [Ollama](../services/ollama.md) and [Open WebUI](../services/open-webui.md). For advanced optimization on specific hardware, explore [llama.cpp](../tools/infrastructure/llama-cpp.md), [MLX](../tools/infrastructure/mlx.md) (for Mac), or [ExLlamaV2](../tools/infrastructure/exllamav2.md).
+- **"I want to build an AI agent"** → Look at [CrewAI](../tools/frameworks/crewai.md) or [AutoGen](../tools/frameworks/autogen.md) for multi-agent workflows, or [LangGraph](../tools/agents/langgraph.md) for stateful, cyclic graphs. Use [MCP](agent_protocols.md) to give them tools.
+- **"I want to add AI to my app"** → Start with [LangChain](../tools/ai_knowledge/langchain.md) or [LlamaIndex](../tools/ai_knowledge/llamaindex.md) and connect to a [Provider](../tools/providers/index.md) like [OpenRouter](../tools/ai_knowledge/openrouter.md).
+- **"I want to evaluate models"** → Check the [Benchmarking](../tools/benchmarking/index.md) section for tools like [Chatbot Arena](../tools/benchmarking/chatbot-arena.md), [SWE-bench](../tools/benchmarking/swe-bench.md), or [LM Evaluation Harness](../tools/benchmarking/lm-evaluation-harness.md).
+- **"I want to stay current"** → Follow the [Essential AI Reading List](ai_reading_list.md) and monitor the [Daily Ingestion Logs](../new-sources.md) for new tool discoveries.
+
+---
 
 ## Sources / references
 - [Sequoia Capital: Generative AI's Act Two](https://www.sequoiacap.com/article/generative-ai-act-two/)
 - [A16Z: Emerging Architectures for LLM Applications](https://a16z.com/emerging-architectures-for-llm-applications/)
 - [MAD Landscape (Machine Learning, AI & Data)](https://mad.firstmark.com/)
+- [MCP Documentation (Anthropic)](https://modelcontextprotocol.io/)
+
+---
 
 ## Contribution Metadata
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-02-28
 - Confidence: high

--- a/docs/knowledge_base/patterns/rag.md
+++ b/docs/knowledge_base/patterns/rag.md
@@ -136,7 +136,7 @@ print(result["answer"])
     *   *Recursive:* Adjusts based on punctuation/structure.
     *   *Semantic:* Uses embeddings to find natural break points.
 *   **Embedding Model Selection:**
-    *   *Local:* (e.g., [Ollama](../../tools/ai_knowledge/ollama.md) with `nomic-embed-text`, BGE, HuggingFace) for privacy and zero cost.
+    *   *Local:* (e.g., [Ollama](../../services/ollama.md) with `nomic-embed-text`, BGE, HuggingFace) for privacy and zero cost.
     *   *API-based:* (e.g., OpenAI, Cohere) for high performance with less local compute.
 *   **Vector Store Selection:**
     *   Options include Chroma, Pinecone, Weaviate, or [pgvector](../../tools/infrastructure/index.md#sub-categories).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -264,7 +264,7 @@ nav:
     - Prompt Catalogue: architecture/prompt-catalogue.md
   - Knowledge Base:
     - Overview: knowledge_base/README.md
-    - AI Tooling Landscape: knowledge_base/ai_tooling_landscape.md
+    - AI Tooling Landscape — 2026 Overview: knowledge_base/ai_tooling_landscape.md
     - Agent Protocols: knowledge_base/agent_protocols.md
     - AI Signal Sources: knowledge_base/ai_signal_sources.md
     - Essential AI Reading List: knowledge_base/ai_reading_list.md


### PR DESCRIPTION
This PR introduces the "AI Tooling Landscape — 2026 Overview" page, which serves as the primary conceptual map for the entire repository. It organizes over 120 documented tools and services into an 8-layer stack, providing clarity on how infrastructure, providers, models, protocols, frameworks, agents, and applications interact. 

The page includes:
- A clear ASCII layered diagram and corresponding detailed table.
- In-depth descriptions of each layer (2-3 sentences) with current industry trends.
- Comprehensive cross-linking to existing tool and service documentation.
- A persona-based "How to use this repo" guide for common user goals (local LLMs, building agents, app integration).
- Integration into the site's primary navigation and landing pages.

Additionally, this change fixes a pre-existing broken link in the RAG pattern documentation to maintain build integrity.

---
*PR created automatically by Jules for task [661886338436842317](https://jules.google.com/task/661886338436842317) started by @joanmarcriera*