### PR TITLE
docs: add Picnic canonical page

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -876,6 +876,12 @@
       "doc_path": "docs/tools/automation_orchestration/browser-use.md"
     },
     {
+      "id": "picnic",
+      "name": "Picnic",
+      "category": "Automation & Orchestration",
+      "doc_path": "docs/tools/automation_orchestration/picnic.md"
+    },
+    {
       "id": "skyvern",
       "name": "Skyvern",
       "category": "Automation & Orchestration",

--- a/docs/tools/automation_orchestration/picnic.md
+++ b/docs/tools/automation_orchestration/picnic.md
@@ -1,0 +1,93 @@
+# Picnic
+
+## What it is
+
+Picnic is a desktop AI automation product that lets users record browser-based work, package it into reusable flows, and run those flows as scheduled agents on top of the OpenClaw runtime.
+
+## What problem it solves
+
+OpenClaw-class agent systems are powerful, but they still assume a fairly technical operator. Picnic lowers that barrier for recurring business and home-office tasks by replacing prompt-and-config heavy setup with a desktop UI, recorded flows, prebuilt agent packages, and scheduled jobs.
+
+## Where it fits in the stack
+
+**Automation runtime / desktop orchestration layer**. Picnic sits above model subscriptions and browser automation primitives, and in front of OpenClaw, giving non-developers a way to teach workflows by demonstration and then run them unattended.
+
+```text
+User -> Picnic desktop UI -> Recorded flows + jobs + agents -> OpenClaw runtime -> LLM/provider subscriptions
+```
+
+## Typical use cases
+
+- Browser-based admin work that repeats every day or week.
+- Overnight or off-hours job execution for reports, follow-ups, and queued tasks.
+- Teams that want OpenClaw-style autonomy without starting in Docker, YAML, or the terminal.
+- Small-business or founder workflows that benefit from prebuilt agent packages.
+
+## Getting started
+
+1. Download the desktop app for macOS, Windows, or Linux from the official site.
+2. Connect the subscription or model access you already use. The product is designed to work with an existing ChatGPT or Claude subscription, with optional direct API keys for advanced users.
+3. Open the built-in Picnic Browser and record a repeatable workflow once.
+4. Save that recording as a Flow, attach it to an Agent, and assign a schedule in the Jobs view.
+5. If the workflow outgrows the default UI, use the built-in OpenClaw Control entrypoint for lower-level runtime control.
+
+## Integration-oriented example
+
+### Scheduled portal follow-up agent
+
+1. Record the steps for logging into a supplier or CRM web portal inside Picnic Browser.
+2. Save the recording as a reusable Flow.
+3. Attach that Flow to an Agent responsible for follow-up work.
+4. Schedule the Agent to run overnight with Picnic's Jobs or Nightshift model.
+5. When you need deeper customization, open the embedded OpenClaw control surface and extend the workflow with more advanced agent behavior.
+
+This makes Picnic a practical front door for people who want OpenClaw-backed automation without starting from raw agent configuration.
+
+## Strengths
+
+- Very low setup friction compared with self-hosting an agent runtime directly.
+- Built-in browser recording is a good fit for web apps that lack clean APIs.
+- Scheduling is a first-class concept rather than an add-on.
+- Sandboxed browser isolation is safer than sharing your day-to-day Chrome or Safari profile.
+- Clear migration path into OpenClaw for users who need more control later.
+
+## Limitations
+
+- Public technical documentation is thin; most public information currently comes from the marketing site and FAQ.
+- Browser-recorded automations still inherit the usual fragility of UI-driven workflows.
+- Picnic itself is not positioned as a source-available or self-hosted server product.
+- Advanced governance, custom integrations, and deep runtime tuning still push you toward OpenClaw underneath.
+
+## When to use it
+
+- When a non-technical operator wants to automate repeated browser work.
+- When the main requirement is scheduled, unattended execution from a desktop app.
+- When you want OpenClaw capabilities but prefer a guided GUI and prebuilt agent library.
+
+## When not to use it
+
+- When you need a documented API-first automation platform with strong developer ergonomics.
+- When the workflow must be fully self-hosted, source-available, or infrastructure-managed.
+- When the task is primarily software-engineering automation rather than browser or business-process automation.
+
+## Licensing and cost
+
+- **Open Source**: No public source repository is advertised for the Picnic application itself.
+- **Cost**: As of 2026-03-29, the official site advertises both bring-your-own-subscription usage and paid Starter, Pro, and Business tiers.
+- **Self-hostable**: No
+
+## Related tools / concepts
+
+- [OpenClaw](../development_ops/openclaw.md)
+- [Browser Use](browser-use.md)
+- [n8n](../../services/n8n.md)
+- [Home Assistant](../../services/home-assistant.md)
+
+## Sources / References
+
+- [Official site](https://picnicos.com/)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-03-29
+- Confidence: medium

--- a/docs/tools/development_ops/openclaw.md
+++ b/docs/tools/development_ops/openclaw.md
@@ -234,6 +234,7 @@ router_settings:
 - [LiteLLM](../../services/litellm.md) — model routing proxy for connecting OpenClaw to local or remote models
 - [OpenHands](openhands.md) — software-engineering agent platform
 - [NanoClaw](nanoclaw.md) — minimal, constrained agent runtime
+- [Picnic](../automation_orchestration/picnic.md) — desktop product that exposes OpenClaw-powered flows and scheduled agents through a non-technical UI
 - [OpenSwarm](openswarm.md) — multi-agent swarm orchestration
 - [Ollama](../../services/ollama.md) — local model serving
 - [n8n](../../services/n8n.md) — complementary workflow automation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,7 @@ nav:
       - Make: tools/automation_orchestration/make.md
       - Makefile MCP: tools/automation_orchestration/makefile-mcp.md
       - MCP Registry: tools/automation_orchestration/mcp-registry.md
+      - Picnic: tools/automation_orchestration/picnic.md
       - ServiceNow MCP Server: tools/automation_orchestration/servicenow-mcp.md
       - Skyvern: tools/automation_orchestration/skyvern.md
       - Vault MCP Server: tools/automation_orchestration/vault-mcp.md


### PR DESCRIPTION
## Summary
- add a canonical Picnic page under Automation & Orchestration
- register Picnic in `data/all_tools.json` and `mkdocs.yml`
- cross-link Picnic from the existing OpenClaw page

Fixes #183

## Validation
- `python3 scripts/check_catalog_consistency.py`
- `python3 scripts/check_docs_contract.py docs/tools/automation_orchestration/picnic.md docs/tools/development_ops/openclaw.md`
- `python3 scripts/validate_new_sources.py`
- `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'`