### PR TITLE
automation: route issues to Jules/OpenRouter and expand n8n ops

### DIFF
--- a/.github/workflows/auto-fix-issues.yml
+++ b/.github/workflows/auto-fix-issues.yml
@@ -46,6 +46,8 @@ jobs:
           git checkout -b auto-fix-issue-$ISSUE_NUMBER
 
       - name: Run Auto-fix Python Script
+        id: autofix
+        continue-on-error: true
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +57,7 @@ jobs:
           python scripts/auto_fix.py $ISSUE_NUMBER
           
       - name: Create PR with fixes
-        if: success()
+        if: steps.autofix.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
@@ -72,5 +74,17 @@ jobs:
             --base main \
             --head auto-fix-issue-$ISSUE_NUMBER \
             || echo "No changes found or PR already exists."
+
+      - name: Fallback to Jules when OpenRouter lane fails
+        if: steps.autofix.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label jules || true
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
+            "OpenRouter auto-fix could not complete this issue in CI. Falling back to Jules (`jules`) for handling."
 
       # Auto-merge removed — all PRs require human review

--- a/.github/workflows/issue-automation-router.yml
+++ b/.github/workflows/issue-automation-router.yml
@@ -1,0 +1,81 @@
+name: Issue Automation Router
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: issue-router-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && github.event.issue.pull_request == null)
+    steps:
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ensure_label() {
+            local name="$1"
+            local color="$2"
+            local description="$3"
+            if ! gh api "repos/$REPO/labels/$name" >/dev/null 2>&1; then
+              gh label create "$name" \
+                --repo "$REPO" \
+                --color "$color" \
+                --description "$description"
+            fi
+          }
+
+          ensure_label "jules" "1f6feb" "Issues queued for Jules automation"
+          ensure_label "autofix" "8b5cf6" "Issues queued for OpenRouter auto-fix"
+
+      - name: Route issue to automation lane
+        if: github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title,body,labels,author)
+          TITLE=$(echo "$ISSUE_JSON" | jq -r '.title // ""' | tr '[:upper:]' '[:lower:]')
+          BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""' | tr '[:upper:]' '[:lower:]')
+          HAS_JULES=$(echo "$ISSUE_JSON" | jq '[.labels[].name | ascii_downcase] | index("jules") != null')
+          HAS_AUTOFIX=$(echo "$ISSUE_JSON" | jq '[.labels[].name | ascii_downcase] | index("autofix") != null')
+
+          # Do not mutate automation-generated control issues.
+          if [[ "$TITLE" == process\ jules\ backlog\ -* ]] || [[ "$TITLE" == daily\ knowledge\ expansion\ -* ]] || [[ "$TITLE" == daily\ maintenance\ run\ -* ]] || [[ "$TITLE" == \[w* ]]; then
+            echo "Control issue detected; no routing changes."
+            exit 0
+          fi
+
+          # Skip if already routed.
+          if [[ "$HAS_JULES" == "true" ]] || [[ "$HAS_AUTOFIX" == "true" ]]; then
+            echo "Issue already has an automation label."
+            exit 0
+          fi
+
+          # Route to OpenRouter auto-fix when explicitly requested.
+          if [[ "$TITLE $BODY" == *"[openrouter]"* ]] || [[ "$TITLE $BODY" == *"#openrouter"* ]] || [[ "$TITLE $BODY" == *"autofix"* ]] || [[ "$TITLE $BODY" == *"auto-fix"* ]]; then
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "autofix"
+            gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
+              "Automation routing: this issue was queued to the OpenRouter auto-fix lane (`autofix`). If no fix PR is produced, it will fall back to `jules`."
+            exit 0
+          fi
+
+          # Default route: Jules lane.
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "jules"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
+            "Automation routing: this issue was queued to Jules (`jules`) for implementation."

--- a/.github/workflows/process-jules-backlog.yml
+++ b/.github/workflows/process-jules-backlog.yml
@@ -3,6 +3,8 @@ name: Process Jules Backlog
 on:
   schedule:
     - cron: '30 0 * * *'  # Runs daily at 00:30 UTC
+  issues:
+    types: [opened, reopened, labeled]
   workflow_dispatch: # allow manual trigger
 
 concurrency:
@@ -11,6 +13,15 @@ concurrency:
 
 jobs:
   open-backlog-issue:
+    if: >-
+      github.event_name != 'issues' ||
+      (
+        github.event_name == 'issues' && (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          (github.event.action == 'labeled' && github.event.label.name == 'jules')
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/docs/services/n8n.md
+++ b/docs/services/n8n.md
@@ -1,37 +1,38 @@
 # n8n
 
 ## What it is
-n8n is an extendable, source-available workflow automation tool that allows you to connect various services and automate tasks using a visual node-based editor.
+n8n is an extendable, source-available workflow automation platform with a visual node editor, API integrations, and first-class support for AI-powered workflow steps.
 
 ## What problem it solves
-It eliminates the need for manual repetition of tasks between different software platforms. Unlike cloud-only alternatives, it can be self-hosted, keeping your automation logic and data private. It also provides advanced AI nodes for building complex AI-driven workflows.
+It replaces repetitive manual operations across tools and teams. Unlike cloud-only automation products, it can be self-hosted, so workflow logic, execution history, and sensitive data stay in your environment.
 
 ## Where it fits in the stack
-**Automation & Orchestration**. It acts as the "glue" between your various services, databases, and AI models.
+**Automation & Orchestration**. It is the control plane for cross-tool business processes.
 
 ## Typical use cases
-- **Autonomous Document Processing**: Automatically extracting data from emails/documents and saving it to a database using LLMs.
-- **AI Agents**: Creating complex multi-step agents that can search the web, interact with APIs, and perform logic.
-- **Data Synchronization**: Keeping data in sync between CRM, project management tools, and local databases.
+- **Autonomous document/email operations**: classify incoming content, extract fields, route to owners.
+- **Cross-system process automation**: connect email, CRM/ERP, ticketing, chat, storage, and databases.
+- **AI-assisted operations**: triage, summarize, draft responses, and escalate only low-confidence cases.
 
 ## Strengths
-- **Visual Interface**: Easy to build and debug complex logic.
-- **Self-Hostable**: Full control over your data and workflows.
-- **Extensible**: Supports custom JavaScript nodes and community-contributed nodes.
-- **Native AI Integration**: First-class support for LangChain-based AI nodes.
+- **Visual + programmable**: easy to build visually, still supports advanced expressions/logic.
+- **Self-hostable**: private automation with infrastructure you control.
+- **Broad integrations**: large ecosystem of built-in and community nodes.
+- **Good ops model**: retries, execution logs, error workflows, queue mode.
 
 ## Limitations
-- **Learning Curve**: Advanced workflows require understanding of data structures and expressions.
-- **Resource Usage**: Can be memory-intensive when running many complex concurrent workflows.
+- **Learning curve**: robust flows require strong data modeling and error handling.
+- **Scale design required**: business-critical usage needs queue mode, persistent DB, and observability.
+- **Credential discipline**: secrets management and environment separation must be done explicitly.
 
 ## When to use it
-- When you need to automate complex business or home-office processes.
-- If you require privacy for your automation logic.
-- For building AI-powered workflows that integrate with multiple tools.
+- You want long-running, auditable business automations.
+- You need privacy and self-hosting.
+- You want AI-assisted processes with clear human-approval boundaries.
 
 ## When not to use it
-- For extremely simple, one-off automations where a basic script suffices.
-- If you prefer a completely managed, hands-off cloud service (though n8n Cloud exists).
+- For one-off scripts or tiny automations with no lifecycle.
+- When you do not want to own operations/security for automation infrastructure.
 
 ## Licensing and cost
 - **Source Available**: Yes (Fair-code license)
@@ -40,37 +41,196 @@ It eliminates the need for manual repetition of tasks between different software
 
 ## Getting started
 
-### Installation (Docker Compose)
+### Installation (Docker Compose, production-oriented baseline)
 ```yaml
 services:
+  postgres:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=n8n
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=n8n
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
+
   n8n:
     image: docker.n8n.io/n8nio/n8n:latest
     container_name: n8n
+    depends_on:
+      - postgres
     ports:
       - 5678:5678
     volumes:
       - ./n8n_data:/home/node/.n8n
+      - ./n8n_files:/files
     environment:
-      - N8N_HOST=localhost
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_PORT=5432
+      - DB_POSTGRESDB_DATABASE=n8n
+      - DB_POSTGRESDB_USER=n8n
+      - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD}
+      - N8N_HOST=n8n.local
       - N8N_PORT=5678
-      - N8N_PROTOCOL=http
+      - N8N_PROTOCOL=https
+      - N8N_ENCRYPTION_KEY=${N8N_ENCRYPTION_KEY}
       - NODE_ENV=production
     restart: unless-stopped
 ```
+
+## Project definitions: JSON workflows and YAML infrastructure
+
+If you want to version-control an n8n project:
+
+- **Workflow definitions**: native n8n format is **JSON**.
+- **Infrastructure/deployment**: usually **YAML** (`docker-compose.yml`, CI workflows, Kubernetes manifests).
+- **Repository manifest (optional)**: your own YAML index for team governance can map business processes to workflow JSON files.
+
+Example repository layout:
+
+```text
+automation-n8n/
+  docker-compose.yml
+  .env.example
+  n8n/
+    workflows/
+      010-email-intake.json
+      020-quote-draft.json
+      030-shipment-updates.json
+    workflow-manifest.yaml
+  docs/
+    runbook.md
+```
+
+Example `workflow-manifest.yaml` (repo convention, not native n8n format):
+
+```yaml
+project: wine-import-export-ops
+owner: operations
+workflows:
+  - name: email-intake-and-triage
+    file: n8n/workflows/010-email-intake.json
+    criticality: high
+  - name: quote-draft-and-follow-up
+    file: n8n/workflows/020-quote-draft.json
+    criticality: high
+```
+
+## CLI examples
+
+```bash
+# Export all workflows as separate JSON files
+docker compose exec n8n n8n export:workflow --all --separate --output=/files/workflows
+
+# Import all workflows from a folder
+docker compose exec n8n n8n import:workflow --separate --input=/files/workflows
+
+# Export credentials for backup/migration (handle securely)
+docker compose exec n8n n8n export:credentials --all --output=/files/credentials.json
+```
+
+## How to use AI to run n8n operations (not only AI nodes inside workflows)
+
+Use AI in three roles around n8n:
+
+1. **Designer role**: convert SOPs into workflow specs, node maps, and test cases.
+2. **Operator role**: review failed executions, classify root cause, propose retries/fixes.
+3. **Optimizer role**: identify manual bottlenecks and propose new automations weekly.
+
+Guardrails:
+
+- AI can propose/create/update workflows and documentation.
+- AI cannot approve legal commitments, banking actions, or final contractual terms.
+- High-risk actions require human approval nodes and explicit audit logs.
+
+## Example: Wine import/export email automation program
+
+Goal: n8n handles most email operations end-to-end while humans keep control of legal and banking decisions.
+
+Core workflows:
+
+1. **Inbound email triage**
+- Trigger: IMAP/Gmail new email.
+- Steps: classify (`supplier`, `customer`, `logistics`, `compliance`, `finance`), extract entities (product, quantity, Incoterm, destination, ETA).
+- Output: route to CRM/ERP/ticket queue and attach suggested response draft.
+
+2. **Quote request automation**
+- Trigger: inbound RFQ emails.
+- Steps: fetch current catalog/pricing rules, draft quote reply, create follow-up tasks, schedule reminder if no response.
+- Output: ready-to-send draft + SLA timer.
+
+3. **Shipment status and exception handling**
+- Trigger: forwarder/carrier updates by email/API.
+- Steps: parse status, update shipment record, notify customer on milestones, escalate delays/anomalies.
+- Output: near-real-time customer comms without manual copy/paste.
+
+4. **Collections and accounts comms (non-payment execution)**
+- Trigger: invoice due/overdue event.
+- Steps: send reminders, track response sentiment, escalate disputed cases.
+- Output: n8n drives communication cadence; finance team approves/executes payment actions externally.
+
+5. **Compliance document orchestration**
+- Trigger: missing/updated document request.
+- Steps: request docs, validate required fields, route to legal/compliance for approval.
+- Output: complete compliance packet ready for human sign-off.
+
+### Human-only boundaries (explicit)
+
+- Bank transfers, payment approval, and settlement.
+- Legal review/approval of contracts and regulatory commitments.
+- Any action above predefined risk threshold.
+
+### Minimal AI prompt contract for email triage
+
+```text
+Classify this email into one of:
+supplier, customer, logistics, compliance, finance, spam.
+
+Return strict JSON:
+{
+  "category": "...",
+  "urgency": "low|medium|high",
+  "entities": {
+    "counterparty": "",
+    "product": "",
+    "quantity": "",
+    "destination": "",
+    "incoterm": ""
+  },
+  "needs_human_approval": true|false,
+  "reason": ""
+}
+```
+
+## How to keep this n8n capability expanding over time (Jules loop)
+
+Use a recurring Jules task focused on n8n value growth:
+
+1. Pull top failed/slow executions from last 24h.
+2. Propose one additive workflow improvement.
+3. Add one new test case for that workflow.
+4. Open a PR with workflow JSON + docs update + rollback note.
+
+This keeps n8n improving as an operating system for your business processes, not just as isolated automations.
 
 ## Related tools / concepts
 - [Ollama](ollama.md) (Use as AI backend)
 - [Zapier](../tools/automation_orchestration/zapier.md) (Alternative)
 - [Make](../tools/automation_orchestration/make.md) (Alternative)
+- [OpenRouter](../tools/ai_knowledge/openrouter.md) (Multi-provider LLM routing for prompts/models)
+- [Home Assistant](home-assistant.md) (Example of broader automation ecosystem integration)
 
 ## Backlog
-- Create a reusable sub-workflow for AI document processing.
-- Implement error handling with automated retry logic.
+- Add reusable sub-workflows: `email-triage`, `risk-gating`, `human-approval`.
+- Add golden test fixtures for 20 real-world wine trade email scenarios.
+- Add SLO dashboard: execution latency, failure rate, manual handoff rate.
+- Add weekly Jules report: top 3 automation gaps and proposed PRs.
 
 ## Sources / References
 - [Official Website](https://n8n.io/)
 - [Documentation](https://docs.n8n.io/)
-- [Pipedream](https://pipedream.com/)
+- [Self-hosting n8n](https://docs.n8n.io/hosting/)
+- [n8n AI capabilities](https://docs.n8n.io/advanced-ai/)
 
 ## Contribution Metadata
 - Last reviewed: 2026-03-08


### PR DESCRIPTION
## What changed
- Added an issue router workflow to auto-route new/reopened/edited issues to `jules` by default, or `autofix` when OpenRouter routing is explicitly requested (`[openrouter]`, `#openrouter`, `autofix`).
- Updated auto-fix workflow to fall back to `jules` when OpenRouter auto-fix fails.
- Updated Jules backlog workflow to also trigger on issue events (`opened`, `reopened`, `labeled:jules`) for faster pickup.
- Expanded `docs/services/n8n.md` with AI-operated n8n patterns, JSON-vs-YAML project guidance, CLI import/export examples, and a full wine import/export email automation blueprint.

## Validation
- `python3 scripts/check_docs_contract.py docs/services/n8n.md`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/issue-automation-router.yml"); YAML.load_file(".github/workflows/auto-fix-issues.yml"); YAML.load_file(".github/workflows/process-jules-backlog.yml"); puts "workflow YAML OK"'`

## Operational follow-through
- Routed all currently open un-routed issues to `jules` so existing backlog is covered now.
- Triggered `process-jules-backlog.yml` manually: https://github.com/joanmarcriera/Home-office-automations/actions/runs/22832908932
