### PR TITLE
fix: harden automation issue hygiene

### DIFF
--- a/.github/issue-templates/process-jules-backlog.md
+++ b/.github/issue-templates/process-jules-backlog.md
@@ -3,16 +3,19 @@
 This is an automated task to clear the backlog of open issues assigned to you. 
 
 ### Step 1 - Search for Open Issues
-Search the repository for all open issues that contain the `jules` label, excluding this exact issue.
+Search the repository for all open non-control issues that contain either the `jules` or `jules-blocked` label, excluding this exact issue.
 
 ### Step 2 - Address the Backlog
 For each open issue found:
 1. Read the issue description and any comments to understand the requested action.
-2. Complete the requested coding task, bug fix, or documentation update.
-3. If the task is successful:
+2. If the issue has the `jules-blocked` label, inspect the blocker comment first.
+   - If the blocker is transient or the task is now actionable, remove `jules-blocked`, re-add `jules`, and continue.
+   - If it is still blocked, leave a comment explaining why it remains blocked and keep `jules-blocked`.
+3. Complete the requested coding task, bug fix, or documentation update for actionable issues.
+4. If the task is successful:
     - Open a pull request containing the fix/update. Include `Fixes #[Issue Number]` in the PR description so the issue closes automatically when merged.
-4. If you are blocked, lack context, or encounter an error:
+5. If you are blocked, lack context, or encounter an error:
     - Leave a comment on the original issue explaining the blocker and remove the `jules` label from that issue to prevent it from stalling future backlog runs.
 
 ### Step 3 - Close this Issue
-Once you have iterated through all the open `jules` issues and completed actions or commented on them, close this "Process Jules Backlog" issue.
+Once you have iterated through all the open `jules` / `jules-blocked` issues and completed actions, relabeled retriable items, or commented on blocked items, close this "Process Jules Backlog" issue.

--- a/.github/workflows/cleanup-automation-issues.yml
+++ b/.github/workflows/cleanup-automation-issues.yml
@@ -23,8 +23,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          PATTERN='^(Daily Maintenance Run -|Daily Knowledge Expansion -|Process Jules Backlog -|Category gap fill:|Weekly deepening:)'
-
           TO_CLOSE=$(gh issue list \
             --repo "$REPO" \
             --state open \
@@ -32,16 +30,30 @@ jobs:
             --author "app/github-actions" \
             --limit 200 \
             --json number,title,createdAt \
-            --jq ".[] | select((.createdAt | fromdateiso8601) < (now - 172800)) | select(.title | test(\"$PATTERN\")) | .number")
+            --jq '
+              def family:
+                if (.title | startswith("Daily Maintenance Run -")) then "daily-maintenance"
+                elif (.title | startswith("Daily Knowledge Expansion -")) then "daily-knowledge"
+                elif (.title | startswith("Process Jules Backlog -")) then "process-backlog"
+                elif (.title | startswith("Category gap fill:")) then "category-gap-fill"
+                elif (.title | startswith("Weekly deepening:")) then "weekly-deepening"
+                else empty
+                end;
+              map(select(.title | test("^(Daily Maintenance Run -|Daily Knowledge Expansion -|Process Jules Backlog -|Category gap fill:|Weekly deepening:)"))
+                  | . + {family: family})
+              | group_by(.family)
+              | map(sort_by(.createdAt) | reverse | .[1:] | .[]?.number)
+              | flatten
+              | .[]')
 
           if [ -z "${TO_CLOSE:-}" ]; then
-            echo "No stale automation issues to close."
+            echo "No superseded automation issues to close."
             exit 0
           fi
 
           for n in $TO_CLOSE; do
             gh issue close "$n" \
               --repo "$REPO" \
-              --comment "Superseded by newer automation cycles; closing stale control issue automatically."
-            echo "Closed stale automation issue #$n"
+              --comment "Superseded by a newer automation control issue; closing automatically."
+            echo "Closed superseded automation issue #$n"
           done

