### PR TITLE
docs: daily knowledge expansion 2026-03-03

### DIFF
--- a/docs/knowledge_base/patterns/rag.md
+++ b/docs/knowledge_base/patterns/rag.md
@@ -199,7 +199,7 @@ The following examples demonstrate a minimal local RAG setup using **Ollama** fo
 
 *   **RAG Platforms:** [Dify](../../tools/ai_knowledge/dify.md), [Flowise](../../tools/ai_knowledge/flowise.md), [RAGFlow](../../tools/process_understanding/ragflow.md)
 *   **Orchestration:** [LlamaIndex](../../tools/ai_knowledge/llamaindex.md), [LangChain](../../tools/ai_knowledge/langchain.md), [Haystack](../../tools/frameworks/haystack.md)
-*   **Infrastructure:** [Vector Databases](../../tools/infrastructure/index.md#sub-categories), [Embedding Models](../../tools/infrastructure/index.md#sub-categories)
+*   **Infrastructure:** [Vector Databases](../../tools/infrastructure/index.md), [Embedding Models](../../tools/infrastructure/index.md)
 *   **Data Extraction:** [Crawl4AI](../../tools/process_understanding/crawl4ai.md), [Firecrawl](../../tools/process_understanding/firecrawl.md), [OCRmyPDF](../../tools/process_understanding/ocrmypdf.md)
 *   **Local Solutions:** [Paperless-AI](../../services/paperless-ai.md), [PageIndex](../../tools/process_understanding/pageindex.md)
 *   **Evaluation:** RAGAS, DeepEval, TruLens

--- a/docs/playbooks/email-to-calendar.md
+++ b/docs/playbooks/email-to-calendar.md
@@ -9,6 +9,21 @@ Automatically extract dates and events from incoming emails and sync them to the
 - [LLM (Ollama or OpenAI)](../services/ollama.md)
 - [Google Calendar](../tools/calendar_tasks/google_calendar.md)
 
+## Workflow Architecture
+```mermaid
+flowchart TD
+    A[New Email in IMAP folder] --> B[n8n Workflow Trigger]
+    B --> C[Convert Email to PDF]
+    C --> D[Upload to Paperless-ngx]
+    D --> E[Extract Text via OCR]
+    E --> F[Call LLM for Date Extraction]
+    F --> G{Event Found?}
+    G -- Yes --> H[Create Google Calendar Event]
+    G -- No --> I[Tag as Failed / Notify]
+    H --> J[Update Paperless Tag: synced]
+    I --> K[Update Paperless Tag: failed]
+```
+
 ## Step-by-Step Flow
 1.  **Ingestion**: n8n workflow triggers via IMAP on a new email in the `Automate/Intake` folder.
 2.  **Storage**: n8n uploads the email body (as PDF) or any existing PDF attachments to Paperless-ngx with the tag `needs-processing`.

--- a/docs/services/metube.md
+++ b/docs/services/metube.md
@@ -5,6 +5,48 @@ MeTube is a web GUI for youtube-dl / yt-dlp.
 ## Description
 It provides a simple and easy-to-use interface for downloading videos from YouTube and other sites. It supports various formats and allows you to manage your downloads through the browser.
 
+## When to use it
+- When you want a user-friendly web interface for `yt-dlp`.
+- For managing video downloads on a remote or headless server.
+- When you need to quickly download videos from various platforms without using the terminal.
+
+## When not to use it
+- If you prefer the flexibility and advanced options of the `yt-dlp` command-line interface.
+- For large-scale media archiving and organization (consider [Tube Archivist](tubearchivist.md) for this).
+
+## Getting started
+
+### Docker
+MeTube is most easily deployed via Docker. Run the following command to start the container:
+
+```bash
+docker run -d \
+  --name metube \
+  -p 8081:8081 \
+  -v /path/to/downloads:/downloads \
+  alexta69/metube
+```
+
+The web interface will be available at `http://localhost:8081`.
+
+## CLI examples
+MeTube is primarily a web-based application and does not feature a dedicated CLI. Downloads are managed via the web UI or the REST API.
+
+## API examples
+You can programmatically add downloads to MeTube using its API.
+
+### Add a download via curl
+```bash
+curl -X POST http://localhost:8081/add \
+     -H "Content-Type: application/json" \
+     -d '{"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "quality": "best"}'
+```
+
+### Get current queue
+```bash
+curl http://localhost:8081/queue
+```
+
 ## Links
 - [GitHub Repository](https://github.com/alexta69/metube)
 

--- a/docs/services/nextcloud.md
+++ b/docs/services/nextcloud.md
@@ -5,6 +5,60 @@ Nextcloud is the most deployed self-hosted content collaboration platform.
 ## Description
 It provides a safe home for all your data - files, contacts, calendars, and more.
 
+## When to use it
+- When you need a comprehensive, self-hosted suite for file storage, collaboration, and productivity.
+- For users who want to maintain full control over their data while having access to features similar to Google Workspace or Microsoft 365.
+- When you want a extensible platform with a wide range of apps (Talk, Calendar, Contacts, Office).
+
+## When not to use it
+- If you only need simple file synchronization without the extra features (consider [Syncthing](syncthing.md)).
+- If you have very limited server resources, as Nextcloud can be resource-intensive.
+
+## Getting started
+
+### Docker
+The fastest way to get Nextcloud running is using the official Docker image:
+
+```bash
+docker run -d \
+  --name nextcloud \
+  -p 8080:80 \
+  -v nextcloud:/var/www/html \
+  nextcloud
+```
+
+Access Nextcloud at `http://localhost:8080`.
+
+## CLI examples
+Nextcloud includes the `occ` (Nextcloud Command-line Control) tool for server management.
+
+```bash
+# List all available occ commands
+docker exec --user www-data nextcloud php occ list
+
+# Reset the admin password
+docker exec --user www-data nextcloud php occ user:resetpassword admin
+
+# Put the server into maintenance mode
+docker exec --user www-data nextcloud php occ maintenance:mode --on
+```
+
+## API examples
+Nextcloud supports the OCS (Open Collaboration Services) API for remote management.
+
+### Get user information
+```bash
+curl -u admin:password \
+     -H "OCS-APIRequest: true" \
+     -X GET "http://localhost:8080/ocs/v1.php/cloud/users/admin"
+```
+
+### List files via WebDAV
+```bash
+curl -u admin:password \
+     -X PROPFIND "http://localhost:8080/remote.php/dav/files/admin/"
+```
+
 ## Links
 - [Official Website](https://nextcloud.com/)
 

--- a/docs/tools/ai_knowledge/dify.md
+++ b/docs/tools/ai_knowledge/dify.md
@@ -34,6 +34,8 @@ AI & Knowledge — serves as a visual platform for building and deploying LLM ap
 
 ## Related tools / concepts
 - [Flowise](flowise.md)
+- [LangChain](langchain.md)
+- [LlamaIndex](llamaindex.md)
 - [LangFlow](https://github.com/langflow-ai/langflow)
 
 ## Getting started

--- a/docs/tools/ai_knowledge/flowise.md
+++ b/docs/tools/ai_knowledge/flowise.md
@@ -34,6 +34,7 @@ AI & Knowledge — provides a no-code visual builder for LLM pipelines that can 
 
 ## Related tools / concepts
 - [Dify](dify.md)
+- [LangChain](langchain.md)
 - [LangFlow](https://github.com/langflow-ai/langflow)
 
 ## Getting started

--- a/docs/tools/development_ops/openhands.md
+++ b/docs/tools/development_ops/openhands.md
@@ -43,7 +43,7 @@ Client-server architecture. Usually runs in a Docker container to provide a sand
 ## Related tools / concepts
 - [Aider](aider.md)
 - [Custom Agents](custom_agents.md)
-- [OpenAI](../ai_knowledge/openai.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
 
 ## Sources / References
 


### PR DESCRIPTION
This PR completes the daily knowledge expansion tasks for 2026-03-03.

Key changes:
1. **Shallow Docs Expansion**: `docs/services/metube.md` and `docs/services/nextcloud.md` now include comprehensive "Getting started" (Docker), "CLI examples", and "API examples" sections, along with "When to use/not to use" guidance.
2. **Architecture Visualization**: Added a Mermaid flowchart to `docs/playbooks/email-to-calendar.md` to visualize the automated event extraction workflow.
3. **Cross-link Integrity**: Fixed broken or missing relative links in the "Related tools / concepts" sections of `dify.md`, `flowise.md`, and `openhands.md`, and corrected infrastructure links in `rag.md`.
4. **Usability Improvements**: Removed generic placeholders from Nextcloud CLI examples by establishing a consistent container name in the setup instructions.

Verification:
- Validated `mkdocs.yml` syntax.
- Ran `scripts/validate_new_sources.py` (passed).
- Manually inspected all modified files for formatting and link correctness.

---
*PR created automatically by Jules for task [12804916575348096683](https://jules.google.com/task/12804916575348096683) started by @joanmarcriera*