### PR TITLE
Add Essential AI Reading List Knowledge Base Page

### DIFF
--- a/docs/knowledge_base/ai_reading_list.md
+++ b/docs/knowledge_base/ai_reading_list.md
@@ -4,48 +4,48 @@
 A curated list of high-signal sources for staying current on AI, LLMs, agents, and tooling.
 
 ## Blogs & Personal Sites
-- **Simon Willison** ([simonwillison.net](https://simonwillison.net)) — LLM tooling, prompt engineering, practical AI. **Why it is valuable:** Exceptional at documenting the fast-moving practical side of LLMs and open-source tooling.
-- **Lilian Weng** ([lilianweng.github.io](https://lilianweng.github.io/posts/)) — Deep technical surveys of ML topics. **Why it is valuable:** Provides some of the most thorough and well-cited technical deep dives on AI architectures and methods.
-- **Jay Alammar** ([jalammar.github.io](https://jalammar.github.io)) — Visual explanations of transformers and LLMs. **Why it is valuable:** Master of visual intuition for complex transformer architectures and model mechanics.
-- **Sebastian Raschka** ([sebastianraschka.com](https://sebastianraschka.com)) — LLM training, fine-tuning, evaluation. **Why it is valuable:** Bridges research and code with highly reproducible tutorials on training and fine-tuning models.
-- **Chip Huyen** ([huyenchip.com](https://huyenchip.com)) — MLOps, LLM systems design. **Why it is valuable:** Leading voice on the infrastructure and systems engineering required to put AI into production.
-- **Eugene Yan** ([eugeneyan.com](https://eugeneyan.com)) — Applied ML, RecSys, LLM patterns. **Why it is valuable:** Focused on the practical patterns and "how-to" of building reliable AI-powered products.
-- **Andrej Karpathy** ([karpathy.ai](https://karpathy.ai)) — AI education and deep learning fundamentals. **Why it is valuable:** Offers world-class clarity on how LLMs work from first principles and the "LLM OS" concept.
-- **Vicki Boykis** ([vickiboykis.com](https://vickiboykis.com)) — ML engineering and data systems. **Why it is valuable:** Provides a grounded, skeptical, and deeply experienced perspective on ML in the real world.
-- **Hamel Husain** ([hamel.dev](https://hamel.dev)) — LLM evaluation and engineering workflows. **Why it is valuable:** Expert on the rigors of LLM evaluation and building high-quality AI features.
-- **Jeremy Howard** ([fast.ai](https://www.fast.ai)) — AI education and top-down learning. **Why it is valuable:** Pioneer of making deep learning accessible to software engineers through a code-first approach.
-- **François Chollet** ([fchollet.com](https://fchollet.com)) — AI research and intelligence theory. **Why it is valuable:** Deep thinker on the nature of intelligence, abstraction, and the limits of current LLM architectures.
+- **Simon Willison** ([simonwillison.net](https://simonwillison.net)) — LLM tooling, prompt engineering, and practical AI analysis, exceptional at documenting the fast-moving practical side of LLMs and open-source tooling.
+- **Lilian Weng** ([lilianweng.github.io](https://lilianweng.github.io/posts/)) — Deep technical surveys of ML topics, providing some of the most thorough and well-cited technical deep dives on AI architectures and methods.
+- **Jay Alammar** ([jalammar.github.io](https://jalammar.github.io)) — Visual explanations of transformers and LLMs, master of visual intuition for complex transformer architectures and model mechanics.
+- **Sebastian Raschka** ([sebastianraschka.com](https://sebastianraschka.com)) — LLM training, fine-tuning, and evaluation tutorials that bridge research and code with highly reproducible results.
+- **Chip Huyen** ([huyenchip.com](https://huyenchip.com)) — MLOps and LLM systems design, a leading voice on the infrastructure and systems engineering required to put AI into production.
+- **Eugene Yan** ([eugeneyan.com](https://eugeneyan.com)) — Applied ML, RecSys, and LLM patterns, focused on the practical patterns and "how-to" of building reliable AI-powered products.
+- **Andrej Karpathy** ([karpathy.ai](https://karpathy.ai)) — AI education and deep learning fundamentals, offering world-class clarity on how LLMs work from first principles and the "LLM OS" concept.
+- **Vicki Boykis** ([vickiboykis.com](https://vickiboykis.com)) — ML engineering and data systems, providing a grounded, skeptical, and deeply experienced perspective on ML in the real world.
+- **Hamel Husain** ([hamel.dev](https://hamel.dev)) — LLM evaluation and engineering workflows, expert on the rigors of LLM evaluation and building high-quality AI features.
+- **Jeremy Howard** ([fast.ai](https://www.fast.ai)) — AI education and top-down learning, a pioneer of making deep learning accessible to software engineers through a code-first approach.
+- **François Chollet** ([fchollet.com](https://fchollet.com)) — AI research and intelligence theory, deep thinker on the nature of intelligence, abstraction, and the limits of current LLM architectures.
 
 ## Newsletters
-- **The Batch** (deeplearning.ai) — Andrew Ng's weekly AI digest. **Why it is valuable:** High-level synthesis of AI trends and their societal/business impacts from an industry legend.
-- **AI News** ([buttondown.com/ainews](https://buttondown.com/ainews)) — Daily aggregator. **Why it is valuable:** Comprehensive daily summary of everything happening in the AI Twitter/X and GitHub ecosystem.
-- **Latent Space** ([latent.space](https://www.latent.space)) — Deep-dive podcast + newsletter. **Why it is valuable:** Excellent for understanding the "AI Engineer" stack and emerging implementation patterns.
-- **Import AI** ([jack-clark.net](https://jack-clark.net)) — Jack Clark's curated roundup. **Why it is valuable:** Best-in-class coverage of AI policy, safety, and global research milestones.
-- **The Gradient** ([thegradient.pub](https://thegradient.pub)) — Long-form AI analysis. **Why it is valuable:** Provides thoughtful, long-form perspectives and debates on the direction of AI research.
-- **TLDR AI** ([tldr.tech/ai](https://tldr.tech/ai)) — Daily technical summary. **Why it is valuable:** Quick, skimmable daily digest of the most important AI tools, papers, and news.
-- **Ben's Bites** ([bensbites.co](https://www.bensbites.co)) — Daily AI product updates. **Why it is valuable:** Focuses on the "new and shiny" AI products and creative use cases appearing every day.
-- **Interconnects** ([interconnects.ai](https://www.interconnects.ai)) — Frontier model analysis. **Why it is valuable:** Deep, practitioner-level analysis of the newest frontier models and research.
-- **AlphaSignal** ([alphasignal.ai](https://alphasignal.ai)) — Technical AI news. **Why it is valuable:** Highly technical, signal-heavy newsletter focusing on the latest breakthroughs and code repositories.
+- **The Batch** (deeplearning.ai) — Andrew Ng's weekly AI digest, high-level synthesis of AI trends and their societal/business impacts from an industry legend.
+- **AI News** ([buttondown.com/ainews](https://buttondown.com/ainews)) — Daily aggregator, comprehensive daily summary of everything happening in the AI Twitter/X and GitHub ecosystem.
+- **Latent Space** ([latent.space](https://www.latent.space)) — Deep-dive podcast and newsletter, excellent for understanding the "AI Engineer" stack and emerging implementation patterns.
+- **Import AI** ([jack-clark.net](https://jack-clark.net)) — Jack Clark's curated roundup, best-in-class coverage of AI policy, safety, and global research milestones.
+- **The Gradient** ([thegradient.pub](https://thegradient.pub)) — Long-form AI analysis, providing thoughtful, long-form perspectives and debates on the direction of AI research.
+- **TLDR AI** ([tldr.tech/ai](https://tldr.tech/ai)) — Daily technical summary, quick, skimmable daily digest of the most important AI tools, papers, and news.
+- **Ben's Bites** ([bensbites.co](https://www.bensbites.co)) — Daily AI product updates, focusing on the "new and shiny" AI products and creative use cases appearing every day.
+- **Interconnects** ([interconnects.ai](https://www.interconnects.ai)) — Frontier model analysis, deep, practitioner-level analysis of the newest frontier models and research.
+- **AlphaSignal** ([alphasignal.ai](https://alphasignal.ai)) — Technical AI news, highly technical, signal-heavy newsletter focusing on the latest breakthroughs and code repositories.
 
 ## Research Labs to Follow
-- **OpenAI Research** — The industry leader in frontier models and safety-aligned AGI research. **Why it is valuable:** Setting the pace for state-of-the-art model capabilities and safety evaluations.
-- **Anthropic Research** — Pioneers of constitutional AI and mechanistic interpretability. **Why it is valuable:** Leading research into how models think and how to align them through structural constraints.
-- **Google DeepMind** — Historical powerhouse of fundamental AI breakthroughs and scientific applications. **Why it is valuable:** Continues to produce foundational research spanning from LLMs to AI for science.
-- **Meta FAIR** — Leading the charge in high-quality open-source models and fundamental research. **Why it is valuable:** Crucial source for open-weights models and research that democratizes AI access.
-- **Mistral** — Proving that small, efficient models can rival giants in performance. **Why it is valuable:** Essential for tracking the efficiency frontier and high-performance local inference.
-- **Allen AI (AI2)** — Non-profit research focusing on AI for the common good and open science. **Why it is valuable:** Important for open-dataset initiatives and research unbiased by commercial interests.
+- **OpenAI Research** — Setting the pace for state-of-the-art model capabilities and safety evaluations as the industry leader in frontier models.
+- **Anthropic Research** — Pioneers of constitutional AI and mechanistic interpretability, leading research into how models think and how to align them through structural constraints.
+- **Google DeepMind** — Historical powerhouse of fundamental AI breakthroughs and scientific applications, continuing to produce foundational research spanning from LLMs to AI for science.
+- **Meta FAIR** — Leading the charge in high-quality open-source models and fundamental research, a crucial source for open-weights models that democratize AI access.
+- **Mistral** — Proving that small, efficient models can rival giants in performance, essential for tracking the efficiency frontier and high-performance local inference.
+- **Allen AI (AI2)** — Non-profit research focusing on AI for the common good and open science, important for open-dataset initiatives and research unbiased by commercial interests.
 
 ## Aggregators & Communities
-- **Hacker News (AI filter)** — Real-time discussion and discovery of new AI tools by the engineering community. **Why it is valuable:** The best place to find early-stage tools and technical debates among practitioners.
-- **r/LocalLLaMA** — The primary hub for the open-weights and local inference community. **Why it is valuable:** Unrivaled for practical tips on running, quantizing, and fine-tuning models locally.
-- **r/MachineLearning** — Serious academic and professional discussion on ML research and engineering. **Why it is valuable:** High-density source for paper discussions and professional ML engineering advice.
-- **Papers With Code** — Essential for finding the implementation behind the latest research papers. **Why it is valuable:** Bridges the gap between academic theory and practical, runnable implementations.
-- **Hugging Face Daily Papers** — Curated daily feed of the most impactful research papers in the community. **Why it is valuable:** Excellent for staying on top of the sheer volume of new research appearing daily.
+- **Hacker News (AI filter)** — Real-time discussion and discovery of new AI tools by the engineering community, the best place to find early-stage tools and technical debates.
+- **r/LocalLLaMA** — The primary hub for the open-weights and local inference community, unrivaled for practical tips on running, quantizing, and fine-tuning models locally.
+- **r/MachineLearning** — Serious academic and professional discussion on ML research and engineering, a high-density source for paper discussions and professional ML engineering advice.
+- **Papers With Code** — Essential for finding the implementation behind the latest research papers, bridging the gap between academic theory and practical, runnable implementations.
+- **Hugging Face Daily Papers** — Curated daily feed of the most impactful research papers in the community, excellent for staying on top of the sheer volume of new research appearing daily.
 
 ## Podcasts
-- **Latent Space Podcast** — Deep technical conversations with the builders of the AI engineering era. **Why it is valuable:** The best source for understanding the actual engineering trade-offs made by leading practitioners.
-- **Gradient Dissent (W&B)** — Interviews with top ML practitioners about their real-world workflows and challenges. **Why it is valuable:** Provides deep insight into the production realities of training and deploying models.
-- **Practical AI** — Accessible discussions on making AI useful in real-world software development. **Why it is valuable:** Great for seeing how AI fits into broader software engineering and business contexts.
+- **Latent Space Podcast** — Deep technical conversations with the builders of the AI engineering era, the best source for understanding the actual engineering trade-offs made by leading practitioners.
+- **Gradient Dissent (W&B)** — Interviews with top ML practitioners about their real-world workflows and challenges, providing deep insight into the production realities of training and deploying models.
+- **Practical AI** — Accessible discussions on making AI useful in real-world software development, great for seeing how AI fits into broader software engineering and business contexts.
 
 ## Sources / References
 - [Simon Willison's Weblog](https://simonwillison.net/)
@@ -70,5 +70,5 @@ A curated list of high-signal sources for staying current on AI, LLMs, agents, a
 - [AlphaSignal](https://alphasignal.ai/)
 
 ## Contribution Metadata
-- Last reviewed: 2026-02-28
+- Last reviewed: 2026-03-01
 - Confidence: high


### PR DESCRIPTION
This PR adds a new knowledge base page titled "Essential AI Reading List" at `docs/knowledge_base/ai_reading_list.md`. 

The page serves as an opinionated guide to the best sources for staying current on AI, LLMs, and agentic workflows. It follows the repository's convention for high-signal resource lists by integrating the "Why it is valuable" explanation directly into concise, single-line bullet points.

Key additions:
- **Blogs & Personal Sites:** 11 sources including Simon Willison, Lilian Weng, Andrej Karpathy, and Jeremy Howard.
- **Newsletters:** 9 high-signal digests including Latent Space, Import AI, and AlphaSignal.
- **Research Labs:** Coverage of major labs (OpenAI, Anthropic, DeepMind, FAIR, Mistral, AI2).
- **Aggregators & Communities:** Essential hubs like r/LocalLLaMA and Papers With Code.
- **Podcasts:** Top industry podcasts like Gradient Dissent and Practical AI.

The page is fully integrated into the repository's navigation (`mkdocs.yml`) and directory index (`docs/knowledge_base/README.md`). It has been validated against the KnowledgeOps contract and verified for site generation integrity.

---
*PR created automatically by Jules for task [6880608319393273295](https://jules.google.com/task/6880608319393273295) started by @joanmarcriera*