--- a/.github/workflows/daily-jules-knowledge.yml
+++ b/.github/workflows/daily-jules-knowledge.yml
@@ -48,10 +48,13 @@ jobs:
           OPEN_PRS=$(gh pr list \
             --repo "$REPO" \
             --state open \
-            --json number,title,labels,headRefName \
+            --json number,title,body,labels,headRefName,author \
             --jq '[.[] | select(
               (.title | test("daily maintenance|daily knowledge|weekly|cross-link|primer|automated resolution"; "i")) or
-              (.labels[]?.name == "jules")
+              ((.body // "") | test("PR created automatically by Jules"; "i")) or
+              (.labels[]?.name == "jules") or
+              (.headRefName | test("jules|daily-maintenance|daily-knowledge|jules-sprint|weekly-deepen|cross-link|primer|auto-fix"; "i")) or
+              (.author.login == "google-labs-jules[bot]")
             )] | length')
           echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
           if [ "$OPEN_PRS" != "0" ]; then

--- a/.github/workflows/daily-jules-maintenance.yml
+++ b/.github/workflows/daily-jules-maintenance.yml
@@ -49,10 +49,13 @@ jobs:
           OPEN_PRS=$(gh pr list \
             --repo "$REPO" \
             --state open \
-            --json number,title,labels,headRefName \
+            --json number,title,body,labels,headRefName,author \
             --jq '[.[] | select(
               (.title | test("daily maintenance|daily knowledge|weekly|cross-link|primer|automated resolution"; "i")) or
-              (.labels[]?.name == "jules")
+              ((.body // "") | test("PR created automatically by Jules"; "i")) or
+              (.labels[]?.name == "jules") or
+              (.headRefName | test("jules|daily-maintenance|daily-knowledge|jules-sprint|weekly-deepen|cross-link|primer|auto-fix"; "i")) or
+              (.author.login == "google-labs-jules[bot]")
             )] | length')
           echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
           if [ "$OPEN_PRS" != "0" ]; then

--- a/.github/workflows/jules-pipeline-trigger.yml
+++ b/.github/workflows/jules-pipeline-trigger.yml
@@ -24,6 +24,7 @@ jobs:
         contains(github.event.pull_request.title, 'cross-link') ||
         contains(github.event.pull_request.title, 'primer') ||
         contains(github.event.pull_request.title, 'automated resolution') ||
+        contains(github.event.pull_request.body || '', 'PR created automatically by Jules') ||
         github.event.pull_request.user.login == 'google-labs-jules[bot]'
       )
     runs-on: ubuntu-latest
@@ -52,3 +53,17 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh workflow run "Jules Sprint Workforce (2 Weeks)" --repo "$REPO" || true
+
+      - name: Trigger backlog workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh workflow run "Process Jules Backlog" --repo "$REPO" || true
+
+      - name: Trigger cleanup workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh workflow run "Cleanup Stale Automation Issues" --repo "$REPO" || true

--- a/.github/workflows/process-jules-backlog.yml
+++ b/.github/workflows/process-jules-backlog.yml
@@ -15,11 +15,11 @@ jobs:
   open-backlog-issue:
     if: >-
       github.event_name != 'issues' ||
-      (
+          (
         github.event_name == 'issues' && (
           github.event.action == 'opened' ||
           github.event.action == 'reopened' ||
-          (github.event.action == 'labeled' && github.event.label.name == 'jules')
+          (github.event.action == 'labeled' && (github.event.label.name == 'jules' || github.event.label.name == 'jules-blocked'))
         )
       )
     runs-on: ubuntu-latest
@@ -49,7 +49,31 @@ jobs:
           REPO: ${{ github.repository }}
         run: python3 scripts/quarantine_failed_jules_issues.py
 
+      - name: Check for open Jules PRs (throttle)
+        id: throttle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          OPEN_PRS=$(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --json number,title,body,labels,headRefName,author \
+            --jq '[.[] | select(
+              (.title | test("daily maintenance|daily knowledge|weekly|cross-link|primer|automated resolution"; "i")) or
+              ((.body // "") | test("PR created automatically by Jules"; "i")) or
+              (.labels[]?.name == "jules") or
+              (.headRefName | test("jules|daily-maintenance|daily-knowledge|jules-sprint|weekly-deepen|cross-link|primer|auto-fix"; "i")) or
+              (.author.login == "google-labs-jules[bot]")
+            )] | length')
+          echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
+          if [ "$OPEN_PRS" != "0" ]; then
+            echo "⏸️ Throttled: $OPEN_PRS open Jules PR(s). Skipping backlog issue creation."
+          fi
+
       - name: Check open Jules backlog status
+        if: steps.throttle.outputs.open_prs == '0'
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,31 +81,49 @@ jobs:
         run: |
           set -euo pipefail
           TODAY=$(date +%Y-%m-%d)
+          NON_CONTROL_FILTER='[.[] | select(
+            (.title | startswith("Process Jules Backlog - ") | not) and
+            (.title | startswith("Daily Knowledge Expansion - ") | not) and
+            (.title | startswith("Daily Maintenance Run - ") | not) and
+            (.title | startswith("[W") | not)
+          )] | length'
+
           OPEN_JULES=$(gh issue list \
             --repo "$REPO" \
             --label jules \
             --state open \
             --json number,title \
-            --jq "[.[] | select(
-              (.title | startswith(\"Process Jules Backlog - \") | not) and
-              (.title | startswith(\"Daily Knowledge Expansion - \") | not) and
-              (.title | startswith(\"Daily Maintenance Run - \") | not) and
-              (.title | startswith(\"[W\") | not)
-            )] | length")
+            --jq "$NON_CONTROL_FILTER")
+          OPEN_BLOCKED=$(gh issue list \
+            --repo "$REPO" \
+            --label jules-blocked \
+            --state open \
+            --json number,title \
+            --jq "$NON_CONTROL_FILTER")
           OPEN_BACKLOG=$(gh issue list \
             --repo "$REPO" \
-            --label jules \
             --state open \
             --search "Process Jules Backlog -" \
-            --json number \
-            --jq "length")
+            --json number,title \
+            --jq "[.[] | select(.title | startswith(\"Process Jules Backlog - \"))] | length")
 
+          OPEN_WORK=$((OPEN_JULES + OPEN_BLOCKED))
+
+          echo "open_work=$OPEN_WORK" >> "$GITHUB_OUTPUT"
+          echo "open_blocked=$OPEN_BLOCKED" >> "$GITHUB_OUTPUT"
           echo "open_jules=$OPEN_JULES" >> "$GITHUB_OUTPUT"
           echo "open_backlog=$OPEN_BACKLOG" >> "$GITHUB_OUTPUT"
           echo "today=$TODAY" >> "$GITHUB_OUTPUT"
 
+          if [ "$OPEN_WORK" = "0" ]; then
+            echo "No open Jules or Jules-blocked backlog items."
+          fi
+          if [ "$OPEN_BACKLOG" != "0" ]; then
+            echo "Existing Process Jules Backlog issue already open."
+          fi
+
       - name: Open Jules backlog issue
-        if: steps.check.outputs.open_jules != '0' && steps.check.outputs.open_backlog == '0'
+        if: steps.throttle.outputs.open_prs == '0' && steps.check.outputs.open_work != '0' && steps.check.outputs.open_backlog == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- broaden remaining Jules PR detectors to include the Jules body marker, branch heuristics, and bot author checks in the daily maintenance / knowledge throttles and the post-merge pipeline trigger
- make `Process Jules Backlog` aware of `jules-blocked` items and add PR throttling so backlog control issues are only created when the queue is actually clear
- replace age-based stale-control cleanup with per-family supersession logic so older daily control issues close as soon as a newer issue exists
- trigger backlog and cleanup workflows immediately after a Jules PR merge so the queue advances without waiting for the next cron window
- update the backlog issue template so blocked items are retried or explicitly documented instead of disappearing from automation

## Why
The live backlog on 2026-03-29 showed:
- superseded control issues `#253` and `#251` still open behind `#255`
- `8` non-control `jules` issues and `8` non-control `jules-blocked` issues
- no open `Process Jules Backlog` control issue
- remaining workflow gates outside `jules-auto-merge` still missing the Jules PR body-marker detection that was needed for PR `#239`

## Validation
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/daily-jules-maintenance.yml"); YAML.load_file(".github/workflows/daily-jules-knowledge.yml"); YAML.load_file(".github/workflows/process-jules-backlog.yml"); YAML.load_file(".github/workflows/jules-pipeline-trigger.yml"); YAML.load_file(".github/workflows/cleanup-automation-issues.yml"); puts "workflow yaml OK"'`
- `python3 scripts/check_catalog_consistency.py`
- `python3 scripts/validate_new_sources.py`
- live dry-run of cleanup selector returned `[253,251]`
- live dry-run of backlog detector returned `8` open `jules` items and `8` open `jules-blocked` items
