### PR TITLE
Add Landscape Overview documentation

### DIFF
--- a/docs/knowledge_base/landscape-overview.md
+++ b/docs/knowledge_base/landscape-overview.md
@@ -1,0 +1,171 @@
+# Landscape Overview
+
+This page provides a bird's-eye view of the AI tool catalogue, showing current metrics, connectivity, and recent additions. It is updated monthly to reflect the evolving state of the repository.
+
+## Overview
+- **Last Generated:** 2026-03-01
+- **Total Tools Documented:** 152
+
+## Category Breakdown
+
+Current tool count and focus per category:
+
+| Category | Count | Summary |
+| :--- | :--- | :--- |
+| **Development & Ops** | 30 | Coding assistants, IDEs, and agentic development tools. |
+| **AI Assistants & Knowledge** | 20 | General-purpose chat interfaces, RAG platforms, and knowledge bases. |
+| **Intake & Storage** | 18 | Data collection, self-hosted storage, and document management. |
+| **Process & Understanding** | 18 | Data extraction, OCR, and document processing. |
+| **Benchmarking** | 15 | Evaluation frameworks and performance measurement tools. |
+| **Automation & Orchestration** | 12 | Workflow automation and tool integration servers. |
+| **Frameworks** | 7 | Development libraries for building AI-powered applications. |
+| **Infrastructure** | 7 | Model serving, inference engines, and fine-tuning platforms. |
+| **Media & Entertainment** | 7 | Self-hosted media servers and creative content tools. |
+| **Providers** | 7 | LLM API providers and model marketplaces. |
+| **Agents** | 6 | Multi-agent orchestration frameworks. |
+| **Creative & Communication** | 3 | Diagramming and secure messaging services. |
+| **Calendar & Tasks** | 2 | Scheduling and task management integrations. |
+
+## Top 10 Most-Connected Tools
+Based on the number of links in their 'Related tools / concepts' sections.
+
+| Tool | Related Links |
+| :--- | :--- |
+| Claude Code | 5 |
+| Google Gemini | 4 |
+| LangGraph | 4 |
+| Agency Swarm | 4 |
+| Composio | 4 |
+| Phidata | 4 |
+| Agno | 4 |
+| Anthropic Claude | 3 |
+| Cohere | 3 |
+| Mistral AI | 3 |
+
+## Underdeveloped Categories
+Categories with fewer than 8 docs are identified as areas where the repository is actively expanding:
+- Agents (6)
+- Calendar & Tasks (2)
+- Creative & Communication (3)
+- Frameworks (7)
+- Infrastructure (7)
+- Media & Entertainment (7)
+- Providers (7)
+
+## What's New This Month
+Tools added in the last 30 days:
+- Agency Swarm
+- Agno
+- Aider
+- Anthropic Claude
+- Anti-Gravity
+- Aphrodite Engine
+- Atlassian Jira MCP Implementations
+- AutoGen
+- Bee Agent Framework
+- Browser Use
+- CalDAV
+- ChatGPT
+- Chatbot Arena
+- Claude Code
+- Claude Code Setup
+- CliHub
+- Cloud Code
+- Codeium
+- Codex (OpenAI)
+- Cohere
+- Composio
+- Continue.dev
+- Crawl4AI
+- CrewAI
+- Cursor
+- Custom Agents
+- DREAM Benchmark
+- DSPy
+- DeepSeek
+- Dify
+- Droid
+- ExLlamaV2
+- Firecrawl
+- Fireworks AI
+- Flowise
+- GPQA
+- GPT Engineer
+- GSM8K
+- GitHub Copilot
+- GitHub Copilot CLI
+- Google Calendar
+- Google Gemini
+- Groq
+- Haystack
+- HumanEval
+- Humanity's Last Exam (HLE)
+- Jules (Google)
+- Junie CLI
+- LLMPerf
+- LM Evaluation Harness
+- LangChain
+- LangGraph
+- LangSmith
+- LlamaIndex
+- Local LLMs
+- Logseq
+- LongCLI-Bench
+- MBPP
+- MCP Registry
+- MLX
+- Make
+- Melty
+- Mentat
+- Mistral AI
+- Mycelium
+- OCRmyPDF
+- Obsidian
+- Ollama Benchmark CLI
+- OpenAI
+- OpenClaw
+- OpenCode
+- OpenHands
+- OpenPipe
+- OpenRouter
+- OpenSwarm
+- PA-bench
+- PageIndex
+- Perplexity
+- Phidata
+- Plandex
+- RAGFlow
+- Replicate
+- SGLang
+- SWE-bench
+- Semantic Kernel
+- ServiceNow MCP Server
+- Skyvern
+- Smolagents
+- Sourcegraph Cody
+- Superconductor
+- Sweep.dev
+- Tabnine
+- TeamOut
+- Terminal-Bench
+- Terminus 2
+- Text Generation Inference (TGI)
+- Together AI
+- VS Code
+- Valyu
+- ZSE
+- Zapier
+- Zed
+- ansigpt
+- llama.cpp
+- vLLM
+
+## Sources / References
+- [All Tools Metadata](https://github.com/joanmarcriera/Home-office-automations/blob/main/data/all_tools.json)
+- [Growth Metrics](https://github.com/joanmarcriera/Home-office-automations/blob/main/data/growth-metrics.json)
+- [Architecture Component Map](../architecture/component_map.md)
+- [GitHub Repository](https://github.com/joanmarcriera/Home-office-automations)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-01
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -264,6 +264,7 @@ nav:
     - Prompt Catalogue: architecture/prompt-catalogue.md
   - Knowledge Base:
     - Overview: knowledge_base/README.md
+    - Landscape Overview: knowledge_base/landscape-overview.md
     - AI Tooling Landscape — 2026 Overview: knowledge_base/ai_tooling_landscape.md
     - Agent Protocols: knowledge_base/agent_protocols.md
     - AI Signal Sources: knowledge_base/ai_signal_sources.md


### PR DESCRIPTION
Added a new `landscape-overview.md` to the `knowledge_base` directory and updated `mkdocs.yml` to include it in the navigation. The new page summarizes the current state of the tool catalogue based on `data/all_tools.json` and recent git history.

---
*PR created automatically by Jules for task [3175505637491759929](https://jules.google.com/task/3175505637491759929) started by @joanmarcriera*