### PR TITLE
Integrate GNU Make, Tesseract CLI, and Joplin

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -1366,6 +1366,24 @@
       "name": "Docker",
       "category": "Infrastructure",
       "doc_path": "docs/tools/infrastructure/docker.md"
+    },
+    {
+      "id": "gnu-make",
+      "name": "GNU Make",
+      "category": "Automation & Orchestration",
+      "doc_path": "docs/tools/automation_orchestration/gnu-make.md"
+    },
+    {
+      "id": "tesseract",
+      "name": "Tesseract CLI",
+      "category": "Process & Understanding",
+      "doc_path": "docs/tools/process_understanding/tesseract.md"
+    },
+    {
+      "id": "joplin",
+      "name": "Joplin",
+      "category": "AI Assistants & Knowledge",
+      "doc_path": "docs/tools/ai_knowledge/joplin.md"
     }
   ]
 }

--- a/docs/new-sources/2026-03-19.md
+++ b/docs/new-sources/2026-03-19.md
@@ -5,7 +5,7 @@
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | Docling | https://github.com/DS4SD/docling | tool | integrated | [docling](../tools/process_understanding/docling.md) | Discovered in docs/tools/process_understanding/docling-mcp.md |
 | Milvus | https://milvus.io/ | tool | new | TBD | Discovered in docs/tools/process_understanding/docling-mcp.md |
-| Tesseract CLI | https://github.com/tesseract-ocr/tesseract | tool | new | TBD | Discovered in docs/tools/process_understanding/ocrmypdf.md |
+| Tesseract CLI | https://github.com/tesseract-ocr/tesseract | tool | integrated | [tesseract](../tools/process_understanding/tesseract.md) | Discovered in docs/tools/process_understanding/ocrmypdf.md |
 | Amazon Textract | https://aws.amazon.com/textract/ | tool | new | TBD | Discovered in docs/tools/process_understanding/ocrmypdf.md |
 
 ## Development & Ops

--- a/docs/new-sources/2026-03-21.md
+++ b/docs/new-sources/2026-03-21.md
@@ -6,7 +6,7 @@
 | Playwright MCP Server | https://github.com/microsoft/playwright-mcp | tool | integrated | [playwright-mcp](../tools/automation_orchestration/playwright-mcp.md) | Discovered in docs/tools/automation_orchestration/browser-use.md |
 | HashiCorp Vault | https://www.vaultproject.io/ | tool | integrated | [hashicorp-vault](../tools/automation_orchestration/hashicorp-vault.md) | Discovered in docs/tools/automation_orchestration/vault-mcp.md |
 | hvac (Python Vault Client) | https://github.com/hvac/hvac | tool | new | TBD | Discovered in docs/tools/automation_orchestration/vault-mcp.md |
-| GNU Make | https://www.gnu.org/software/make/ | tool | new | TBD | Discovered in docs/tools/automation_orchestration/makefile-mcp.md |
+| GNU Make | https://www.gnu.org/software/make/ | tool | integrated | [gnu-make](../tools/automation_orchestration/gnu-make.md) | Discovered in docs/tools/automation_orchestration/makefile-mcp.md |
 | PulseMCP | https://pulsemcp.com/ | tool | new | TBD | Discovered in docs/tools/automation_orchestration/mcp-registry.md |
 | Chronos CalDAV library | https://github.com/democratize-technology/chronos-mcp | tool | new | TBD | Discovered in docs/tools/automation_orchestration/chronos-mcp.md |
 
@@ -14,7 +14,7 @@
 | Title | URL | Tags | Status | Canonical Page | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | Roam Research | https://roamresearch.com/ | tool | new | TBD | Discovered in docs/tools/ai_knowledge/logseq.md |
