### PR TITLE
Enhance documentation for 5 shallow service docs

### DIFF
--- a/docs/services/focalboard.md
+++ b/docs/services/focalboard.md
@@ -5,8 +5,43 @@ Focalboard is an open-source, multilingual, self-hosted project management tool.
 ## Description
 It is an alternative to Trello, Notion, and Asana, providing a Kanban-style board for task management.
 
+## Getting started
+
+### Docker
+To run Focalboard locally using the official Docker image:
+
+```bash
+docker run -it -p 80:8000 mattermost/focalboard
+```
+
+Access the interface at `http://localhost`.
+
+## CLI examples
+Focalboard is primarily a web-based application. Development and build tasks are managed via `make`:
+
+```bash
+# Build the server
+make
+
+# Run the server binary
+./bin/focalboard-server
+
+# Build the web app
+make webapp
+```
+
+## API examples
+The Boards API can be accessed via `curl`. Use your session token for authentication:
+
+```bash
+# Get all boards
+curl -H "Authorization: Bearer <your_session_token>" \
+     "http://localhost:8000/api/v1/boards"
+```
+
 ## Links
 - [Official Website](https://www.focalboard.com/)
+- [GitHub Repository](https://github.com/mattermost/focalboard)
 
 ## Alternatives
 - [Kanboard](https://kanboard.org/)
@@ -15,11 +50,10 @@ It is an alternative to Trello, Notion, and Asana, providing a Kanban-style boar
 ## Backlog
 - Sync with Nextcloud Tasks.
 
+## Sources / References
+- [GitHub README](https://github.com/mattermost/focalboard#readme)
+- [Developer Guide](https://developers.mattermost.com/contribute/focalboard/)
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-01
-
-## Sources / References
-- https://www.focalboard.com/
-- https://kanboard.org/
+- Last reviewed: 2026-03-02

--- a/docs/services/grocy.md
+++ b/docs/services/grocy.md
@@ -5,8 +5,40 @@ Grocy is a self-hosted groceries & household management solution for your home.
 ## Description
 It tracks your stock, shopping list, recipes, and more.
 
+## Getting started
+
+### Docker
+The recommended way to install Grocy is via the LinuxServer.io Docker image:
+
+```bash
+docker run -d \
+  --name=grocy \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  -e TZ=Etc/UTC \
+  -p 9283:80 \
+  -v /path/to/config:/config \
+  --restart unless-stopped \
+  lscr.io/linuxserver/grocy:latest
+```
+
+Access the web interface at `http://localhost:9283`.
+
+## CLI examples
+Grocy does not have an official CLI. Management is performed through the web interface or the REST API.
+
+## API examples
+Grocy provides a RESTful API. Authenticate using an API key (generated in the web UI under "Manage API keys"):
+
+```bash
+# Get current stock
+curl -X GET "http://localhost:9283/api/stock" \
+     -H "GROCY-API-KEY: <your_api_key>"
+```
+
 ## Links
 - [Official Website](https://grocy.info/)
+- [Demo](https://en.demo.grocy.info/)
 
 ## Alternatives
 - [Homebox](homebox.md)
@@ -17,10 +49,10 @@ It tracks your stock, shopping list, recipes, and more.
 
 ## Sources / References
 
-- [Reference](https://grocy.info/)
-- [Reference](https://github.com/TomW1605/kitchenowl)
+- [Official Website](https://grocy.info/)
+- [LinuxServer.io Grocy Documentation](https://docs.linuxserver.io/images/docker-grocy/)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-03-02
+- Confidence: high

--- a/docs/services/radicale.md
+++ b/docs/services/radicale.md
@@ -5,8 +5,47 @@ Radicale is a small but powerful CalDAV and CardDAV server.
 ## Description
 It is lightweight and easy to set up, providing a way to host your own calendars and contacts.
 
+## Getting started
+
+### Installation
+Install Radicale using `pip`:
+
+```bash
+python3 -m pip install --upgrade radicale
+```
+
+### Running Radicale
+To start the server with default settings (binds to `localhost:5232`):
+
+```bash
+python3 -m radicale
+```
+
+## CLI examples
+The `radicale` module supports several command-line flags:
+
+```bash
+# Print version
+python3 -m radicale --version
+
+# Run verification of local collections storage
+python3 -m radicale --verify-storage
+
+# Start with debug logging enabled
+python3 -m radicale --debug
+```
+
+## API examples
+As a CalDAV/CardDAV server, Radicale is accessed via standard DAV methods. You can use `curl` to create a collection:
+
+```bash
+# Create a new calendar collection
+curl -u username:password -X MKCOL "http://localhost:5232/username/calendar/"
+```
+
 ## Links
 - [Official Website](https://radicale.org/)
+- [GitHub Repository](https://github.com/Kozea/Radicale)
 
 ## Alternatives
 - [Nextcloud (Contacts/Calendar)](nextcloud.md)
@@ -17,10 +56,10 @@ It is lightweight and easy to set up, providing a way to host your own calendars
 
 ## Sources / References
 
-- [Reference](https://radicale.org/)
-- [Reference](https://sabre.io/baikal/)
+- [Radicale Documentation](https://radicale.org/v3.html)
+- [Installation Guide](https://radicale.org/v3.html#installation)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-03-02
+- Confidence: high

--- a/docs/services/syncthing.md
+++ b/docs/services/syncthing.md
@@ -5,8 +5,46 @@ Syncthing is a continuous file synchronization program.
 ## Description
 It synchronizes files between two or more computers in real time, safely and securely.
 
+## Getting started
+
+### Installation
+Download the latest binary for your operating system from the [official downloads page](https://syncthing.net/downloads/).
+
+### Running Syncthing
+Simply run the `syncthing` binary to start the service and open the web GUI:
+
+```bash
+./syncthing
+```
+
+The admin GUI will be available at `http://localhost:8384/`.
+
+## CLI examples
+The `syncthing` binary supports several command-line arguments:
+
+```bash
+# Show version information
+syncthing --version
+
+# Generate a new configuration and keys in the specified directory
+syncthing --generate="/path/to/config"
+
+# Set the GUI listen address
+syncthing --gui-address="0.0.0.0:8384"
+```
+
+## API examples
+Syncthing provides a REST API. Authenticate using the `X-API-Key` header:
+
+```bash
+# Get system version
+curl -X GET -H "X-API-Key: <your_api_key>" \
+     "http://localhost:8384/rest/system/version"
+```
+
 ## Links
 - [Official Website](https://syncthing.net/)
+- [Documentation](https://docs.syncthing.net/)
 
 ## Alternatives
 - [Resilio Sync](https://www.resilio.com/) (Non-OSS)
@@ -17,10 +55,10 @@ It synchronizes files between two or more computers in real time, safely and sec
 
 ## Sources / References
 
-- [Reference](https://syncthing.net/)
-- [Reference](https://www.resilio.com/)
+- [Getting Started Guide](https://docs.syncthing.net/intro/getting-started.html)
+- [REST API Documentation](https://docs.syncthing.net/dev/rest.html)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-03-02
+- Confidence: high

--- a/docs/services/vikunja.md
+++ b/docs/services/vikunja.md
@@ -5,8 +5,44 @@ Vikunja is an open-source, self-hosted To-do list application.
 ## Description
 It allows you to organize all your tasks on all platforms. It features boards, lists, and a powerful filter system.
 
+## Getting started
+
+### Docker
+To get Vikunja up and running quickly with Docker:
+
+```bash
+docker run -p 3456:3456 -v $PWD/files:/app/vikunja/files -v $PWD/db:/db vikunja/vikunja
+```
+
+Navigate to `http://localhost:3456` to access the web interface.
+
+## CLI examples
+
+When running in Docker, execute commands using `docker exec`:
+
+```bash
+# List all users
+docker exec <container_name> /app/vikunja/vikunja user list
+
+# Create a full dump of the database and files
+docker exec <container_name> /app/vikunja/vikunja dump
+
+# Show Vikunja version
+docker exec <container_name> /app/vikunja/vikunja version
+```
+
+## API examples
+
+Authenticate using an API token in the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer <your_api_token>" \
+     "https://try.vikunja.io/api/v1/tasks"
+```
+
 ## Links
 - [Official Website](https://vikunja.io/)
+- [Documentation](https://vikunja.io/docs/)
 
 ## Alternatives
 - [Focalboard](focalboard.md)
@@ -17,9 +53,10 @@ It allows you to organize all your tasks on all platforms. It features boards, l
 
 ## Sources / References
 
-- [Reference](https://vikunja.io/)
+- [Official Documentation](https://vikunja.io/docs/)
+- [CLI Reference](https://vikunja.io/docs/cli/)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-03-02
+- Confidence: high


### PR DESCRIPTION
This PR enhances the documentation for five shallow service docs as identified from `data/growth-metrics.json`. For each service, I researched official documentation and added:

1.  **Getting started:** Installation instructions (Docker/pip/binary) and first-run steps.
2.  **CLI examples:** Three common commands or flags (where applicable).
3.  **API examples:** Minimal `curl` snippets showing how to interact with the service's REST or DAV API.

Services updated:
- Vikunja
- Focalboard
- Grocy
- Syncthing
- Radicale

Verified that all documentation follows the KnowledgeOps standards and passes the repository's validation scripts.

---
*PR created automatically by Jules for task [3110483089855235704](https://jules.google.com/task/3110483089855235704) started by @joanmarcriera*