### PR TITLE
docs: deepen OpenClaw ecosystem coverage

### DIFF
--- a/docs/knowledge_base/patterns/openclaw-security-operations.md
+++ b/docs/knowledge_base/patterns/openclaw-security-operations.md
@@ -1,0 +1,119 @@
+# OpenClaw Security and Operations Pattern
+
+## What it is
+
+An operating pattern for running OpenClaw with explicit trust boundaries, patch discipline, skill review, model-routing tiers, and approval gates for high-impact actions.
+
+## What problem it solves
+
+OpenClaw combines messaging channels, browser automation, shell-capable skills, and third-party integrations. That makes it powerful, but it also means a casual setup can expose credentials, execute unsafe skills, or let hostile content steer the agent. This pattern turns OpenClaw from an impressive demo into something you can operate repeatedly with less risk.
+
+## Where it fits in the stack
+
+**Pattern / operations layer**. It wraps the OpenClaw runtime with the safety, routing, and review controls needed for production or always-on home-office use.
+
+## Typical use cases
+
+- Hardening a personal assistant that reads messages, email, and calendar events.
+- Running research or reporting agents that browse the web and summarize results.
+- Operating draft-only or approval-gated assistants for communications or business ops.
+- Separating cheap monitoring work from expensive deep-analysis work.
+
+## Core operating pattern
+
+### 1. Split skills by capability tier
+
+Use separate skill classes instead of giving every agent full autonomy:
+
+- **Read-only**: summaries, monitoring, search, log inspection.
+- **Draft-only**: email replies, content drafts, action plans, issue summaries.
+- **Approval-gated**: shell changes, message sending, browser-side effects, external mutations.
+
+### 2. Treat all inbound content as untrusted
+
+Messages, emails, webpages, PDFs, and copied prompts can all contain hostile instructions. The practical rule is simple: user intent comes from trusted humans and configured skills, not from the content being processed.
+
+### 3. Keep the runtime patched
+
+OpenClaw has already had real-world security incidents in 2026. In particular, TechRadar reported the March 2026 "ClawJacked" local-gateway flaw and noted that users should upgrade to version `2026.2.25` or later. The operating pattern here is to treat upgrades as routine maintenance, not optional cleanup.
+
+### 4. Review the skill supply chain
+
+Community skills and fake installers are part of the risk surface. Install from known sources, inspect what the skill can call, and prefer self-authored or heavily reviewed skills for anything with credentials, browser sessions, or filesystem access.
+
+### 5. Route models by task shape
+
+Do not use the same model profile for every workflow:
+
+- Cheap models for heartbeat checks, summaries, and lightweight triage.
+- Balanced models for daily assistants, inbox review, and browser navigation.
+- Premium models for deep research, high-stakes planning, or ambiguous investigations.
+
+This reduces cost while keeping stronger reasoning available where mistakes are expensive.
+
+### 6. Design for draft-first external behavior
+
+If the workflow touches customers, finance, or irreversible actions, OpenClaw should prepare drafts, plans, or recommendations first. Another system or human should confirm before anything is sent or executed.
+
+## Threat model and controls
+
+| Risk | What it looks like | Primary control |
+|---|---|---|
+| Prompt injection from web/email content | A page or message tries to override system rules or request secrets | Treat content as data, not authority; keep tool policies outside retrieved content |
+| Local gateway or runtime vulnerability | Browser- or network-reachable service exposed through weak auth | Patch quickly, limit exposure, and avoid unnecessary network reachability |
+| Skill supply-chain compromise | Community skill or fake installer runs unexpected code | Review source, pin trusted install paths, and prefer least-privilege bindings |
+| Credential exposure | Secrets leak through prompts, logs, or poorly scoped tools | Store secrets outside prompts, reference them by name only, and isolate sensitive tools |
+| Destructive autonomy | Agent restarts services, deletes files, or sends messages without review | Require approval gates for side effects and keep destructive skills separate |
+| Runaway cost | High-end model used for routine summaries or recurring cron jobs | Explicit model tiers and per-skill routing profiles |
+
+## Operational checklist
+
+- Patch OpenClaw promptly and track known security advisories.
+- Separate read-only, draft-only, and approval-gated skills.
+- Keep browser automation in sandboxed or dedicated profiles.
+- Log what skills can access and review those permissions periodically.
+- Route low-value recurring work to cheaper models.
+- Treat email and web content as hostile until proven otherwise.
+
+## Strengths
+
+- Converts vague "be careful" advice into concrete operating controls.
+- Works for both solo operators and small teams.
+- Pairs naturally with LiteLLM routing and n8n approval flows.
+
+## Limitations
+
+- Still depends on operator discipline; OpenClaw does not remove the need for good judgment.
+- Public security guidance is fragmented across official docs, community material, and reporting.
+- High-autonomy workflows remain risky even with stronger guardrails.
+
+## When to use it
+
+- When OpenClaw is always on or connected to real accounts and real data.
+- When skills can touch shell, browser, or communication surfaces.
+- When you want a repeatable pattern for deciding which actions need approval.
+
+## When not to use it
+
+- When the workflow is fully deterministic and should just be a script or n8n flow.
+- When you cannot maintain patching, credential hygiene, and skill review.
+- When the agent has no meaningful side effects and no sensitive access.
+
+## Related tools / concepts
+
+- [OpenClaw](../../tools/development_ops/openclaw.md)
+- [LiteLLM](../../services/litellm.md)
+- [n8n](../../services/n8n.md)
+- [OpenClaw Use-Case Catalog](openclaw-use-case-catalog.md)
+- [LLM Trust Boundaries](llm-trust-boundaries.md)
+
+## Sources / References
+
+- [OpenClaw system prompt concepts](https://docs.openclaw.ai/concepts/system-prompt)
+- [TechRadar: "ClawJacked" vulnerability report](https://www.techradar.com/pro/security/a-human-chosen-password-doesnt-stand-a-chance-openclaw-has-yet-another-major-security-flaw-heres-what-we-know-about-clawjacked)
+- [TechRadar: fake OpenClaw installers and GitHub malware campaign](https://www.techradar.com/pro/security/hackers-exploit-openclaw-to-spread-malware-via-github-and-a-little-help-from-bing)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-03-29
+- Confidence: medium

--- a/docs/knowledge_base/patterns/openclaw-use-case-catalog.md
+++ b/docs/knowledge_base/patterns/openclaw-use-case-catalog.md
@@ -1,0 +1,96 @@
+# OpenClaw Use-Case Catalog
+
+## What it is
+
+A categorized catalog of recurring OpenClaw use cases distilled from long-running real workflows and community-curated examples.
+
+## What problem it solves
+
+OpenClaw is flexible enough that new users often know it is "powerful" but not whether it is the right fit for a given workflow. This page translates community examples into concrete workload shapes, guardrails, and implementation notes.
+
+## Where it fits in the stack
+
+**Pattern / selection guide**. It helps decide when OpenClaw should be the agent runtime versus when a simpler script, n8n flow, or dedicated tool would be a better choice.
+
+## Categorized use cases
+
+| Category | Use case | Why OpenClaw fits | Guardrail |
+|---|---|---|---|
+| Home-office | Morning briefing assistant | Good for collecting tasks, weather, reminders, and daily summaries across tools | Keep it read-only |
+| Knowledge management | "Second brain" capture and recall | Works well when a conversational layer needs memory and retrieval over bookmarks, notes, and saved links | Make note-writing explicit |
+| Research | Nightly research digest | Strong fit for scheduled search, summary, and digest workflows | Verify sources before external sharing |
+| Content | Idea capture and content machine | Useful for capturing rough ideas, organizing them, and expanding into reusable drafts | Draft-only before publishing |
+| Web work | URL summary and link processing | Efficient when a lightweight skill can summarize an article, PDF, or video from a link | Keep browsing isolated |
+| Infrastructure | Server and service monitoring | Works well for SSH-backed checks plus human-readable reporting in chat | Require approval for fixes and restarts |
+| Development | Coding from phone / remote PR prep | Helpful when conversational requests must turn into branch, commit, and PR actions | Never auto-merge without review |
+| Communications | Email triage and draft replies | Good for classifying inbox traffic and drafting responses in the user's tone | Draft-only mode, never send directly |
+| Calendar and family | Scheduling and reminder coordination | Useful when the same assistant handles calendar checks, event creation, and reminders | Require confirmation for sensitive events |
+| Operations | Daily life admin and recurring checklists | Strong fit for errands, reminders, recurring personal tasks, and follow-up loops | Keep external side effects explicit |
+| Reporting | Scheduled reporting and anomaly detection | Good for pulling routine metrics and calling out patterns humans might miss | Separate reporting from action-taking |
+
+## Selection criteria
+
+### OpenClaw is a good fit when
+
+- The workflow is conversational, recurring, or schedule-driven.
+- The same task benefits from memory, routing, or multiple skill/tool surfaces.
+- A messaging channel or chat interface is part of the operator experience.
+- Human review is possible for the highest-risk actions.
+
+### OpenClaw is a poor fit when
+
+- The workflow is deterministic and easier as a plain script or API integration.
+- The task requires strict auditability with minimal autonomous interpretation.
+- Browser or shell access would create more risk than value.
+- The operator really needs a visual automation control plane rather than an agent runtime.
+
+## Implementation notes
+
+- Use LiteLLM or a similar router to separate cheap routine jobs from expensive deep-thinking tasks.
+- Keep destructive skills out of the default assistant loop.
+- Put draft-first boundaries around email, publishing, and customer-facing actions.
+- Use n8n or another workflow system when timing, retries, approvals, and auditability matter more than conversation.
+- Start with one or two well-bounded skills before layering more channels or capabilities.
+
+## Strengths
+
+- Gives concrete examples across coding, research, operations, and home-office work.
+- Helps map community excitement onto realistic workflow design.
+- Makes it easier to choose guardrails before implementation starts.
+
+## Limitations
+
+- Community examples are biased toward enthusiastic power users.
+- Not every showcased workflow is equally reliable in production.
+- Specific integrations and tools change quickly, so examples need periodic refresh.
+
+## When to use it
+
+- When deciding whether a new idea belongs in OpenClaw.
+- When translating a vague "agent assistant" goal into a workflow category.
+- When prioritizing which agent workloads to build first.
+
+## When not to use it
+
+- When you already know the workflow should live in a conventional automation tool.
+- When you need vendor-neutral guidance that does not assume an agent runtime.
+- When the requirement is formal process design rather than examples and fit criteria.
+
+## Related tools / concepts
+
+- [OpenClaw](../../tools/development_ops/openclaw.md)
+- [OpenClaw Workflow Prompt Library Pattern](openclaw-workflow-prompts.md)
+- [OpenClaw Security and Operations Pattern](openclaw-security-operations.md)
+- [n8n](../../services/n8n.md)
+- [Picnic](../../tools/automation_orchestration/picnic.md)
+
+## Sources / References
+
+- [OpenClaw automation examples and workflow notes](https://gist.github.com/ANcpLua/4ba21cd7f0bf08e0b483f3187dd93308)
+- [OpenClaw after 50 days: all prompts for 20 real workflows](https://gist.github.com/velvet-shark/b4c6724c391f612c4de4e9a07b0a74b6)
+- [awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-03-29
+- Confidence: medium

--- a/docs/knowledge_base/patterns/openclaw-workflow-prompts.md
+++ b/docs/knowledge_base/patterns/openclaw-workflow-prompts.md
@@ -34,6 +34,8 @@ Users often know desired outcomes but struggle to express executable agent instr
 
 ## Related tools / concepts
 - [OpenCode (Oh My OpenCode Ecosystem)](../../tools/development_ops/opencode.md)
+- [OpenClaw Use-Case Catalog](openclaw-use-case-catalog.md)
+- [OpenClaw Security and Operations Pattern](openclaw-security-operations.md)
 - [Agent Protocols](../agent_protocols.md)
 - [Patterns Index](index.md)
 

--- a/docs/new-sources.md
+++ b/docs/new-sources.md
@@ -6,6 +6,7 @@ This index tracks daily source-ingestion files. Each day gets a dedicated log fi
 
 | Date | Log File | New | Integrated | Notes |
 | :--- | :--- | :---: | :---: | :--- |
+| 2026-03-29 | [2026-03-29](/new-sources/2026-03-29/) | 0 | 5 | Added OpenClaw security/operations and use-case catalog patterns. |
 | 2026-03-16 | [2026-03-16](/new-sources/2026-03-16/) | 0 | 0 | Standardized related tools sections across all documentation. |
 | 2026-03-15 | [2026-03-15](/new-sources/2026-03-15/) | 0 | 11 | Added website-hosting canonicals, free website playbook, and discovery-style builder index |
 | 2026-03-14 | [2026-03-14](/new-sources/2026-03-14/) | 0 | 33 | Added Claude ecosystem coverage, search/backend/browser tools, Google AI product pages, direct pages for memory/context/local inference, and company-stack extensions |

--- a/docs/new-sources/2026-03-29.md
+++ b/docs/new-sources/2026-03-29.md
@@ -1,0 +1,9 @@
+# New Sources Log — 2026-03-29
+
+| Title | URL | Tags | Status | Canonical Page | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| OpenClaw system prompt concepts | https://docs.openclaw.ai/concepts/system-prompt | tutorial/guide | integrated | [OpenClaw Security and Operations Pattern](../knowledge_base/patterns/openclaw-security-operations.md) | Used for trust-boundary, role, and guardrail guidance. |
+| OpenClaw automation examples and workflow notes | https://gist.github.com/ANcpLua/4ba21cd7f0bf08e0b483f3187dd93308 | tutorial/guide | integrated | [OpenClaw Use-Case Catalog](../knowledge_base/patterns/openclaw-use-case-catalog.md) | Used as an additional community workflow source for categorized OpenClaw use cases. |
+| awesome-openclaw-usecases | https://github.com/hesamsheikh/awesome-openclaw-usecases | tutorial/guide | integrated | [OpenClaw Use-Case Catalog](../knowledge_base/patterns/openclaw-use-case-catalog.md) | Used as community validation for categorized OpenClaw workload coverage. |
+| TechRadar: "ClawJacked" vulnerability report | https://www.techradar.com/pro/security/a-human-chosen-password-doesnt-stand-a-chance-openclaw-has-yet-another-major-security-flaw-heres-what-we-know-about-clawjacked | analysis | integrated | [OpenClaw Security and Operations Pattern](../knowledge_base/patterns/openclaw-security-operations.md) | Used for patch-level and local-gateway hardening guidance. |
+| TechRadar: fake OpenClaw installers and GitHub malware campaign | https://www.techradar.com/pro/security/hackers-exploit-openclaw-to-spread-malware-via-github-and-a-little-help-from-bing | analysis | integrated | [OpenClaw Security and Operations Pattern](../knowledge_base/patterns/openclaw-security-operations.md) | Used for supply-chain caution around fake installers and malicious repos. |

--- a/docs/services/n8n.md
+++ b/docs/services/n8n.md
@@ -234,6 +234,8 @@ This keeps n8n improving as an operating system for your business processes, not
 - [Make](../tools/automation_orchestration/make.md) (Alternative)
 - [OpenRouter](../tools/ai_knowledge/openrouter.md) (Multi-provider LLM routing for prompts/models)
 - [Home Assistant](home-assistant.md) (Example of broader automation ecosystem integration)
+- [OpenClaw Use-Case Catalog](../knowledge_base/patterns/openclaw-use-case-catalog.md) (Concrete OpenClaw workload shapes that n8n can coordinate or gate)
+- [OpenClaw Security and Operations Pattern](../knowledge_base/patterns/openclaw-security-operations.md) (Guardrails for autonomous agent actions touching real systems)
 
 ## Backlog
 - Add reusable sub-workflows: `email-triage`, `risk-gating`, `human-approval`.

--- a/docs/tools/development_ops/openclaw.md
+++ b/docs/tools/development_ops/openclaw.md
@@ -51,6 +51,16 @@ Skills are self-contained behaviour modules. Each skill defines:
 
 Skills are distributed as files (YAML + Markdown) or packages from ClawHub. They compose: a skill can invoke another skill, pass context forward, or branch based on LLM output.
 
+## Ecosystem map
+
+| Layer | What it covers | Practical examples |
+|---|---|---|
+| **Core runtime** | Agent loop, memory, channel adapters, scheduler, skill execution | OpenClaw itself |
+| **Skill distribution** | Reusable behaviors and integrations | ClawHub marketplace, self-authored YAML skills |
+| **Workflow libraries** | Field-tested prompts and scenario libraries | [OpenClaw Workflow Prompt Library Pattern](../../knowledge_base/patterns/openclaw-workflow-prompts.md), [OpenClaw Use-Case Catalog](../../knowledge_base/patterns/openclaw-use-case-catalog.md) |
+| **Operator surfaces** | Easier ways to drive the runtime | [Picnic](../automation_orchestration/picnic.md), messaging channels, CLI |
+| **Model routing** | Cost and reliability control for skills | LiteLLM + Ollama/OpenRouter profiles |
+
 ## Typical use cases
 
 - **Personal assistant via Telegram**: Ask questions, manage tasks, set reminders, trigger home-automation scenes.
@@ -174,7 +184,14 @@ router_settings:
   allowed_fails: 2
 ```
 
-## Security model
+### Routing patterns for cost and reliability
+
+- **Cheap routing**: monitoring, link summaries, and lightweight triage can use smaller or cheaper models.
+- **Balanced routing**: daily assistants, browser navigation, and inbox review usually benefit from a middle tier.
+- **Premium routing**: deep research, ambiguous investigations, and high-stakes planning deserve the strongest model profile you can justify.
+- **Approval-aware routing**: destructive or external-side-effect skills should combine stronger models with explicit approval gates, not just bigger models.
+
+## Production hardening
 
 | Risk | Mitigation |
 |---|---|
@@ -183,6 +200,14 @@ router_settings:
 | Credential exposure | Secrets via environment variables; never hardcoded in skill YAML |
 | Unvetted ClawHub skills | Review skill source before installing; prefer community-vetted or self-authored |
 | Channel access control | Per-channel permission lists in skill config; OPENCLAW_API_KEY for REST API |
+
+### Practical operating controls
+
+- **Patch quickly**: TechRadar's March 2026 "ClawJacked" coverage reported a local-gateway authentication flaw and recommended upgrading to `2026.2.25` or later.
+- **Assume hostile content**: emails, webpages, and copied prompts should be treated as untrusted input, not as authority over the system prompt.
+- **Separate capability tiers**: keep read-only, draft-only, and approval-gated skills distinct.
+- **Review the install path**: community skills and fake installers are part of the threat surface; use trusted sources and inspect capabilities before enabling them.
+- **Use cost-aware routing**: most scheduled workflows do not need the most expensive model on every invocation.
 
 !!! warning "High-autonomy risk"
     OpenClaw skills can execute shell commands and HTTP calls. Always review skill source before installing from ClawHub. Apply the principle of least privilege in tool bindings.
@@ -239,16 +264,22 @@ router_settings:
 - [Ollama](../../services/ollama.md) — local model serving
 - [n8n](../../services/n8n.md) — complementary workflow automation
 - [OpenClaw Workflow Prompts](../../knowledge_base/patterns/openclaw-workflow-prompts.md) — curated prompt library
+- [OpenClaw Use-Case Catalog](../../knowledge_base/patterns/openclaw-use-case-catalog.md) — categorized workload ideas and fit criteria
+- [OpenClaw Security and Operations Pattern](../../knowledge_base/patterns/openclaw-security-operations.md) — hardening and operating controls
 - [Agent Skills Best Practices](../../knowledge_base/patterns/skills-best-practices.md) — skill authoring guide
 
 ## Sources / References
 
 - [GitHub — openclaw/openclaw](https://github.com/openclaw/openclaw)
 - [ClawHub Marketplace](https://www.clawhub.ai/)
+- [OpenClaw system prompt concepts](https://docs.openclaw.ai/concepts/system-prompt)
 - [OpenClaw after 50 days: all prompts for 20 real workflows](https://gist.github.com/velvet-shark/b4c6724c391f612c4de4e9a07b0a74b6)
+- [awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases)
+- [TechRadar: "ClawJacked" vulnerability report](https://www.techradar.com/pro/security/a-human-chosen-password-doesnt-stand-a-chance-openclaw-has-yet-another-major-security-flaw-heres-what-we-know-about-clawjacked)
+- [TechRadar: fake OpenClaw installers and GitHub malware campaign](https://www.techradar.com/pro/security/hackers-exploit-openclaw-to-spread-malware-via-github-and-a-little-help-from-bing)
 - [Pattern: OpenClaw Workflow Prompts](../../knowledge_base/patterns/openclaw-workflow-prompts.md)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-03-21
+- Last reviewed: 2026-03-29
 - Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -360,6 +360,8 @@ nav:
       - Agent Skills Best Practices: knowledge_base/patterns/skills-best-practices.md
       - Fine-tuning Open Models: knowledge_base/patterns/fine-tuning-open-models.md
       - OpenClaw Workflow Prompt Library: knowledge_base/patterns/openclaw-workflow-prompts.md
+      - OpenClaw Use-Case Catalog: knowledge_base/patterns/openclaw-use-case-catalog.md
+      - OpenClaw Security and Operations: knowledge_base/patterns/openclaw-security-operations.md
       - LLM Trust Boundaries: knowledge_base/patterns/llm-trust-boundaries.md
       - Software Factories: knowledge_base/patterns/software-factories.md
       - Filesystem-as-Interface: knowledge_base/patterns/filesystem-context.md


### PR DESCRIPTION
## Summary
- deepen the canonical OpenClaw page with ecosystem mapping, production hardening, and routing guidance
- add dedicated OpenClaw security/operations and use-case catalog pattern pages
- add cross-links from related docs and record the source pool in today's intake log

Fixes #182
Fixes #184

## Validation
- `python3 scripts/check_catalog_consistency.py`
- `python3 scripts/check_docs_contract.py docs/tools/development_ops/openclaw.md docs/knowledge_base/patterns/openclaw-security-operations.md docs/knowledge_base/patterns/openclaw-use-case-catalog.md docs/knowledge_base/patterns/openclaw-workflow-prompts.md docs/services/n8n.md`
- `python3 scripts/validate_new_sources.py`
- `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'`