### PR TITLE
fix: restore unattended Jules PR handling

### DIFF
--- a/.github/workflows/jules-auto-merge.yml
+++ b/.github/workflows/jules-auto-merge.yml
@@ -53,6 +53,7 @@ jobs:
         contains(github.event.pull_request.title, 'cross-link') ||
         contains(github.event.pull_request.title, 'primer') ||
         contains(github.event.pull_request.title, 'automated resolution') ||
+        contains(github.event.pull_request.body || '', 'PR created automatically by Jules') ||
         github.event.pull_request.user.login == 'google-labs-jules[bot]'
       )
     runs-on: ubuntu-latest
@@ -72,14 +73,15 @@ jobs:
             exit 0
           fi
 
-          # Find open PRs created by Jules (branch pattern or author)
+          # Find open PRs created by Jules (title/body marker, branch pattern, label, or author)
           JULES_PRS=$(gh pr list \
             --repo "$REPO" \
             --state open \
-            --json number,title,labels,headRefName,author \
+            --json number,title,body,labels,headRefName,author \
             --jq '[.[] | select(
               (.headRefName != "automation/weekly-rollup") and (
               (.title | test("daily maintenance|daily knowledge|weekly|cross-link|primer|automated resolution"; "i")) or
+              ((.body // "") | test("PR created automatically by Jules"; "i")) or
               (.labels[]?.name == "jules") or
               (.headRefName | test("jules|daily-maintenance|daily-knowledge|jules-sprint|weekly-deepen|cross-link|primer|auto-fix"; "i")) or
               (.author.login == "google-labs-jules[bot]")

--- a/docs/services/tubearchivist.md
+++ b/docs/services/tubearchivist.md
@@ -10,7 +10,7 @@ It allows you to index and download YouTube videos, metadata, and comments to yo
 - [GitHub Repository](https://github.com/tubearchivist/tubearchivist)
 
 ## Alternatives
-- [MeTube](metube.md)
+- MeTube
 - [Youtube-dl](https://github.com/ytdl-org/youtube-dl)
 
 ## Backlog


### PR DESCRIPTION
## Summary
- fix the pre-existing broken `MeTube` internal link in `docs/services/tubearchivist.md` that was causing repo-wide link health failures
- update `jules-auto-merge.yml` to recognize Jules-created PRs by the PR body marker (`PR created automatically by Jules`) in addition to the existing title/branch/author heuristics
- keep the selector logic aligned between the job gate and the `gh pr list` discovery step so unattended merge behavior is consistent

## Why
PR #239 was blocked by a combination of:
1. a repo-wide broken internal docs link on `main`, and
2. auto-merge discovery that ignored Jules-created PRs with free-form titles and branch names.

## Validation
- `python3 scripts/check_catalog_consistency.py`
- `python3 scripts/check_docs_contract.py docs/services/tubearchivist.md`
- `python3 scripts/validate_new_sources.py`
- `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'`
- simulated updated Jules PR selector via `gh pr list ... --jq ...` and confirmed it returns `[239]`
