### PR TITLE
Ralph-loop: Knowledge Base and Roadmap Improvements

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -612,6 +612,12 @@
       "doc_path": "docs/tools/benchmarking/chatbot-arena.md"
     },
     {
+      "id": "mmlu",
+      "name": "MMLU",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/mmlu.md"
+    },
+    {
       "id": "actual-budget",
       "name": "Actual Budget",
       "category": "Intake & Storage",
@@ -1144,6 +1150,12 @@
       "name": "Tavily",
       "category": "Providers",
       "doc_path": "docs/tools/providers/tavily.md"
+    },
+    {
+      "id": "aws-bedrock",
+      "name": "AWS Bedrock",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/aws-bedrock.md"
     },
     {
       "id": "supabase",

--- a/docs/new-sources/2026-03-30.md
+++ b/docs/new-sources/2026-03-30.md
@@ -4,7 +4,7 @@
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | ARC (AI2 Reasoning Challenge) | https://github.com/allenai/ARC-benchmark?update=2026-03-30 | benchmark | new | [gpqa](../tools/benchmarking/gpqa.md) | Identified as related tool/concept in gpqa.md. |
 | ASDiv | https://github.com/chiahsuan/ASDiv?update=2026-03-30 | repository | new | [gsm8k](../tools/benchmarking/gsm8k.md) | Identified as related tool/concept in gsm8k.md. |
-| AWS Bedrock | https://aws.amazon.com/bedrock/?update=2026-03-30 | tool | new | [claude-code-container-mcp](../tools/development_ops/claude-code-container-mcp.md) | Identified as related tool/concept in claude-code-container-mcp.md. |
+| AWS Bedrock | https://aws.amazon.com/bedrock/?update=2026-03-30 | tool | integrated | [aws-bedrock](../tools/providers/aws-bedrock.md) | Identified as related tool/concept in claude-code-container-mcp.md. |
 | AlpacaEval | https://github.com/tatsu-lab/alpaca_eval?update=2026-03-30 | repository | new | [chatbot-arena](../tools/benchmarking/chatbot-arena.md) | Identified as related tool/concept in chatbot-arena.md. |
 | Amazon Textract | https://aws.amazon.com/textract/?update=2026-03-30 | tool | new | [ocrmypdf](../tools/process_understanding/ocrmypdf.md) | Identified as related tool/concept in ocrmypdf.md. |
 | Apple Silicon | https://www.apple.com/silicon/?update=2026-03-30 | tool | new | [mlx](../tools/infrastructure/mlx.md) | Identified as related tool/concept in mlx.md. |
@@ -12,9 +12,9 @@
 | Chronos CalDAV library | https://github.com/democratize-technology/chronos-mcp?update=2026-03-30 | repository | new | [chronos-mcp](../tools/automation_orchestration/chronos-mcp.md) | Identified as related tool/concept in chronos-mcp.md. |
 | Claude | https://claude.ai/?update=2026-03-30 | tool | integrated | [chatgpt](../tools/ai_knowledge/chatgpt.md) | Identified as related tool/concept in chatgpt.md. |
 | CrossHair | https://github.com/pschanely/CrossHair?update=2026-03-30 | repository | new | [symbolic-mcp](../tools/development_ops/symbolic-mcp.md) | Identified as related tool/concept in symbolic-mcp.md. |
-| Devin | https://cognition.ai/?update=2026-03-30 | tool | new | [terminus-2](../tools/development_ops/terminus-2.md) | Identified as related tool/concept in terminus-2.md. |
+| Devin | https://cognition.ai/?update=2026-03-30 | tool | integrated | [devin](../tools/development_ops/devin.md) | Identified as related tool/concept in terminus-2.md. |
 | Docker | https://www.docker.com/?update=2026-03-30 | tool | integrated | [docker](../tools/infrastructure/docker.md) | Identified as related tool/concept in claude-code-container-mcp.md. |
-| Docling | https://github.com/DS4SD/docling?update=2026-03-30 | repository | new | [docling-mcp](../tools/process_understanding/docling-mcp.md) | Identified as related tool/concept in docling-mcp.md. |
+| Docling | https://github.com/DS4SD/docling?update=2026-03-30 | repository | integrated | [docling](../tools/process_understanding/docling.md) | Identified as related tool/concept in docling-mcp.md. |
 | EvalPlus | https://github.com/evalplus/evalplus?update=2026-03-30 | repository | new | [mbpp](../tools/benchmarking/mbpp.md) | Identified as related tool/concept in mbpp.md. |
 | FastAPI | https://fastapi.tiangolo.com/?update=2026-03-30 | tool | integrated | [fastapi](../tools/frameworks/fastapi.md) | Identified as related tool/concept in agno.md. |
 | FastMCP | https://github.com/jlowin/fastmcp?update=2026-03-30 | repository | new | [jupyter-kernel-mcp](../tools/development_ops/jupyter-kernel-mcp.md) | Identified as related tool/concept in jupyter-kernel-mcp.md. |
@@ -38,8 +38,8 @@
 | Llama 3 (Fine-tuned for code) | https://ollama.com/library/llama3?update=2026-03-30 | tool | new | [codex](../tools/development_ops/codex.md) | Identified as related tool/concept in codex.md. |
 | Luma Dream Machine | https://lumalabs.ai/dream-machine | tool | integrated | [runwayml](../tools/ai_knowledge/runwayml.md) | Identified as related tool/concept in runwayml.md. |
 | MATH Benchmark | https://github.com/hendrycks/math?update=2026-03-30 | benchmark | new | [gsm8k](../tools/benchmarking/gsm8k.md) | Identified as related tool/concept in gsm8k.md. |
-| MMLU | https://github.com/hendrycks/test?update=2026-03-30 | repository | new | [humanitys-last-exam](../tools/benchmarking/humanitys-last-exam.md) | Identified as related tool/concept in humanitys-last-exam.md. |
-| MMLU (Massive Multitask Language Understanding) | https://github.com/hendrycks/test?update=2026-03-30 | repository | new | [gpqa](../tools/benchmarking/gpqa.md) | Identified as related tool/concept in gpqa.md. |
+| MMLU | https://github.com/hendrycks/test?update=2026-03-30 | repository | integrated | [mmlu](../tools/benchmarking/mmlu.md) | Identified as related tool/concept in humanitys-last-exam.md. |
+| MMLU (Massive Multitask Language Understanding) | https://github.com/hendrycks/test?update=2026-03-30 | repository | integrated | [mmlu](../tools/benchmarking/mmlu.md) | Identified as related tool/concept in gpqa.md. |
 | MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge?update=2026-03-30 | benchmark | new | [chatbot-arena](../tools/benchmarking/chatbot-arena.md) | Identified as related tool/concept in chatbot-arena.md. |
 | Maestro | https://github.com/yogthos/maestro?update=2026-03-30 | repository | new | [mycelium](../tools/frameworks/mycelium.md) | Identified as related tool/concept in mycelium.md. |
 | Malli | https://github.com/metosin/malli?update=2026-03-30 | repository | new | [mycelium](../tools/frameworks/mycelium.md) | Identified as related tool/concept in mycelium.md. |

--- a/docs/tools/benchmarking/gpqa.md
+++ b/docs/tools/benchmarking/gpqa.md
@@ -34,7 +34,7 @@ Measures whether LLMs possess deep, expert-level scientific knowledge and reason
 
 ## Related tools / concepts
 
-- [MMLU (Massive Multitask Language Understanding)](https://github.com/hendrycks/test)
+- [MMLU (Massive Multitask Language Understanding)](mmlu.md)
 - [ARC (AI2 Reasoning Challenge)](https://github.com/allenai/ARC-benchmark)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [SWE-bench](swe-bench.md)

--- a/docs/tools/benchmarking/humanitys-last-exam.md
+++ b/docs/tools/benchmarking/humanitys-last-exam.md
@@ -35,7 +35,7 @@ Addresses the saturation of easier benchmarks by providing a set of questions th
 ## Related tools / concepts
 
 - [GPQA](gpqa.md)
-- [MMLU](https://github.com/hendrycks/test)
+- [MMLU](mmlu.md)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [SWE-bench](swe-bench.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)

--- a/docs/tools/benchmarking/mmlu.md
+++ b/docs/tools/benchmarking/mmlu.md
@@ -1,0 +1,47 @@
+# MMLU (Massive Multitask Language Understanding)
+
+## What it is
+MMLU is a comprehensive benchmark designed to measure the general knowledge and problem-solving abilities of Large Language Models. It consists of approximately 16,000 multiple-choice questions across 57 subjects, including STEM, the humanities, social sciences, and more.
+
+## What problem it solves
+It provides a standardized way to evaluate a model's "world knowledge" and academic proficiency across a vast array of disciplines, moving beyond narrow tasks to assess broad intellectual capability.
+
+## Where it fits in the stack
+**Benchmarking**. It is one of the most widely cited benchmarks for comparing the general intelligence of different LLMs.
+
+## Typical use cases
+- **General Model Comparison**: Assessing which model has a broader knowledge base.
+- **Tracking Progress**: Measuring how new model versions improve in general world knowledge.
+- **Identifying Knowledge Gaps**: Analyzing performance across specific subjects (e.g., Law vs. Physics).
+
+## Strengths
+- **Breadth**: Covers a massive range of subjects, from elementary mathematics to professional law and medicine.
+- **Industry Standard**: Almost every major LLM release includes MMLU scores.
+- **Granularity**: Allows for fine-grained analysis of performance on specific topics.
+
+## Limitations
+- **Format**: Multiple-choice format doesn't capture open-ended reasoning or generation quality.
+- **Data Contamination**: Due to its popularity, questions may have leaked into the training data of newer models.
+- **Ambiguity**: Some questions and answers have been criticized for being ambiguous or containing errors.
+
+## When to use it
+- When you want a broad overview of a model's general knowledge and academic proficiency.
+- When comparing the general "intelligence" level of various foundation models.
+
+## When not to use it
+- When you need to evaluate specific reasoning depth (use [GPQA](gpqa.md) instead).
+- When evaluating coding performance (use [HumanEval](human-eval.md) or [SWE-bench](swe-bench.md) instead).
+
+## Related tools / concepts
+- [GPQA](gpqa.md)
+- [HumanEval](human-eval.md)
+- [ARC (AI2 Reasoning Challenge)](https://github.com/allenai/ARC-benchmark)
+- [Humanity's Last Exam (HLE)](humanitys-last-exam.md)
+
+## Sources / References
+- [Original Paper (Hendrycks et al.)](https://arxiv.org/abs/2009.03300)
+- [GitHub Repository](https://github.com/hendrycks/test)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-06
+- Confidence: high

--- a/docs/tools/development_ops/claude-code-container-mcp.md
+++ b/docs/tools/development_ops/claude-code-container-mcp.md
@@ -42,7 +42,7 @@ It enables AI assistants to create and control isolated Claude Code instances pr
 ## Related tools / concepts
 - [Claude Code](claude-code.md)
 - [Docker](https://www.docker.com/)
-- [AWS Bedrock](https://aws.amazon.com/bedrock/)
+- [AWS Bedrock](../providers/aws-bedrock.md)
 
 ## Sources / References
 - [Claude Code Container MCP GitHub](https://github.com/democratize-technology/claude-code-container-mcp)

--- a/docs/tools/development_ops/terminus-2.md
+++ b/docs/tools/development_ops/terminus-2.md
@@ -35,7 +35,7 @@ Demonstrates that a simple, direct approach to terminal-based AI agents (LLM + t
 ## Related tools / concepts
 
 - [OpenHands](openhands.md)
-- [Devin](https://cognition.ai/)
+- [Devin](devin.md)
 - [Codeium](codeium.md)
 - [Claude Code — Project Setup Guide](claude-code-setup.md)
 - [OpenCode (Oh My OpenCode Ecosystem)](opencode.md)

--- a/docs/tools/process_understanding/docling-mcp.md
+++ b/docs/tools/process_understanding/docling-mcp.md
@@ -39,7 +39,7 @@ It simplifies the integration of sophisticated document understanding capabiliti
 
 ## Related tools / concepts
 - [Model Context Protocol](../../knowledge_base/patterns/tool-calling-and-mcp.md)
-- [Docling](https://github.com/DS4SD/docling)
+- [Docling](docling.md)
 - [OCRmyPDF](ocrmypdf.md)
 - [Milvus](https://milvus.io/)
 

--- a/docs/tools/providers/aws-bedrock.md
+++ b/docs/tools/providers/aws-bedrock.md
@@ -1,0 +1,51 @@
+# AWS Bedrock
+
+## What it is
+AWS Bedrock is a fully managed service from Amazon Web Services that makes foundational models (FMs) available through an API. It provides a single interface to access models from leading AI providers including Amazon, Anthropic, AI21 Labs, Cohere, Meta, Mistral AI, and Stability AI.
+
+## What problem it solves
+It simplifies the process of building and scaling generative AI applications by removing the need to manage underlying infrastructure. It provides a unified API for multiple models, along with tools for fine-tuning, RAG (Knowledge Bases for Amazon Bedrock), and agentic workflows (Agents for Amazon Bedrock).
+
+## Where it fits in the stack
+**Provider / Infrastructure**. It serves as an enterprise-grade gateway to multiple high-performance LLMs.
+
+## Typical use cases
+- **Enterprise AI Applications**: Building secure, scalable AI solutions within the AWS ecosystem.
+- **Retrieval-Augmented Generation (RAG)**: Using "Knowledge Bases for Amazon Bedrock" to connect models to proprietary data.
+- **Agentic Workflows**: Deploying autonomous agents that can execute multi-step tasks using AWS resources.
+- **Model Fine-tuning**: Customizing foundation models with private data.
+
+## Strengths
+- **Enterprise-Grade Security**: Strong data privacy and compliance features (HIPAA, GDPR, etc.). Data is not used to train the underlying foundation models.
+- **Model Variety**: Access to a broad range of models (Claude, Llama, Mistral, Titan) through a single API.
+- **Serverless Experience**: No infrastructure to manage; scales automatically.
+- **AWS Integration**: Seamless integration with S3, Lambda, IAM, and other AWS services.
+
+## Limitations
+- **AWS Ecosystem Lock-in**: Deeply tied to AWS; moving to another provider requires significant re-engineering.
+- **Complexity**: AWS's extensive configuration options can be daunting for simple projects.
+- **Regional Availability**: Not all models or features are available in all AWS regions.
+
+## When to use it
+- When building enterprise-scale AI applications that require high security, compliance, and scalability.
+- If your organization is already heavily invested in the AWS ecosystem.
+- When you need a managed RAG or agent framework that integrates natively with cloud resources.
+
+## When not to use it
+- For simple, low-volume projects where a direct API like OpenAI or Anthropic might be simpler.
+- If you require a provider-agnostic solution that can easily move between clouds.
+
+## Related tools / concepts
+- [Anthropic (Claude)](anthropic.md)
+- [Meta (Llama)](../ai_knowledge/local_llms.md)
+- [Mistral AI](mistral.md)
+- [Claude Code Container MCP](../development_ops/claude-code-container-mcp.md)
+- [Docker](../infrastructure/docker.md)
+
+## Sources / References
+- [Official AWS Bedrock Page](https://aws.amazon.com/bedrock/)
+- [Amazon Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-06
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -209,6 +209,7 @@ nav:
       - Pa Bench: tools/benchmarking/pa-bench.md
       - Swe Bench: tools/benchmarking/swe-bench.md
       - Terminal Bench: tools/benchmarking/terminal-bench.md
+      - MMLU: tools/benchmarking/mmlu.md
     - Calendar & Tasks:
       - Overview: tools/calendar_tasks/index.md
       - Google Calendar: tools/calendar_tasks/google_calendar.md
@@ -293,6 +294,7 @@ nav:
       - Moonshot AI: tools/providers/moonshot.md
       - BigSwitch: tools/providers/bigswitch.md
       - Tavily: tools/providers/tavily.md
+      - AWS Bedrock: tools/providers/aws-bedrock.md
       - Hugging Face: tools/providers/huggingface.md
     - Agents:
       - Overview: tools/agents/index.md

--- a/roadmap.md
+++ b/roadmap.md
@@ -18,6 +18,10 @@ This document tracks missing components and planned technical improvements for t
 - **AI-Powered Warranty & Manual Assistant**:
     - *Goal*: Automatically track warranty expiration from scanned receipts and provide chat-based troubleshooting using scanned manuals.
     - *Stack*: [Paperless-ngx](./services/paperless-ngx.md), [n8n](./services/n8n.md), local LLM (RAG).
+    - [ ] Define Paperless-ngx tag schema for warranties and manuals.
+    - [ ] Create n8n workflow to extract expiration dates from warranty documents.
+    - [ ] Set up Vector DB index for scanned manuals.
+    - [ ] Implement chat-based troubleshooting interface using RAG over manuals.
 - **Smart Energy Anomaly Detection**:
     - *Goal*: Use local reasoning to detect unusual power spikes or appliances left on, providing proactive alerts.
     - *Stack*: [Home Assistant](./services/home-assistant.md), [Ollama](./services/ollama.md).
@@ -45,6 +49,10 @@ This document tracks missing components and planned technical improvements for t
 - **Sovereign Identity & SSO**:
     - *Goal*: Fully self-hosted single sign-on for all family members across all services.
     - *Stack*: Authentik or LL-LDAP.
+    - [ ] Research Authentik vs Kanidm vs LL-LDAP for family use.
+    - [ ] Deploy chosen SSO solution via Docker.
+    - [ ] Configure OIDC for first 3 services (Nextcloud, Vikunja, Gitea).
+    - [ ] Set up 2FA for all family member accounts.
 
 ## Technical Next Steps
 


### PR DESCRIPTION
This PR implements the "Ralph-loop" strategy to improve the repository's knowledge base and roadmap. 

Key changes:
1.  **New Documentation**: Created canonical pages for `AWS Bedrock` and `MMLU` following the standard template.
2.  **Internal Linking**: Updated `terminus-2.md`, `docling-mcp.md`, `gpqa.md`, `humanitys-last-exam.md`, and `claude-code-container-mcp.md` to use internal relative links instead of external URLs for documented tools.
3.  **Registry & Navigation**: Added the new tools to `data/all_tools.json` and `mkdocs.yml`.
4.  **Intake Processing**: Updated `docs/new-sources/2026-03-30.md` to reflect the integration of several tools.
5.  **Roadmap Refinement**: Broke down two major "Future Projects" in `roadmap.md` into smaller, specific sub-tasks to facilitate implementation.
6.  **Validation**: All changes were verified using the repository's validation scripts (`check_catalog_consistency.py`, `check_docs_contract.py`, and `validate_new_sources.py`).

---
*PR created automatically by Jules for task [5773484645352365162](https://jules.google.com/task/5773484645352365162) started by @joanmarcriera*