-| Joplin | https://joplinapp.org/ | tool | new | TBD | Discovered in docs/tools/ai_knowledge/obsidian.md |
+| Joplin | https://joplinapp.org/ | tool | integrated | [joplin](../tools/ai_knowledge/joplin.md) | Discovered in docs/tools/ai_knowledge/obsidian.md |
 | Google Search | https://www.google.com | tool | new | TBD | Discovered in docs/tools/ai_knowledge/perplexity.md |
 | Genspark | https://www.genspark.ai/ | tool | new | TBD | Discovered in docs/tools/ai_knowledge/perplexity.md |
 | Natural Language Inference | https://huggingface.co/models?pipeline_tag=zero-shot-classification | tool | integrated | [Hugging Face Hub](../tools/providers/huggingface.md) | Discovered in docs/tools/development_ops/axiom-guardian.md |

--- a/docs/new-sources/2026-03-30.md
+++ b/docs/new-sources/2026-03-30.md
@@ -18,7 +18,7 @@
 | EvalPlus | https://github.com/evalplus/evalplus?update=2026-03-30 | repository | new | [mbpp](../tools/benchmarking/mbpp.md) | Identified as related tool/concept in mbpp.md. |
 | FastAPI | https://fastapi.tiangolo.com/?update=2026-03-30 | tool | integrated | [fastapi](../tools/frameworks/fastapi.md) | Identified as related tool/concept in agno.md. |
 | FastMCP | https://github.com/jlowin/fastmcp?update=2026-03-30 | repository | new | [jupyter-kernel-mcp](../tools/development_ops/jupyter-kernel-mcp.md) | Identified as related tool/concept in jupyter-kernel-mcp.md. |
-| GNU Make | https://www.gnu.org/software/make/?update=2026-03-30 | tool | new | [makefile-mcp](../tools/automation_orchestration/makefile-mcp.md) | Identified as related tool/concept in makefile-mcp.md. |
+| GNU Make | https://www.gnu.org/software/make/?update=2026-03-30 | tool | integrated | [gnu-make](../tools/automation_orchestration/gnu-make.md) | Identified as related tool/concept in makefile-mcp.md. |
 | GPTQ | https://github.com/IST-DASLab/gptq?update=2026-03-30 | repository | new | [exllamav2](../tools/infrastructure/exllamav2.md) | Identified as related tool/concept in exllamav2.md. |
 | Gemini | https://gemini.google.com/?update=2026-03-30 | tool | integrated | [gemini](../tools/ai_knowledge/gemini.md) | Identified as related tool/concept in chatgpt.md. |
 | Genspark | https://www.genspark.ai/?update=2026-03-30 | tool | new | [perplexity](../tools/ai_knowledge/perplexity.md) | Identified as related tool/concept in perplexity.md. |
@@ -31,7 +31,7 @@
 | Hugging Face Hub | https://huggingface.co/models?update=2026-03-30 | model-hub | new | [smolagents](../tools/frameworks/smolagents.md) | Identified as related tool/concept in smolagents.md. |
 | Hypothesis | https://hypothesis.works/?update=2026-03-30 | tool | new | [fuzzing-mcp-server](../tools/development_ops/fuzzing-mcp-server.md) | Identified as related tool/concept in fuzzing-mcp-server.md. |
 | InterCode | https://github.com/princeton-nlp/intercode?update=2026-03-30 | repository | new | [terminal-bench](../tools/benchmarking/terminal-bench.md) | Identified as related tool/concept in terminal-bench.md. |
-| Joplin | https://joplinapp.org/?update=2026-03-30 | tool | new | [obsidian](../tools/ai_knowledge/obsidian.md) | Identified as related tool/concept in obsidian.md. |
+| Joplin | https://joplinapp.org/?update=2026-03-30 | tool | integrated | [joplin](../tools/ai_knowledge/joplin.md) | Identified as related tool/concept in obsidian.md. |
 | Jupyter | https://jupyter.org/?update=2026-03-30 | tool | new | [jupyter-kernel-mcp](../tools/development_ops/jupyter-kernel-mcp.md) | Identified as related tool/concept in jupyter-kernel-mcp.md. |
 | LangFlow | https://github.com/langflow-ai/langflow?update=2026-03-30 | repository | new | [dify](../tools/ai_knowledge/dify.md) | Identified as related tool/concept in dify.md. |
 | Lens | https://k8slens.dev/?update=2026-03-30 | tool | new | [cloud_code](../tools/development_ops/cloud_code.md) | Identified as related tool/concept in cloud_code.md. |
