### PR TITLE
Document and link to system prompts

### DIFF
--- a/docs/knowledge_base/README.md
+++ b/docs/knowledge_base/README.md
@@ -7,6 +7,7 @@ This section contains deep dives into the technologies, protocols, and conceptua
     [**AI Tooling Landscape — 2026 Overview**](ai_tooling_landscape.md) — A high-level map of the entire AI tooling ecosystem as documented in this repository. Use this as your primary entry point to understand how everything connects.
 
 - [**Model Classes**](model_classes.md) - Understanding the different types of LLMs (MoE, Reasoning, Multimodal, etc.).
+- [**System Prompts**](system_prompts.md) - Foundational instructions for frontier models and "high engineering" persona design.
 - [**Model Comparison and Evaluation**](model_comparison_and_evaluation.md) - Guide to LLM leaderboards, benchmarks, and metrics.
 - [**Agent Protocols**](agent_protocols.md) - Deep dive into MCP (Model Context Protocol) and ACP (Agent Control Protocol).
 - [**API Pricing & Free Tier Matrix**](api_pricing_free_tiers.md) - Canonical tracker for provider pricing links and current free-tier availability.

--- a/docs/knowledge_base/ai_signal_sources.md
+++ b/docs/knowledge_base/ai_signal_sources.md
@@ -28,6 +28,12 @@ This page tracks high-signal sources worth monitoring for model updates, tooling
 | Nathan Lambert (Interconnects) | Clear frontier-model research commentary from a practitioner lens | https://www.interconnects.ai/ |
 | Latent Space | Engineering-focused interviews and implementation patterns | https://www.latent.space/ |
 | Daniel Saewitz | High-signal analysis of commercial OSS and AI strategy | https://saewitz.com/ |
+
+## Prompt Engineering & System Prompts
+
+| Source | Focus | URL |
+| :--- | :--- | :--- |
+| System Prompts Leaks | Extracted system prompts from frontier models (Claude, GPT, Gemini) | https://github.com/asgeirtj/system_prompts_leaks/ |
 | Dmitri Sotnikov (Yogthos) | Deep dives into managing AI complexity and Clojure patterns | https://yogthos.net/ |
 | Tyler Rockwood | Applied LLM security analysis with practical trust-boundary experiments | https://rockwotj.com/blog/ |
 
@@ -64,9 +70,10 @@ This page tracks high-signal sources worth monitoring for model updates, tooling
 - [Daniel Saewitz's Blog](https://saewitz.com/)
 - [Dmitri Sotnikov's Blog (yogthos.net)](https://yogthos.net/)
 - [Tyler Rockwood's Blog](https://rockwotj.com/blog/)
+- [System Prompts Leaks GitHub](https://github.com/asgeirtj/system_prompts_leaks/tree/main)
 - [The AI Agent Tools Landscape: 120+ Tools Mapped [2026]](https://stackone.com/blog/ai-agent-tools-landscape-2026/)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-27
+- Last reviewed: 2026-03-09
 - Confidence: medium

--- a/docs/knowledge_base/system_prompts.md
+++ b/docs/knowledge_base/system_prompts.md
@@ -1,0 +1,36 @@
+# System Prompts
+
+## What are System Prompts
+System prompts (also known as system messages or developer messages) are the foundational instructions provided to a Large Language Model (LLM) before a conversation begins. They define the model's persona, its capabilities, its behavioral constraints, and the tone it should adopt.
+
+In frontier models (high engineering), these prompts are often complex, multi-layered instructions that guide the model through sophisticated reasoning paths, tool-calling protocols, and safety alignments.
+
+## Why They Matter
+- **Persona & Tone**: They establish how the model interacts (e.g., helpful assistant, technical expert, concise reporter).
+- **Capability Disclosure**: They inform the model about the tools it has access to (e.g., Python execution, web search, specific APIs).
+- **Constraint Enforcement**: They set hard boundaries on what the model can and cannot do (e.g., no medical advice, no sensitive data handling).
+- **Instruction Following**: A well-engineered system prompt improves the reliability and quality of the model's output.
+
+## High Engineering Examples
+Studying the system prompts of frontier models like Claude, GPT-4, and Gemini provides deep insight into how these models are aligned and how they handle complex tasks.
+
+### System Prompt Collections
+A curated collection of extracted system prompts from popular chatbots and frontier models.
+- [System Prompts Leaks (asgeirtj/system_prompts_leaks)](https://github.com/asgeirtj/system_prompts_leaks/tree/main)
+
+### Claude System Prompt
+Anthropic's system prompt for Claude is a prime example of "high engineering" prompt design, featuring detailed instructions for tool use and response formatting.
+- [Claude System Prompt](https://asgeirtj.github.io/system_prompts_leaks/Anthropic/claude.html)
+
+## Related tools / concepts
+- [Agent Protocols](agent_protocols.md)
+- [Model Classes](model_classes.md)
+- [Claude Code Router](../tools/development_ops/claude-code-router.md)
+
+## Sources / References
+- [System Prompts Leaks GitHub](https://github.com/asgeirtj/system_prompts_leaks/tree/main)
+- [Claude System Prompt Leak](https://asgeirtj.github.io/system_prompts_leaks/Anthropic/claude.html)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-09
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -298,6 +298,7 @@ nav:
     - Landscape Overview: knowledge_base/landscape-overview.md
     - Agent Protocols: knowledge_base/agent_protocols.md
     - Model Comparison and Evaluation: knowledge_base/model_comparison_and_evaluation.md
+    - System Prompts: knowledge_base/system_prompts.md
     - AI Signal Sources: knowledge_base/ai_signal_sources.md
     - Essential AI Reading List: knowledge_base/ai_reading_list.md
     - Model Classes: knowledge_base/model_classes.md


### PR DESCRIPTION
This PR adds documentation for system prompts as requested. It includes:
- A new knowledge base page (`docs/knowledge_base/system_prompts.md`) explaining the role and importance of system prompts in "high engineering" (frontier models).
- Direct links to the `asgeirtj/system_prompts_leaks` repository and the Claude system prompt page.
- Integration into the site navigation and Knowledge Base overview.
- An update to the AI Signal Sources page to include prompt engineering as a tracked category.

Fixes #145

---
*PR created automatically by Jules for task [3690580210838839308](https://jules.google.com/task/3690580210838839308) started by @joanmarcriera*