### PR TITLE
Improve 5 shallow service documentation files with practical examples

### DIFF
--- a/docs/services/diskover.md
+++ b/docs/services/diskover.md
@@ -1,35 +1,51 @@
 # Diskover
 
-Diskover is an open-source file indexer and data management tool.
+Diskover is an open-source file indexer and data management tool that uses Elasticsearch to index and manage data across heterogeneous storage systems.
 
 ## Description
-It helps you identify disk space usage, find old or duplicate files, and gain insights into your storage infrastructure.
+It helps you identify disk space usage, find old or duplicate files, and gain insights into your storage infrastructure. It provides a web-based dashboard for visualizing and searching through your indexed file systems.
+
+## When to use it
+- When you need to gain visibility into large, heterogeneous storage environments.
+- To identify "dark data," such as old, large, or duplicate files that are wasting space.
+- When you want a searchable index of your files without having to scan the live file system every time.
+- For data management tasks like cleanup, migration, or capacity planning.
+
+## When not to use it
+- If you only need a simple, real-time disk usage visualizer for a single local drive (consider `ncdu` or WizTree).
+- If you don't have the resources to run Elasticsearch, which is a mandatory requirement for Diskover.
+- For real-time file monitoring, as Diskover relies on scheduled indexing tasks.
 
 ## Links
 - [GitHub Repository](https://github.com/diskoverdata/diskover-community)
+- [Official Website](https://diskoverdata.com/)
 
 ## Alternatives
-- [WizTree](https://diskanalyzer.com/) (Non-OSS)
-- [ncdu](https://dev.yorhel.nl/ncdu)
+- [WizTree](https://diskanalyzer.com/) (Non-OSS, Windows)
+- [ncdu](https://dev.yorhel.nl/ncdu) (CLI-based)
+- [WinDirStat](https://windirstat.net/)
 
 ## Getting started
 
 ### Docker installation
-Diskover requires an Elasticsearch instance. Using Docker Compose is the recommended way to set up both:
+The recommended way to run Diskover is using Docker Compose, as it handles both the Diskover application and the required Elasticsearch instance.
 
 ```yaml
 version: '2'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.22
     environment:
       - discovery.type=single-node
+      - xpack.security.enabled=false
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
   diskover:
     image: lscr.io/linuxserver/diskover
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
+      - TZ=Etc/UTC
       - ES_HOST=elasticsearch
     volumes:
       - /path/to/config:/config
@@ -38,30 +54,54 @@ services:
       - 80:80
     depends_on:
       - elasticsearch
+volumes:
+  esdata:
 ```
+
+### Hello World
+1. Start the containers: `docker-compose up -d`.
+2. Access the web UI at `http://localhost`. The default credentials are `diskover` / `darkdata`.
+3. Run your first index: `docker exec -it diskover python3 /app/diskover/diskover.py -i my_first_index /data`.
+4. Refresh the web UI and select the `my_first_index` index in Settings to view your data.
 
 ## CLI examples
 
-You can run indexing tasks manually using the `diskover.py` script inside the container.
+Indexing and management tasks are performed using the `diskover.py` script.
 
 ```bash
-# Run a manual index of the /data directory
-docker exec -it diskover python3 /app/diskover/diskover.py -i my_index_name /data
+# Index a specific directory into a new index
+docker exec -it diskover python3 /app/diskover/diskover.py -i diskover-data /data
 
-# List all current indices in Elasticsearch
+# Run an index task in the background (detached)
+docker exec -d diskover python3 /app/diskover/diskover.py -i diskover-data /data
+
+# List all indices in the Elasticsearch instance
 curl -X GET "http://localhost:9200/_cat/indices?v"
 
-# Remove an old index
-curl -X DELETE "http://localhost:9200/my_old_index"
+# Remove an index from Elasticsearch
+curl -X DELETE "http://localhost:9200/diskover-old-index"
 ```
 
 ## API examples
 
-Diskover stores its data in Elasticsearch, so you can use the Elasticsearch REST API to query Diskover's data.
+Diskover stores its data in Elasticsearch, allowing you to use the standard Elasticsearch REST API for advanced queries.
 
+### Search for files larger than 1GB
 ```bash
-# Search for files larger than 1GB in the diskover index
-curl -X GET "http://localhost:9200/diskover-test/_search?q=filesize:>1073741824&pretty"
+curl -X GET "http://localhost:9200/diskover-data/_search?q=filesize:>1073741824&pretty"
+```
+
+### Python example to query indices
+```python
+import requests
+
+es_url = "http://localhost:9200/_cat/indices?format=json"
+response = requests.get(es_url)
+indices = response.json()
+
+for index in indices:
+    if index['index'].startswith('diskover-'):
+        print(f"Diskover Index: {index['index']}, Documents: {index['docs.count']}")
 ```
 
 ## Backlog
@@ -70,7 +110,7 @@ curl -X GET "http://localhost:9200/diskover-test/_search?q=filesize:>1073741824&
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-01
+- Last reviewed: 2026-03-02
 
 ## Sources / References
 - https://github.com/diskoverdata/diskover-community

--- a/docs/services/homebox.md
+++ b/docs/services/homebox.md
@@ -1,22 +1,35 @@
 # Homebox
 
-Homebox is an inventory and organization system for your home.
+Homebox is an inventory and organization system built specifically for home users, focusing on simplicity, speed, and ease of use.
 
 ## Description
-It is designed to be simple, fast, and easy to use. It helps you keep track of your belongings, where they are, and what they are worth.
+It helps you keep track of your belongings, their locations, warranties, and purchase details. Written in Go, it is extremely lightweight (typically using less than 50MB of RAM) and uses SQLite for portable data management.
 
 ## When to use it
-- When you need a simple, fast inventory system for home use.
-- When you want to track belongings, warranties, and purchase dates without complex overhead.
+- When you need a simple, fast inventory system to track household items.
+- For organizing belongings across multiple locations (e.g., "Garage", "Attic", "Storage Unit").
+- To keep track of warranties, purchase dates, and prices for insurance or maintenance purposes.
+- When you want a self-hosted solution that is easy to backup and move.
 
 ## When not to use it
-- When you need complex multi-user permissions or enterprise-grade asset management.
-- When you require deep integration with e-commerce or point-of-sale systems.
+- When you need complex multi-user permission models or enterprise-grade asset management.
+- When you require deep integration with e-commerce platforms or point-of-sale systems.
+- If you need a system that supports a massive number of concurrent users (it is designed for home/small team use).
+
+## Links
+- [Official Website](https://homebox.software/)
+- [GitHub Repository](https://github.com/sysadminsmedia/homebox)
+- [Live Demo](https://demo.homebox.software/)
+
+## Alternatives
+- [Grocy](grocy.md) (more focused on groceries and meal planning)
+- [Snipe-IT](https://snipeitapp.com/) (Enterprise-grade IT asset management)
+- [Inventory Manager](https://github.com/v-shatkyy/inventory-manager)
 
 ## Getting started
 
 ### Docker
-To run Homebox using Docker:
+The fastest way to run Homebox is using the official Docker image:
 
 ```bash
 docker run -d \
@@ -31,41 +44,54 @@ Access the web interface at `http://localhost:3100`.
 
 ### Hello World
 1. Open `http://localhost:3100` in your browser.
-2. Create an initial account (the first user is the admin).
-3. Go to **Locations** and create a "Main Storage".
-4. Go to **Items** and add "My First Item" to start tracking your inventory.
+2. Create your initial admin account.
+3. Navigate to **Locations** and create a new location called "Living Room".
+4. Go to **Items**, click **Add Item**, and add "Smart TV" to the "Living Room" location.
+5. You've started your inventory!
 
 ## CLI examples
-Management is primarily via the web UI, but you can use `docker exec` for basic tasks:
+While Homebox is primarily managed via its web interface, you can use `docker exec` for basic administrative tasks:
 
 ```bash
-# View container logs
-docker logs homebox
-
-# Check Homebox version
-docker exec homebox /app/homebox --version
-
-# View help for available commands
+# View the help menu for the Homebox binary
 docker exec homebox /app/homebox --help
+
+# Check the version of the running Homebox instance
+docker exec homebox /app/homebox version
+
+# Export the internal database to a SQL file (manual backup)
+docker exec homebox sqlite3 /data/homebox.db .dump > backup.sql
 ```
 
 ## API examples
-Homebox provides a REST API for data interaction. Use a Bearer token if authentication is enabled:
+Homebox provides a REST API for programmatic interaction.
 
+### Health Check
 ```bash
-# Basic health check
 curl -X GET "http://localhost:3100/api/v1/health"
-
-# List items (requires API token)
-curl -H "Authorization: Bearer YOUR_TOKEN" "http://localhost:3100/api/v1/items"
 ```
 
-## Links
-- [GitHub Repository](https://github.com/sysadminsmedia/homebox)
+### List Items (using a Bearer Token)
+If authentication is enabled, you will need to provide an API token:
 
-## Alternatives
-- [Grocy](grocy.md)
-- [Snipe-IT](https://snipeitapp.com/)
+```bash
+curl -H "Authorization: Bearer YOUR_API_TOKEN" \
+     "http://localhost:3100/api/v1/items"
+```
+
+### Python Example
+```python
+import requests
+
+url = "http://localhost:3100/api/v1/items"
+headers = {"Authorization": "Bearer YOUR_API_TOKEN"}
+
+response = requests.get(url, headers=headers)
+if response.status_code == 200:
+    items = response.json()
+    for item in items:
+        print(f"Item: {item['name']}, Location: {item['location']['name']}")
+```
 
 ## Backlog
 - Export data to CSV for insurance purposes.
@@ -73,8 +99,9 @@ curl -H "Authorization: Bearer YOUR_TOKEN" "http://localhost:3100/api/v1/items"
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-01
+- Last reviewed: 2026-03-02
 
 ## Sources / References
 - https://github.com/sysadminsmedia/homebox
+- https://homebox.software/
 - https://snipeitapp.com/

--- a/docs/services/homebox.md
+++ b/docs/services/homebox.md
@@ -24,7 +24,6 @@ It helps you keep track of your belongings, their locations, warranties, and pur
 ## Alternatives
 - [Grocy](grocy.md) (more focused on groceries and meal planning)
 - [Snipe-IT](https://snipeitapp.com/) (Enterprise-grade IT asset management)
-- [Inventory Manager](https://github.com/v-shatkyy/inventory-manager)
 
 ## Getting started
 

--- a/docs/services/kiwix.md
+++ b/docs/services/kiwix.md
@@ -23,7 +23,7 @@ It uses the highly compressed ZIM format to store entire websites or databases i
 ## Alternatives
 - [Internet-in-a-Box](https://internet-in-a-box.org/)
 - [Xowa](http://xowa.org/)
-- [Aard 2](https://aard2.github.io/)
+- [Aard 2](https://github.com/itkach/aard2-android)
 
 ## Getting started
 

--- a/docs/services/kiwix.md
+++ b/docs/services/kiwix.md
@@ -1,25 +1,38 @@
 # Kiwix
 
-Kiwix is an offline content reader.
+Kiwix is an offline content reader that allows you to download and access content like Wikipedia, Wiktionary, and TED talks without an internet connection.
 
 ## Description
-It allows you to download and access content like Wikipedia, Wiktionary, and TED talks without an internet connection. It is highly useful for environments with limited or no internet access.
+It uses the highly compressed ZIM format to store entire websites or databases in a single file. Kiwix is an essential tool for environments with limited or no internet access, such as schools in remote areas, prisons, or for personal archival.
 
 ## When to use it
-- When you need to access large datasets (like Wikipedia) in offline or low-bandwidth environments.
-- For local archival and fast searching of educational or historical content.
+- When you need to access large datasets (like Wikipedia) in offline, low-bandwidth, or censored environments.
+- For local archival and fast searching of educational, medical, or historical content.
+- When traveling or in locations where data costs are prohibitive.
 
 ## When not to use it
-- When you need real-time updates and the latest content.
-- When you require editing capabilities for the content.
+- When you need real-time updates and the latest content (ZIM files are snapshots).
+- When you require editing capabilities for the content (it is a reader, not an editor).
+- If you have very limited disk space, as full Wikipedia ZIM files can be very large (tens of GB).
+
+## Links
+- [Official Website](https://www.kiwix.org/)
+- [Kiwix Get (Downloads)](https://get.kiwix.org/)
+- [GitHub Repository (Kiwix Tools)](https://github.com/kiwix/kiwix-tools)
+
+## Alternatives
+- [Internet-in-a-Box](https://internet-in-a-box.org/)
+- [Xowa](http://xowa.org/)
+- [Aard 2](https://aard2.github.io/)
 
 ## Getting started
 
 ### Docker
-To serve a single `.zim` file using `kiwix-serve` in Docker:
+The easiest way to serve a ZIM file using `kiwix-serve` in Docker:
 
 ```bash
 docker run -d \
+  --name kiwix \
   -p 8080:80 \
   -v /path/to/zims:/data \
   ghcr.io/kiwix/kiwix-serve wikipedia_en_all_maxi_2024-01.zim
@@ -27,40 +40,61 @@ docker run -d \
 
 Access the content at `http://localhost:8080`.
 
+### Local Installation (Linux)
+You can download pre-compiled binaries from the [releases page](https://download.kiwix.org/release/kiwix-tools/).
+
+```bash
+# Download and extract the tools
+curl -L https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-x86_64.tar.gz | tar xz
+cd kiwix-tools_*
+
+# Run the server directly
+./kiwix-serve --port=8080 /path/to/your_content.zim
+```
+
 ### Hello World
-1. Download a small `.zim` file from the [official Kiwix Wikipedia catalog](https://download.kiwix.org/zim/wikipedia/).
-2. Place it in `/path/to/zims`.
-3. Start the container with that filename.
+1. Download a small `.zim` file (e.g., a "mini" version or a specific Wiktionary) from the [official Kiwix Wikipedia catalog](https://download.kiwix.org/zim/wikipedia/).
+2. Place it in a directory (e.g., `/home/user/zims`).
+3. Start the Kiwix server using the Docker command above, replacing the filename with your downloaded ZIM.
 4. Navigate to `http://localhost:8080` to read the offline content.
 
 ## CLI examples
-The `kiwix-manage` tool allows you to manage library XML files:
+The `kiwix-tools` package includes several utilities:
 
 ```bash
-# Create a new library file
-kiwix-manage /data/library.xml add /data/wikipedia.zim
+# Serve multiple ZIM files using a library file
+kiwix-serve --port=8080 --library /data/library.xml
 
-# Remove a zim file from the library
-kiwix-manage /data/library.xml remove wikipedia
+# Manage an XML-based library (add a new ZIM)
+kiwix-manage /data/library.xml add /data/new_content.zim
 
-# List all files in a ZIM archive
-kiwix-search --list /data/wikipedia.zim
+# Search for a term across a ZIM file from the command line
+kiwix-search /data/wikipedia.zim "Quantum Physics"
 ```
 
 ## API examples
-Kiwix-serve provides an OPDS catalog and a basic API for library exploration:
+`kiwix-serve` provides an OPDS (Open Publication Distribution System) catalog and a basic search API.
 
+### Fetch the OPDS Catalog
 ```bash
-# Fetch library information in OPDS format
 curl -X GET "http://localhost:8080/catalog.xml"
 ```
 
-## Links
-- [Official Website](https://www.kiwix.org/)
-- [GitHub Repository](https://github.com/kiwix/kiwix-tools)
+### Search via API (if supported by the ZIM)
+```bash
+curl -G "http://localhost:8080/search" --data-urlencode "content=wikipedia" --data-urlencode "pattern=Einstein"
+```
 
-## Alternatives
-- [Internet-in-a-Box](https://internet-in-a-box.org/)
+### Python Example
+```python
+import requests
+
+# Fetch the library information in XML format
+response = requests.get("http://localhost:8080/catalog.xml")
+if response.status_code == 200:
+    print("Kiwix Library Catalog:")
+    print(response.text[:500] + "...")
+```
 
 ## Backlog
 - Set up automated downloads for new ZIM files.
@@ -68,7 +102,7 @@ curl -X GET "http://localhost:8080/catalog.xml"
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-01
+- Last reviewed: 2026-03-02
 
 ## Sources / References
 - https://www.kiwix.org/

--- a/docs/services/plex.md
+++ b/docs/services/plex.md
@@ -1,21 +1,35 @@
 # Plex
 
-Plex is a global streaming media service and a media player platform.
+Plex is a global streaming media service and a media player platform that organizes your video, music, and photos from your personal libraries and streams them to all your devices.
 
 ## Description
-It organizes your video, music, and photos from your personal libraries and streams them to all your devices. While it is not fully open-source, it is a highly popular and feature-rich media server solution.
+While it is not fully open-source, Plex is one of the most popular and feature-rich media server solutions. It consists of the Plex Media Server, which hosts your content, and various Plex apps that allow you to play that content on smart TVs, mobile devices, and web browsers.
+
+## When to use it
+- When you want a polished, user-friendly interface for managing and streaming your personal media collection.
+- To access your media library remotely from anywhere in the world.
+- When you want to share your media library with friends or family members.
+- If you value features like automatic metadata fetching, transcode support, and cross-platform compatibility.
+
+## When not to use it
+- If you strictly require 100% open-source software (consider [Jellyfin](jellyfin.md)).
+- If you don't want to rely on a central authentication server (Plex requires an account on plex.tv for most features).
+- In environments with no internet access (Plex can be configured for offline use, but it is not its primary design).
 
 ## Links
 - [Official Website](https://www.plex.tv/)
+- [Plex Media Server Downloads](https://www.plex.tv/media-server-downloads/)
+- [Plex Support Articles](https://support.plex.tv/articles/)
 
 ## Alternatives
-- [Jellyfin](jellyfin.md)
-- [Emby](https://emby.media/)
+- [Jellyfin](jellyfin.md) (Fully open-source)
+- [Emby](https://emby.media/) (Proprietary, but often seen as a middle ground)
+- [Kodi](https://kodi.tv/) (Local playback focused)
 
 ## Getting started
 
 ### Docker installation
-The most common way to host Plex is via Docker. Replace placeholders with your actual paths and a [Plex Claim Token](https://www.plex.tv/claim/).
+The most common way to host Plex is via Docker. You will need a [Plex Claim Token](https://www.plex.tv/claim/) to associate the server with your account.
 
 ```bash
 docker run -d \
@@ -32,31 +46,56 @@ docker run -d \
   linuxserver/plex
 ```
 
+Access the web interface at `http://localhost:32400/web`.
+
+### Hello World
+1. Start the Plex Docker container.
+2. Open `http://localhost:32400/web` in your browser and sign in.
+3. Follow the setup wizard to name your server.
+4. Click **Add Library**, choose **Movies**, and point it to the `/data/movies` directory.
+5. Add a single movie file to that directory and watch Plex automatically fetch the poster and metadata.
+
 ## CLI examples
 
-Plex provides the `Plex Media Scanner` for command-line library management. On Linux/Docker, you can execute it within the container:
+Plex provides the `Plex Media Scanner` for command-line library management. In a Docker environment, you execute it within the container.
 
 ```bash
-# List all libraries (sections)
+# List all configured library sections
 docker exec -it plex "/usr/lib/plexmediaserver/Plex Media Scanner" --list
 
-# Scan a specific library (replace <id> with the section number)
+# Scan a specific library section to find new files (replace <id> with the section number)
 docker exec -it plex "/usr/lib/plexmediaserver/Plex Media Scanner" --scan --section <id>
 
-# Refresh metadata for a specific library
+# Update metadata for all items in a specific library
 docker exec -it plex "/usr/lib/plexmediaserver/Plex Media Scanner" --refresh --section <id>
 ```
 
 ## API examples
 
-Plex exposes a REST API on port 32400. You need a `X-Plex-Token` for authentication.
+Plex exposes a REST API on port 32400. You need a `X-Plex-Token` for most requests.
 
+### Get Server Identity and Version
 ```bash
-# Get all library sections in XML format
-curl -X GET "http://localhost:32400/library/sections?X-Plex-Token=YOUR_PLEX_TOKEN"
-
-# Get server identity and version
 curl -X GET "http://localhost:32400/identity"
+```
+
+### List All Libraries (Sections)
+```bash
+curl -X GET "http://localhost:32400/library/sections?X-Plex-Token=YOUR_PLEX_TOKEN"
+```
+
+### Python Example (using plexapi)
+The `plexapi` library is the recommended way to interact with Plex via Python.
+
+```python
+from plexapi.server import PlexServer
+
+baseurl = 'http://localhost:32400'
+token = 'YOUR_PLEX_TOKEN'
+plex = PlexServer(baseurl, token)
+
+for section in plex.library.sections():
+    print(f"Library: {section.title}, Type: {section.type}")
 ```
 
 ## Backlog
@@ -65,7 +104,7 @@ curl -X GET "http://localhost:32400/identity"
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-01
+- Last reviewed: 2026-03-02
 
 ## Sources / References
 - https://www.plex.tv/

--- a/docs/services/tika.md
+++ b/docs/services/tika.md
@@ -3,14 +3,27 @@
 The Apache Tika toolkit detects and extracts metadata and text from over a thousand different file types.
 
 ## Description
-It is useful for content analysis, search indexing, and automated document processing.
+It is useful for content analysis, search indexing, and automated document processing. It provides a single interface for parsing all these file types, making it a cornerstone for many search engines and content analysis tools.
+
+## When to use it
+- When you need to extract text and metadata from a wide variety of file formats (PPT, XLS, PDF, etc.).
+- For search engine indexing where you need consistent output across different document types.
+- For content analysis, translation, and language detection tasks.
+- When building automated document processing pipelines.
+
+## When not to use it
+- If you only need to process a single, specific format and a lightweight, specialized library exists (e.g., just plain text).
+- In extremely memory-constrained environments, as the Java-based Tika server can be resource-intensive.
+- If you require the highest possible OCR accuracy and speed, specialized OCR engines may be more appropriate (though Tika integrates with Tesseract).
 
 ## Links
 - [Official Website](https://tika.apache.org/)
+- [Tika Wiki](https://cwiki.apache.org/confluence/display/tika)
 
 ## Alternatives
 - [Textract](https://aws.amazon.com/textract/) (AWS)
 - [Unstructured.io](https://unstructured.io/)
+- [Pandoc](https://pandoc.org/) (mainly for document conversion)
 
 ## Getting started
 
@@ -23,18 +36,29 @@ docker run -d -p 9998:9998 --name tika apache/tika
 
 Tika will be available at `http://localhost:9998`.
 
+### Java Application (CLI)
+You can also use the Tika application jar for local processing without a server:
+
+```bash
+# Download the latest tika-app jar
+curl -O https://archive.apache.org/dist/tika/2.9.2/tika-app-2.9.2.jar
+
+# Run it against a file
+java -jar tika-app-2.9.2.jar --text document.pdf
+```
+
 ### Hello World
-1. Ensure the container is running: `docker ps | grep tika`
-2. Create a test file: `echo "Hello World" > test.txt`
-3. Send it to Tika: `curl -T test.txt http://localhost:9998/tika`
-4. Tika should return the extracted text: `Hello World`
+1. Ensure the Tika Docker container is running: `docker ps | grep tika`
+2. Create a test file: `echo "Hello Tika World" > test.txt`
+3. Send it to Tika's REST API: `curl -T test.txt http://localhost:9998/tika`
+4. Tika should return the extracted text: `Hello Tika World`
 
 ## CLI examples
 
-You can use the Tika Server's REST API via `curl` for command-line processing.
+You can use the Tika Server's REST API via `curl` or use the `tika-app` JAR for command-line processing.
 
 ```bash
-# Extract text from a local PDF file
+# Extract text from a local PDF file using Tika Server
 curl -T document.pdf http://localhost:9998/tika
 
 # Extract metadata from a local document in JSON format
@@ -43,14 +67,15 @@ curl -H "Accept: application/json" -T document.docx http://localhost:9998/meta
 # Detect the MIME type of a file
 curl -T image.png http://localhost:9998/detect/stream
 
-# List all available parsers
-curl http://localhost:9998/parsers
+# List all available parsers (using tika-app)
+java -jar tika-app.jar --list-parsers
 ```
 
 ## API examples
 
-You can interact with the Tika Server using any HTTP client. Here is a Python example using the `requests` library:
+You can interact with the Tika Server using any HTTP client.
 
+### Python (using requests)
 ```python
 import requests
 
@@ -63,13 +88,20 @@ with open("document.pdf", "rb") as f:
 print(response.text)
 ```
 
+### Recursive Metadata (curl)
+The `/rmeta` endpoint is powerful for getting metadata and text from both the container and all embedded documents (e.g., images inside a Word doc).
+
+```bash
+curl -T document.docx http://localhost:9998/rmeta/text --header "Accept: application/json"
+```
+
 ## Backlog
 - Integrate with n8n for automated PDF-to-Markdown conversion.
 
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-01
+- Last reviewed: 2026-03-02
 
 ## Sources / References
 - https://tika.apache.org/


### PR DESCRIPTION
This PR improves the documentation for five "shallow" service docs identified in the growth metrics: Tika, Diskover, Homebox, Kiwix, and Plex. Each document now features comprehensive "Getting started" guides, practical CLI examples, and minimal API code snippets, researched from official sources.

---
*PR created automatically by Jules for task [10192890828350474421](https://jules.google.com/task/10192890828350474421) started by @joanmarcriera*