@@ -57,7 +57,7 @@
 | Skaffold | https://skaffold.dev/?update=2026-03-30 | tool | new | [cloud_code](../tools/development_ops/cloud_code.md) | Identified as related tool/concept in cloud_code.md. |
 | Sora (OpenAI) | https://openai.com/sora | tool | new | [runwayml](../tools/ai_knowledge/runwayml.md) | Identified as related tool/concept in runwayml.md. |
 | StarCoder | https://github.com/bigcode-project/starcoder?update=2026-03-30 | repository | new | [codex](../tools/development_ops/codex.md) | Identified as related tool/concept in codex.md. |
-| Tesseract CLI | https://github.com/tesseract-ocr/tesseract?update=2026-03-30 | repository | new | [ocrmypdf](../tools/process_understanding/ocrmypdf.md) | Identified as related tool/concept in ocrmypdf.md. |
+| Tesseract CLI | https://github.com/tesseract-ocr/tesseract?update=2026-03-30 | repository | integrated | [tesseract](../tools/process_understanding/tesseract.md) | Identified as related tool/concept in ocrmypdf.md. |
 | Z3 Solver | https://github.com/Z3Prover/z3?update=2026-03-30 | repository | integrated | [symbolic-mcp](../tools/development_ops/symbolic-mcp.md) | Identified as related tool/concept in symbolic-mcp.md. |
 | asteval | https://github.com/newville/asteval?update=2026-03-30 | repository | new | [fuzzing-mcp-server](../tools/development_ops/fuzzing-mcp-server.md) | Identified as related tool/concept in fuzzing-mcp-server.md. |
 | hvac (Python Vault Client) | https://github.com/hvac/hvac?update=2026-03-30 | repository | integrated | [vault-mcp](../tools/automation_orchestration/vault-mcp.md) | Identified as related tool/concept in vault-mcp.md. |

