### PR TITLE
Ralph-loop: Benchmarking Integration and Roadmap Decomposition

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -618,6 +618,24 @@
       "doc_path": "docs/tools/benchmarking/mmlu.md"
     },
     {
+      "id": "opencompass",
+      "name": "OpenCompass",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/opencompass.md"
+    },
+    {
+      "id": "helm",
+      "name": "HELM",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/helm.md"
+    },
+    {
+      "id": "evalplus",
+      "name": "EvalPlus",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/evalplus.md"
+    },
+    {
       "id": "actual-budget",
       "name": "Actual Budget",
       "category": "Intake & Storage",

--- a/docs/new-sources/2026-03-20.md
+++ b/docs/new-sources/2026-03-20.md
@@ -3,10 +3,10 @@
 ## Benchmarking
 | Title | URL | Tags | Status | Canonical Page | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| OpenCompass | https://opencompass.org.cn/ | tool | new | TBD | Discovered in docs/tools/benchmarking/lm-evaluation-harness.md |
-| HELM | https://crfm.stanford.edu/helm/lite/ | tool | new | TBD | Discovered in docs/tools/benchmarking/lm-evaluation-harness.md |
+| OpenCompass | https://opencompass.org.cn/ | tool | integrated | [OpenCompass](../tools/benchmarking/opencompass.md) | Discovered in docs/tools/benchmarking/lm-evaluation-harness.md |
+| HELM | https://crfm.stanford.edu/helm/lite/ | tool | integrated | [HELM](../tools/benchmarking/helm.md) | Discovered in docs/tools/benchmarking/lm-evaluation-harness.md |
 | MMLU | https://github.com/hendrycks/test | tool | new | TBD | Discovered in docs/tools/benchmarking/humanitys-last-exam.md |
-| EvalPlus | https://github.com/evalplus/evalplus | tool | new | TBD | Discovered in docs/tools/benchmarking/mbpp.md |
+| EvalPlus | https://github.com/evalplus/evalplus | tool | integrated | [EvalPlus](../tools/benchmarking/evalplus.md) | Discovered in docs/tools/benchmarking/mbpp.md |
 | AlpacaEval | https://github.com/tatsu-lab/alpaca_eval | tool | new | TBD | Discovered in docs/tools/benchmarking/chatbot-arena.md |
 | MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge | tool | new | TBD | Discovered in docs/tools/benchmarking/chatbot-arena.md |
 | InterCode | https://github.com/princeton-nlp/intercode | tool | new | TBD | Discovered in docs/tools/benchmarking/terminal-bench.md |

--- a/docs/tools/benchmarking/evalplus.md
+++ b/docs/tools/benchmarking/evalplus.md
@@ -1,0 +1,54 @@
+# EvalPlus
+
+## What it is
+EvalPlus is a rigorous evaluation framework for Large Language Models (LLMs) focused on code generation (LLM4Code). It significantly expands existing benchmarks like HumanEval and MBPP with more comprehensive test cases to improve evaluation accuracy.
+
+## What problem it solves
+Original coding benchmarks like [HumanEval](human-eval.md) often have very few test cases, allowing fragile or incorrect code to pass. EvalPlus addresses this "under-testing" problem by adding 80x more tests to HumanEval and 35x more tests to MBPP, revealing model weaknesses that simpler benchmarks miss.
+
+## Where it fits in the stack
+**Benchmarking**. It is a specialized tool for deeply evaluating the code generation capabilities and efficiency of LLMs.
+
+## Typical use cases
+- **Rigorous Coding Evaluation**: Testing a model's true coding ability beyond simple benchmarks.
+- **Fragility Detection**: Identifying if a model's generated code is robust across many different inputs.
+- **Code Efficiency Benchmarking**: Using the EvalPerf extension to measure the execution speed of LLM-generated code.
+
+## Strengths
+- **High Rigor**: Expanded test suites (HumanEval+, MBPP+) significantly reduce false positives.
+- **Multi-backend Support**: Supports evaluation via vLLM, Hugging Face, OpenAI, Anthropic, Gemini, and Ollama.
+- **Security**: Supports safe code execution within Docker containers to protect the host system.
+- **Performance Evaluation**: Includes EvalPerf for measuring code efficiency.
+
+## Limitations
+- **Focus**: Primarily limited to Python and coding-specific tasks.
+- **Execution Cost**: Running 80x more tests naturally takes more time and compute than the original benchmarks.
+
+## When to use it
+- When you are developing or fine-tuning an LLM for code generation and need high-confidence metrics.
+- When you want to rank models based on their coding robustness and efficiency.
+- When comparing against major industry models (many of which, like Llama 3.1 and Qwen 2.5, use EvalPlus).
+
+## When not to use it
+- For general knowledge or reasoning tasks (use [MMLU](mmlu.md) or [GPQA](gpqa.md) instead).
+- For quick, non-rigorous evaluations of simple code snippets.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0)
+- **Cost**: Free
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [HumanEval](human-eval.md)
+- [MBPP](mbpp.md)
+- [SWE-bench](swe-bench.md)
+- [vLLM](../infrastructure/vllm.md)
+
+## Sources / References
+- [Official Website](https://evalplus.github.io/)
+- [GitHub Repository](https://github.com/evalplus/evalplus)
+- [NeurIPS 2023 Paper](https://openreview.net/forum?id=1qvx610Cu7)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-21
+- Confidence: high

--- a/docs/tools/benchmarking/helm.md
+++ b/docs/tools/benchmarking/helm.md
@@ -1,0 +1,56 @@
+# HELM (Holistic Evaluation of Language Models)
+
+## What it is
+HELM (Holistic Evaluation of Language Models) is an open-source evaluation framework developed by Stanford University's Center for Research on Foundation Models (CRFM). It is designed to provide a comprehensive, transparent, and multi-dimensional assessment of Large Language Models (LLMs).
+
+## What problem it solves
+LLM evaluation is often narrow, focusing only on accuracy for a few tasks. HELM addresses this by evaluating models across a wide range of "scenarios" (tasks) and "metrics" (accuracy, fairness, safety, efficiency, etc.), providing a holistic view of model behavior rather than just a single score.
+
+## Where it fits in the stack
+**Benchmarking**. It is a major framework used by researchers and engineers to perform deep-dive evaluations of foundation models.
+
+## Typical use cases
+- **Holistic Model Assessment**: Evaluating a new model version across accuracy, safety, and bias simultaneously.
+- **Comparison of Foundation Models**: Using standardized scenarios to compare models like GPT-4, Claude, and Llama on equal footing.
+- **Safety and Fairness Auditing**: Specifically checking for toxicity and bias in model responses across different demographics.
+
+## Strengths
+- **Multi-dimensional**: Moves beyond simple accuracy to include metrics like calibration, robustness, and fairness.
+- **Scenario-Metric Grid**: Uses a systematic approach to ensure broad coverage of tasks.
+- **Transparency**: Provides full visibility into the prompts used and the individual model responses.
+- **Active Research**: Regularly updated by Stanford with new datasets and the latest models.
+
+## Limitations
+- **High Complexity**: Setting up and running full HELM evaluations is computationally expensive and complex.
+- **API Dependency**: Many scenarios require access to external model APIs, which can incur high costs.
+- **Learning Curve**: The framework's modularity makes it powerful but also harder to master than simpler evaluation scripts.
+
+## When to use it
+- When you need a highly rigorous, academic-grade evaluation of a foundation model.
+- When you are concerned with safety, bias, or robustness in addition to raw performance.
+- When participating in or reproducing results for major LLM leaderboards.
+
+## When not to use it
+- For quick, "vibe-check" style evaluations of a specific application prompt.
+- If you have very limited compute or budget for API calls.
+- For evaluating specific RAG pipelines (consider [RAGAS](https://github.com/explodinggradients/ragas) instead).
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0)
+- **Cost**: Free (but compute/API costs for running evals apply)
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [LM Evaluation Harness](lm-evaluation-harness.md)
+- [OpenCompass](opencompass.md)
+- [MMLU](mmlu.md)
+- [GPQA](gpqa.md)
+
+## Sources / References
+- [Official Website](https://crfm.stanford.edu/helm/)
+- [GitHub Repository](https://github.com/stanford-crfm/helm)
+- [Stanford CRFM Blog](https://crfm.stanford.edu/2022/11/17/helm.html)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-21
+- Confidence: high

--- a/docs/tools/benchmarking/opencompass.md
+++ b/docs/tools/benchmarking/opencompass.md
@@ -1,0 +1,54 @@
+# OpenCompass
+
+## What it is
+OpenCompass is a comprehensive, one-stop platform designed for evaluating the capabilities of large language models (LLMs) and vision-language models (VLMs). It provides a complete evaluation pipeline, including dataset preparation, evaluation scripts, and leaderboards.
+
+## What problem it solves
+Evaluating modern large models is complex, requiring diverse datasets and multiple evaluation paradigms (e.g., zero-shot, few-shot, CoT). OpenCompass standardizes this process, providing a reproducible and extensible framework that supports over 100 datasets and various model backends.
+
+## Where it fits in the stack
+**Benchmarking**. It serves as an evaluation toolkit and platform for comparing model performance across a wide range of tasks.
+
+## Typical use cases
+- **Model Development**: Benchmarking in-house models against industry standards during training.
+- **Model Selection**: Comparing different open-source or API-based models to find the best fit for a specific application.
+- **Academic Research**: Reproducing evaluation results for papers and contributing new datasets to the community.
+
+## Strengths
+- **Comprehensive Coverage**: Supports 100+ datasets covering linguistics, knowledge, reasoning, coding, and multi-modality.
+- **Flexible Architecture**: Supports various evaluation paradigms (Zero-shot, Few-shot, CoT, LLM-as-a-judge).
+- **High Performance**: Integrates with acceleration backends like vLLM, LMDeploy, and ModelScope for distributed evaluation.
+- **Active Community**: Frequently updated with new benchmarks and model support.
+
+## Limitations
+- **Complexity**: The extensive configuration options and features can lead to a steeper learning curve for beginners.
+- **Resource Intensive**: Running full-scale evaluations on large models requires significant local compute or API credits.
+
+## When to use it
+- When you need a standardized, reproducible way to evaluate models across dozens of different dimensions.
+- When you want to contribute to or compare against public leaderboards (CompassRank).
+- When evaluating Vision-Language Models (VLMs) alongside LLMs.
+
+## When not to use it
+- For very simple, single-task evaluations where a lightweight script might suffice.
+- If you only need to evaluate basic RAG performance (consider [DeepEval](https://github.com/confident-ai/deepeval) or [RAGAS](https://github.com/explodinggradients/ragas) instead).
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0)
+- **Cost**: Free
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [LM Evaluation Harness](lm-evaluation-harness.md)
+- [HELM](helm.md)
+- [vLLM](../infrastructure/vllm.md)
+- [Chatbot Arena](chatbot-arena.md)
+
+## Sources / References
+- [Official Website](https://opencompass.org.cn/)
+- [GitHub Repository](https://github.com/open-compass/opencompass)
+- [Introduction by Jimmy Song](https://jimmysong.io/ai/opencompass/)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-21
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,6 +200,9 @@ nav:
       - Gsm8K: tools/benchmarking/gsm8k.md
       - Human Eval: tools/benchmarking/human-eval.md
       - Humanitys Last Exam: tools/benchmarking/humanitys-last-exam.md
+      - OpenCompass: tools/benchmarking/opencompass.md
+      - HELM: tools/benchmarking/helm.md
+      - EvalPlus: tools/benchmarking/evalplus.md
       - LangSmith: tools/benchmarking/langsmith.md
       - LLMperf: tools/benchmarking/llmperf.md
       - Lm Evaluation Harness: tools/benchmarking/lm-evaluation-harness.md

--- a/roadmap.md
+++ b/roadmap.md
@@ -38,6 +38,9 @@ This document tracks missing components and planned technical improvements for t
 - **AI-Categorized Home Video Archive**:
     - *Goal*: Automated tagging and semantic search for home videos (e.g., "Find the video of the birthday party").
     - *Stack*: Local vision models (CLIP/Whisper), TrueNAS storage.
+    - [ ] Research local vision models for video frame embedding.
+    - [ ] Prototype metadata extraction script using Whisper and CLIP.
+    - [ ] Set up Vector DB for semantic search over video metadata.
 - **Local Audio Library Enrichment**:
     - *Goal*: Automated transcription of personal audiobooks and podcasts for full-text search.
     - *Stack*: Whisper (local), [Ollama](./services/ollama.md).


### PR DESCRIPTION
This change processes multiple repository "Issues" as part of the Ralph-loop:
1. **Performed Work**: Researched and created comprehensive documentation for three major benchmarking tools (OpenCompass, HELM, EvalPlus) in `docs/tools/benchmarking/`.
2. **Integrated Links**: Updated `docs/new-sources/2026-03-20.md` to reflect the integration of these tools.
3. **Divided Work**: Broke down the high-level "AI-Categorized Home Video Archive" roadmap goal into specific, checkable sub-tasks in `roadmap.md`.
All changes adhere to the repository standards for metadata, navigation, and catalog consistency.

---
*PR created automatically by Jules for task [15793920337396227455](https://jules.google.com/task/15793920337396227455) started by @joanmarcriera*