--- a/docs/tools/ai_knowledge/joplin.md
+++ b/docs/tools/ai_knowledge/joplin.md
@@ -1,0 +1,51 @@
+# Joplin
+
+## What it is
+Joplin is a free, open-source note-taking and to-do application, which can handle a large number of notes organized into notebooks.
+
+## What problem it solves
+It provides a secure, private way to sync notes across multiple devices (desktop and mobile) using various cloud or self-hosted services (Nextcloud, Dropbox, WebDAV, etc.). It supports end-to-end encryption (E2EE).
+
+## Where it fits in the stack
+**Tool / AI Assistants & Knowledge**. It serves as a privacy-focused knowledge management and note-taking tool.
+
+## Typical use cases
+- Organizing personal and professional notes in a structured notebook format.
+- Capturing web pages and screenshots using the web clipper extension.
+- Syncing notes across devices with E2EE for maximum privacy.
+
+## Strengths
+- **Privacy**: Strong E2EE and support for various sync targets (including self-hosted).
+- **Format**: Notes are stored in Markdown format.
+- **Extensibility**: Support for plugins and themes.
+- **Web Clipper**: Powerful extension for capturing online content.
+
+## Limitations
+- **Sync Conflict Resolution**: Can sometimes be less intuitive than cloud-native alternatives like Notion.
+- **UI**: While functional, the UI might feel less "polished" to some users compared to proprietary tools.
+
+## When to use it
+- When you need a cross-platform, open-source note-taking app with strong privacy features.
+- When you want to host your own note synchronization (e.g., using Nextcloud).
+
+## When not to use it
+- When real-time, multi-user collaboration is the primary requirement.
+- When you prefer the "canvas" or "block" based approach of tools like Obsidian or Notion.
+
+## Licensing and cost
+- **Open Source**: Yes (MIT)
+- **Cost**: Free
+- **Self-hostable**: Yes (sync targets can be self-hosted)
+
+## Related tools / concepts
+- [Obsidian](obsidian.md)
+- [Logseq](logseq.md)
+- [Trilium Notes](../../services/trilium.md)
+
+## Sources / References
+- [Official Website](https://joplinapp.org/)
+- [Joplin GitHub](https://github.com/laurent22/joplin)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-06
+- Confidence: high

--- a/docs/tools/ai_knowledge/obsidian.md
+++ b/docs/tools/ai_knowledge/obsidian.md
@@ -35,7 +35,7 @@ AI & Knowledge — serves as a personal knowledge management tool that stores da
 ## Related tools / concepts
 
 - [Logseq](logseq.md)
-- [Joplin](https://joplinapp.org/)
+- [Joplin](joplin.md)
 - [AI Templates](aitmpl.md)
 - [Google Gemini](google-gemini.md)
 - [Google Opal](google-opal.md)

--- a/docs/tools/automation_orchestration/gnu-make.md
+++ b/docs/tools/automation_orchestration/gnu-make.md
@@ -1,0 +1,52 @@
+# GNU Make
+
+## What it is
+GNU Make is a tool which controls the generation of executables and other non-source files of a program from the program's source files. It uses a file called a `Makefile` to determine how to build the target programs.
+
+## What problem it solves
+It automatically determines which pieces of a large program need to be recompiled, and issues commands to recompile them. This saves time and ensures that the software is always built correctly according to the latest source changes.
+
+## Where it fits in the stack
+**Tool / Automation**. It provides a foundational layer for automating build processes and task execution within a project.
+
+## Typical use cases
+- Compiling source code into executables or libraries.
+- Automating repetitive tasks like linting, testing, and deployment.
+- Managing complex dependencies between files and processes.
+
+## Strengths
+- **Ubiquitous**: Pre-installed on almost all Unix-like systems.
+- **Dependency Tracking**: Intelligent enough to only run necessary commands based on file modification times.
+- **Language Agnostic**: Can be used with any programming language or toolchain.
+
+## Limitations
+- **Syntax**: Strict and sometimes confusing syntax (e.g., the requirement for tabs instead of spaces).
+- **Debugging**: Can be difficult to debug complex `Makefiles`.
+- **Portability**: While GNU Make is common, slight variations in `make` versions (like BSD Make) can lead to portability issues.
+
+## When to use it
+- When you need a standard, reliable way to automate build and task pipelines.
+- For managing projects with multiple interdependent components.
+
+## When not to use it
+- For very simple, single-step tasks where a basic shell script is sufficient.
+- When a language-specific build tool (like `npm` for Node.js or `cargo` for Rust) provides a more integrated experience for the entire workflow.
+
+## Licensing and cost
+- **Open Source**: Yes (GPLv3)
+- **Cost**: Free
+- **Self-hostable**: Yes (runs locally)
+
+## Related tools / concepts
+- [Makefile MCP](makefile-mcp.md)
+- [n8n](../../services/n8n.md)
+- [Make (formerly Integromat)](make.md)
+
+## Sources / References
+- [GNU Make Official Site](https://www.gnu.org/software/make/)
+- [GNU Make Documentation](https://www.gnu.org/software/make/manual/make.html)
+- [Makefile Tutorial](https://makefiletutorial.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-06
+- Confidence: high

--- a/docs/tools/automation_orchestration/makefile-mcp.md
+++ b/docs/tools/automation_orchestration/makefile-mcp.md
@@ -38,7 +38,7 @@ Traditional Makefile MCP implementations often expose a single generic `make` to
 - **Self-hostable**: Yes
 
 ## Related tools / concepts
-- [GNU Make](https://www.gnu.org/software/make/)
+- [GNU Make](gnu-make.md)
 - [Model Context Protocol](../../knowledge_base/agent_protocols.md)
 - [FastMCP](https://github.com/jlowin/fastmcp)
 

--- a/docs/tools/process_understanding/ocrmypdf.md
+++ b/docs/tools/process_understanding/ocrmypdf.md
@@ -57,7 +57,7 @@ done
 
 ## Related tools / concepts
 - [Paperless AI](../../services/paperless-ai.md)
-- [Tesseract CLI](https://github.com/tesseract-ocr/tesseract)
+- [Tesseract CLI](tesseract.md)
 - [Amazon Textract](https://aws.amazon.com/textract/)
 
 ## Sources / references

--- a/docs/tools/process_understanding/tesseract.md
+++ b/docs/tools/process_understanding/tesseract.md
@@ -1,0 +1,51 @@
+# Tesseract CLI
+
+## What it is
+Tesseract is an open-source Optical Character Recognition (OCR) engine. It can be used directly via the command line (CLI) to extract text from images and PDF files.
+
+## What problem it solves
+It converts images containing text (like scans or screenshots) into machine-readable text. This is a critical component for searchable document archives and automated data extraction.
+
+## Where it fits in the stack
+**Tool / Process & Understanding**. It serves as the core OCR engine for higher-level tools like OCRmyPDF and document management systems.
+
+## Typical use cases
+- Extracting text from scanned documents and images.
+- Powering automated workflows that require text analysis of image-based inputs.
+- Batch processing images for archival and indexing.
+
+## Strengths
+- **Language Support**: Supports over 100 languages out of the box.
+- **Accuracy**: Highly accurate for clean, high-resolution scans.
+- **Extensibility**: Can be trained to recognize new fonts or languages.
+
+## Limitations
+- **Format Support**: Requires external tools (like Leptonica) for many image formats and PDF processing (often handled by wrappers like OCRmyPDF).
+- **Complex Layouts**: Can struggle with multi-column layouts or complex formatting without pre-processing.
+- **Handwriting**: Generally not suited for handwritten text recognition.
+
+## When to use it
+- When you need a robust, open-source OCR engine for local processing.
+- When you are building custom automation that needs to "read" images.
+
+## When not to use it
+- For handwritten documents (consider specialized AI models).
+- When a higher-level wrapper like OCRmyPDF is available for PDF-specific tasks.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [OCRmyPDF](ocrmypdf.md)
+- [Docling](docling.md)
+- [Amazon Textract](https://aws.amazon.com/textract/)
+
+## Sources / References
+- [Tesseract OCR GitHub](https://github.com/tesseract-ocr/tesseract)
+- [Tesseract Documentation](https://tesseract-ocr.github.io/)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-06
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
       - Flowise: tools/ai_knowledge/flowise.md
       - Gemini Canvas: tools/ai_knowledge/gemini-canvas.md
       - Jasper: tools/ai_knowledge/jasper.md
+      - Joplin: tools/ai_knowledge/joplin.md
       - Jules: tools/ai_knowledge/jules.md
       - Langchain: tools/ai_knowledge/langchain.md
       - Llamaindex: tools/ai_knowledge/llamaindex.md
@@ -181,6 +182,7 @@ nav:
       - Chronos MCP: tools/automation_orchestration/chronos-mcp.md
       - CliHub: tools/automation_orchestration/clihub.md
       - Google Workspace CLI: tools/automation_orchestration/google-workspace-cli.md
+      - GNU Make: tools/automation_orchestration/gnu-make.md
       - Make: tools/automation_orchestration/make.md
       - Makefile MCP: tools/automation_orchestration/makefile-mcp.md
       - MCP Registry: tools/automation_orchestration/mcp-registry.md
@@ -331,6 +333,7 @@ nav:
       - Overview: tools/process_understanding/index.md
       - Docling MCP: tools/process_understanding/docling-mcp.md
       - OCRmypdf: tools/process_understanding/ocrmypdf.md
+      - Tesseract CLI: tools/process_understanding/tesseract.md
       - Crawl4AI: tools/process_understanding/crawl4ai.md
       - Firecrawl: tools/process_understanding/firecrawl.md
       - PageIndex: tools/process_understanding/pageindex.md


### PR DESCRIPTION
This PR integrates three tools that were previously in the 'new' state in the intake logs:

1. **GNU Make**: Added documentation and updated references in `makefile-mcp.md`.
2. **Tesseract CLI**: Added documentation and updated references in `ocrmypdf.md`.
3. **Joplin**: Added documentation and updated references in `obsidian.md`.

All tools have been registered in `data/all_tools.json` and added to the `mkdocs.yml` navigation. The status in the relevant daily logs in `docs/new-sources/` has been updated to `integrated`.

---
*PR created automatically by Jules for task [1684364262218323960](https://jules.google.com/task/1684364262218323960) started by @joanmarcriera*