### PR TITLE
Ralph-loop: Documentation Integration and Roadmap Refinement

### DIFF
--- a/docs/new-sources/2026-03-20.md
+++ b/docs/new-sources/2026-03-20.md
@@ -7,11 +7,11 @@
 | HELM | https://crfm.stanford.edu/helm/lite/ | tool | integrated | [HELM](../tools/benchmarking/helm.md) | Discovered in docs/tools/benchmarking/lm-evaluation-harness.md |
 | MMLU | https://github.com/hendrycks/test | tool | new | TBD | Discovered in docs/tools/benchmarking/humanitys-last-exam.md |
 | EvalPlus | https://github.com/evalplus/evalplus | tool | integrated | [EvalPlus](../tools/benchmarking/evalplus.md) | Discovered in docs/tools/benchmarking/mbpp.md |
-| AlpacaEval | https://github.com/tatsu-lab/alpaca_eval | tool | new | TBD | Discovered in docs/tools/benchmarking/chatbot-arena.md |
-| MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge | tool | new | TBD | Discovered in docs/tools/benchmarking/chatbot-arena.md |
+| AlpacaEval | https://github.com/tatsu-lab/alpaca_eval | tool | integrated | [alpaca-eval](../tools/benchmarking/alpaca-eval.md) | Discovered in docs/tools/benchmarking/chatbot-arena.md |
+| MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge | tool | integrated | [mt-bench](../tools/benchmarking/mt-bench.md) | Discovered in docs/tools/benchmarking/chatbot-arena.md |
 | InterCode | https://github.com/princeton-nlp/intercode | tool | new | TBD | Discovered in docs/tools/benchmarking/terminal-bench.md |
 | Simple `time` command with `curl` | https://github.com/ollama/ollama/blob/main/docs/api.md | tool | new | TBD | Discovered in docs/tools/benchmarking/ollama-benchmark-cli.md |
-| MATH Benchmark | https://github.com/hendrycks/math | tool | new | TBD | Discovered in docs/tools/benchmarking/gsm8k.md |
+| MATH Benchmark | https://github.com/hendrycks/math | tool | integrated | [math-benchmark](../tools/benchmarking/math-benchmark.md) | Discovered in docs/tools/benchmarking/gsm8k.md |
 | ASDiv | https://github.com/chiahsuan/ASDiv | tool | new | TBD | Discovered in docs/tools/benchmarking/gsm8k.md |
 | ARC (AI2 Reasoning Challenge) | https://github.com/allenai/ARC-benchmark | tool | new | TBD | Discovered in docs/tools/benchmarking/gpqa.md |
-| BigCodeBench | https://github.com/bigcode-project/bigcodebench | tool | new | TBD | Discovered in docs/tools/benchmarking/human-eval.md |
+| BigCodeBench | https://github.com/bigcode-project/bigcodebench | tool | integrated | [bigcodebench](../tools/benchmarking/bigcodebench.md) | Discovered in docs/tools/benchmarking/human-eval.md |

--- a/docs/new-sources/2026-03-30.md
+++ b/docs/new-sources/2026-03-30.md
@@ -5,10 +5,10 @@
 | ARC (AI2 Reasoning Challenge) | https://github.com/allenai/ARC-benchmark?update=2026-03-30 | benchmark | integrated | [arc](../tools/benchmarking/arc.md) | Identified as related tool/concept in gpqa.md. |
 | ASDiv | https://github.com/chiahsuan/ASDiv?update=2026-03-30 | repository | integrated | [asdiv](../tools/benchmarking/asdiv.md) | Identified as related tool/concept in gsm8k.md. |
 | AWS Bedrock | https://aws.amazon.com/bedrock/?update=2026-03-30 | tool | integrated | [aws-bedrock](../tools/providers/aws-bedrock.md) | Identified as related tool/concept in claude-code-container-mcp.md. |
-| AlpacaEval | https://github.com/tatsu-lab/alpaca_eval?update=2026-03-30 | repository | new | [chatbot-arena](../tools/benchmarking/chatbot-arena.md) | Identified as related tool/concept in chatbot-arena.md. |
+| AlpacaEval | https://github.com/tatsu-lab/alpaca_eval?update=2026-03-30 | repository | integrated | [alpaca-eval](../tools/benchmarking/alpaca-eval.md) | Identified as related tool/concept in chatbot-arena.md. |
 | Amazon Textract | https://aws.amazon.com/textract/?update=2026-03-30 | tool | new | [ocrmypdf](../tools/process_understanding/ocrmypdf.md) | Identified as related tool/concept in ocrmypdf.md. |
 | Apple Silicon | https://www.apple.com/silicon/?update=2026-03-30 | tool | new | [mlx](../tools/infrastructure/mlx.md) | Identified as related tool/concept in mlx.md. |
-| BigCodeBench | https://github.com/bigcode-project/bigcodebench?update=2026-03-30 | benchmark | new | [human-eval](../tools/benchmarking/human-eval.md) | Identified as related tool/concept in human-eval.md. |
+| BigCodeBench | https://github.com/bigcode-project/bigcodebench?update=2026-03-30 | benchmark | integrated | [bigcodebench](../tools/benchmarking/bigcodebench.md) | Identified as related tool/concept in human-eval.md. |
 | Chronos CalDAV library | https://github.com/democratize-technology/chronos-mcp?update=2026-03-30 | repository | new | [chronos-mcp](../tools/automation_orchestration/chronos-mcp.md) | Identified as related tool/concept in chronos-mcp.md. |
 | Claude | https://claude.ai/?update=2026-03-30 | tool | integrated | [chatgpt](../tools/ai_knowledge/chatgpt.md) | Identified as related tool/concept in chatgpt.md. |
 | CrossHair | https://github.com/pschanely/CrossHair?update=2026-03-30 | repository | new | [symbolic-mcp](../tools/development_ops/symbolic-mcp.md) | Identified as related tool/concept in symbolic-mcp.md. |
@@ -37,10 +37,10 @@
 | Lens | https://k8slens.dev/?update=2026-03-30 | tool | new | [cloud_code](../tools/development_ops/cloud_code.md) | Identified as related tool/concept in cloud_code.md. |
 | Llama 3 (Fine-tuned for code) | https://ollama.com/library/llama3?update=2026-03-30 | tool | new | [codex](../tools/development_ops/codex.md) | Identified as related tool/concept in codex.md. |
 | Luma Dream Machine | https://lumalabs.ai/dream-machine | tool | integrated | [runwayml](../tools/ai_knowledge/runwayml.md) | Identified as related tool/concept in runwayml.md. |
-| MATH Benchmark | https://github.com/hendrycks/math?update=2026-03-30 | benchmark | new | [gsm8k](../tools/benchmarking/gsm8k.md) | Identified as related tool/concept in gsm8k.md. |
+| MATH Benchmark | https://github.com/hendrycks/math?update=2026-03-30 | benchmark | integrated | [math-benchmark](../tools/benchmarking/math-benchmark.md) | Identified as related tool/concept in gsm8k.md. |
 | MMLU | https://github.com/hendrycks/test?update=2026-03-30 | repository | integrated | [mmlu](../tools/benchmarking/mmlu.md) | Identified as related tool/concept in humanitys-last-exam.md. |
 | MMLU (Massive Multitask Language Understanding) | https://github.com/hendrycks/test?update=2026-03-30 | repository | integrated | [mmlu](../tools/benchmarking/mmlu.md) | Identified as related tool/concept in gpqa.md. |
-| MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge?update=2026-03-30 | benchmark | new | [chatbot-arena](../tools/benchmarking/chatbot-arena.md) | Identified as related tool/concept in chatbot-arena.md. |
+| MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge?update=2026-03-30 | benchmark | integrated | [mt-bench](../tools/benchmarking/mt-bench.md) | Identified as related tool/concept in chatbot-arena.md. |
 | Maestro | https://github.com/yogthos/maestro?update=2026-03-30 | repository | new | [mycelium](../tools/frameworks/mycelium.md) | Identified as related tool/concept in mycelium.md. |
 | Malli | https://github.com/metosin/malli?update=2026-03-30 | repository | new | [mycelium](../tools/frameworks/mycelium.md) | Identified as related tool/concept in mycelium.md. |
 | Microsoft Graph API | https://learn.microsoft.com/en-us/graph/overview?update=2026-03-30 | tool | integrated | [caldav](../tools/intake_storage/caldav.md) | Identified as related tool/concept in caldav.md. |

--- a/docs/tools/benchmarking/alpaca-eval.md
+++ b/docs/tools/benchmarking/alpaca-eval.md
@@ -1,0 +1,54 @@
+# AlpacaEval
+
+## What it is
+AlpacaEval is an automatic evaluator for instruction-following language models. It uses an LLM-as-a-judge (typically GPT-4) to conduct pairwise comparisons between a model's output and a reference output, generating a "win rate" that serves as a proxy for human preference.
+
+## What problem it solves
+Human evaluation of LLM outputs is slow, expensive, and difficult to scale. AlpacaEval provides a fast, cheap, and reproducible alternative by using a highly capable model to simulate human judgment across a diverse set of instructions.
+
+## Where it fits in the stack
+**Benchmarking**. It is a tool for evaluating the "helpfulness" and instruction-following quality of chat-tuned LLMs.
+
+## Typical use cases
+- **Rapid Iteration**: Evaluating new model versions or hyperparameter changes quickly without waiting for human feedback.
+- **Leaderboard Ranking**: Comparing various instruction-tuned models on a standardized set of 805 prompts.
+- **Model Regression Testing**: Ensuring that updates to a model don't negatively impact its instruction-following performance.
+
+## Strengths
+- **Simulates Human Preference**: High correlation with human judgment (specifically the LMSYS Chatbot Arena).
+- **Scalable and Fast**: Can evaluate hundreds of responses in minutes for a fraction of the cost of human annotators.
+- **Debiasing Mechanisms**: AlpacaEval 2.0 includes "length-controlled" win rates to mitigate the bias where LLM judges favor longer (more verbose) responses regardless of quality.
+- **Reference-Free**: Doesn't require "gold standard" answers, making it suitable for open-ended creative tasks.
+
+## Limitations
+- **Judge Bias**: Inherits the biases of the judge model (e.g., self-preference, verbosity bias, ordering bias).
+- **Cost of API**: Requires access to a high-end judge model (like GPT-4o), which incurs API costs.
+- **Static Dataset**: The evaluation prompts are fixed, which can lead to "data contamination" if models are trained on the evaluation set.
+
+## When to use it
+- When you are instruction-tuning a model and need a quick, automated way to measure progress.
+- When you want to see how your model ranks against industry leaders like GPT-4 or Claude.
+
+## When not to use it
+- For evaluating factual accuracy or reasoning in objective domains (use [MMLU](mmlu.md) or [GSM8K](gsm8k.md)).
+- When you need a truly unbiased "ground truth" (human evaluation is still the gold standard).
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0)
+- **Cost**: Free software, but requires payment for LLM API calls (the judge).
+- **Self-hostable**: Yes, the evaluation script can be run locally.
+
+## Related tools / concepts
+- [Chatbot Arena](chatbot-arena.md)
+- [MT-Bench](mt-bench.md)
+- [HELM](helm.md)
+- **LLM-as-a-judge**: The underlying methodology used by AlpacaEval.
+
+## Sources / References
+- [GitHub Repository](https://github.com/tatsu-lab/alpaca_eval)
+- [Official Website / Leaderboard](https://tatsu-lab.github.io/alpaca_eval/)
+- [AlpacaEval 2.0 Technical Report](https://arxiv.org/abs/2402.13453)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-30
+- Confidence: high

--- a/docs/tools/benchmarking/bigcodebench.md
+++ b/docs/tools/benchmarking/bigcodebench.md
@@ -1,0 +1,55 @@
+# BigCodeBench
+
+## What it is
+BigCodeBench is a comprehensive benchmark designed to evaluate the code generation capabilities of Large Language Models (LLMs) when dealing with diverse function calls and complex instructions. It features 1,140 programming tasks that require the use of 139 different Python libraries.
+
+## What problem it solves
+Traditional benchmarks like [HumanEval](human-eval.md) and [MBPP](mbpp.md) primarily focus on short, algorithmic problems that rarely involve external libraries. BigCodeBench addresses the gap between these "toy" problems and real-world software engineering by testing a model's ability to invoke diverse APIs and follow multi-step, complex instructions.
+
+## Where it fits in the stack
+**Benchmarking**. It serves as a high-fidelity evaluation tool for developers and researchers to assess how well an LLM can perform as a real-world coding assistant.
+
+## Typical use cases
+- **API Usage Evaluation**: Testing if a model can correctly import and use specific Python libraries (e.g., pandas, matplotlib, requests).
+- **Instruction Following**: Assessing a model's ability to adhere to complex constraints and requirements within a coding prompt.
+- **Model Comparison**: Ranking different LLMs based on their practical coding utility rather than just algorithmic logic.
+
+## Strengths
+- **Scale and Diversity**: 1,140 tasks across various domains (data science, web dev, etc.) and 139 libraries.
+- **Instruction Variants**: Offers two versions: `BigCodeBench-Complete` (code completion) and `BigCodeBench-Instruct` (instruction following).
+- **Rigorous Verification**: Uses automated test cases to verify the correctness of generated code.
+- **Real-world Alignment**: Much closer to actual developer workflows than legacy benchmarks.
+
+## Limitations
+- **Language Focus**: Currently primarily focused on Python.
+- **Complexity**: Harder for smaller models to score well, as it requires significant reasoning and knowledge of external libraries.
+- **Execution Overhead**: Requires a complex environment with many pre-installed libraries to run the full evaluation suite.
+
+## When to use it
+- When you need to evaluate an LLM's readiness for integration into a professional IDE or developer tool.
+- When comparing "coding-specific" models (e.g., CodeLlama, DeepSeek-Coder) against general-purpose models.
+
+## When not to use it
+- For testing basic programming logic in a language-agnostic way.
+- For evaluating non-coding capabilities like general reasoning or creative writing.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0)
+- **Cost**: Free to use (software and dataset).
+- **Self-hostable**: Yes, via the BigCodeBench evaluation framework.
+
+## Related tools / concepts
+- [HumanEval](human-eval.md)
+- [MBPP](mbpp.md)
+- [SWE-bench](swe-bench.md)
+- [EvalPlus](evalplus.md)
+- [LiveCodeBench](https://livecodebench.github.io/)
+
+## Sources / References
+- [GitHub Repository](https://github.com/bigcode-project/bigcodebench)
+- [arXiv: BigCodeBench: Benchmarking Code Generation with Diverse Function Calls and Complex Instructions](https://arxiv.org/abs/2406.15877)
+- [Hugging Face Dataset](https://huggingface.co/datasets/bigcode/bigcodebench)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-30
+- Confidence: high

--- a/docs/tools/benchmarking/math-benchmark.md
+++ b/docs/tools/benchmarking/math-benchmark.md
@@ -1,0 +1,54 @@
+# MATH Benchmark
+
+## What it is
+The MATH benchmark is a dataset of 12,500 challenging mathematics competition problems designed to evaluate the mathematical reasoning capabilities of AI models. It was created by researchers at UC Berkeley led by Dan Hendrycks.
+
+## What problem it solves
+Many general-purpose benchmarks only test basic arithmetic or simple word problems. The MATH benchmark pushes models to solve complex, multi-step problems from high school competitions, requiring deep conceptual understanding and precise symbolic reasoning rather than just pattern matching.
+
+## Where it fits in the stack
+**Benchmarking**. It is a specialized tool for evaluating mathematical reasoning and advanced problem-solving skills in LLMs.
+
+## Typical use cases
+- **Mathematical Reasoning Evaluation**: Assessing how well a model can solve complex math problems across different subjects.
+- **Difficulty Scaling Analysis**: Understanding a model's performance limit by testing across five distinct levels of difficulty.
+- **CoT (Chain of Thought) Testing**: Evaluating the quality of a model's step-by-step reasoning using the detailed solutions provided in the dataset.
+
+## Strengths
+- **High Difficulty**: Includes problems from the AMC 10, AMC 12, and AIME competitions, which are difficult even for human experts.
+- **Detailed Solutions**: Every problem comes with a step-by-step human-written solution, enabling fine-grained evaluation of reasoning paths.
+- **Subject Variety**: Covers seven core subjects: Prealgebra, Algebra, Number Theory, Counting and Probability, Geometry, Intermediate Algebra, and Precalculus.
+- **Standardized Scoring**: Uses a simple "correct/incorrect" metric based on the final answer, which is often boxed in LaTeX format.
+
+## Limitations
+- **LaTeX Heavy**: Requires the model to be proficient in reading and generating LaTeX notation.
+- **Parsing Challenges**: Automated scoring can be tricky due to different ways of formatting mathematically equivalent answers (though tools like [MiniCPM](https://github.com/OpenBMB/MiniCPM) and [DeepSeek](https://github.com/deepseek-ai/DeepSeek-Math) have standardized some of this).
+- **Data Contamination**: As one of the most famous benchmarks, it is highly likely that many models have seen some or all of the MATH dataset during pre-training.
+
+## When to use it
+- When you are developing or evaluating models for scientific, engineering, or educational applications.
+- When you want to benchmark the "reasoning ceiling" of a large model.
+
+## When not to use it
+- For evaluating basic numeracy or elementary school math (use [GSM8K](gsm8k.md) instead).
+- For general conversation or instruction-following tasks.
+
+## Licensing and cost
+- **Open Source**: Yes (MIT License for the dataset).
+- **Cost**: Free.
+- **Self-hostable**: Yes, the dataset is available on Hugging Face and GitHub.
+
+## Related tools / concepts
+- [GSM8K](gsm8k.md)
+- [ASDiv](asdiv.md)
+- [MMLU](mmlu.md) (which contains a math sub-section)
+- **Latex**: The standard formatting used for math problems.
+
+## Sources / References
+- [GitHub Repository](https://github.com/hendrycks/math)
+- [arXiv: Measuring Mathematical Problem Solving With the MATH Dataset](https://arxiv.org/abs/2103.03874)
+- [Hugging Face Dataset](https://huggingface.co/datasets/hendrycks/competition_math)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-30
+- Confidence: high

--- a/docs/tools/benchmarking/mt-bench.md
+++ b/docs/tools/benchmarking/mt-bench.md
@@ -1,0 +1,54 @@
+# MT-Bench
+
+## What it is
+MT-Bench (Multi-Turn Benchmark) is a set of 80 high-quality multi-turn questions across eight categories, designed to evaluate the conversational and instruction-following abilities of Large Language Models (LLMs). It was developed by the LMSYS Org (the team behind the Chatbot Arena).
+
+## What problem it solves
+Most traditional benchmarks focus on single-turn interactions. However, real-world usage of LLMs often involves multiple turns where the model must maintain context, follow follow-up instructions, and refine its previous answers. MT-Bench specifically tests this "multi-turn" capability.
+
+## Where it fits in the stack
+**Benchmarking**. It is a key tool for evaluating the "chat" performance of models, sitting between static single-turn benchmarks and full human evaluation.
+
+## Typical use cases
+- **Multi-Turn Evaluation**: Assessing how well a model handles follow-up questions and context retention.
+- **LLM-as-a-judge Testing**: Using a strong model (like GPT-4) to score the responses of other models on a scale of 1-10.
+- **Model Comparison**: Benchmarking open-source chat models against proprietary ones in a conversational setting.
+
+## Strengths
+- **Multi-Turn Logic**: Specifically designed to test how models handle the second turn of a conversation.
+- **Diverse Categories**: Covers Writing, Roleplay, Reasoning, Math, Coding, Extraction, STEM, and Humanities.
+- **Scalable**: Uses an automated scoring system (LLM-as-a-judge) which is faster and cheaper than human evaluation.
+- **Well-Aligned**: Scores show a high correlation (over 80%) with human preferences in the Chatbot Arena.
+
+## Limitations
+- **Judge Bias**: Relying on an LLM judge can introduce biases (e.g., preference for longer answers or specific styles).
+- **Small Sample Size**: With only 80 questions, it provides a "snapshot" rather than an exhaustive evaluation.
+- **Limited to 2 Turns**: While it tests multi-turn capability, it only evaluates two turns per question.
+
+## When to use it
+- When you are building a chatbot or conversational assistant and need to evaluate its dialogue flow.
+- When you want to compare models' ability to follow complex, multi-step instructions in a chat format.
+
+## When not to use it
+- For evaluating purely factual knowledge (use [MMLU](mmlu.md)).
+- For heavy coding-specific tasks where [BigCodeBench](bigcodebench.md) or [HumanEval](human-eval.md) are more appropriate.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0)
+- **Cost**: Free software/dataset, but requires payment for the judge LLM's API.
+- **Self-hostable**: Yes, via the FastChat evaluation framework.
+
+## Related tools / concepts
+- [Chatbot Arena](chatbot-arena.md)
+- [AlpacaEval](alpaca-eval.md)
+- [HELM](helm.md)
+- **FastChat**: The framework used to run MT-Bench.
+
+## Sources / References
+- [GitHub Repository (FastChat)](https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge)
+- [arXiv: Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena](https://arxiv.org/abs/2306.05685)
+- [Official Leaderboard](https://chat.lmsys.org/?leaderboard)
+
+## Contribution Metadata
+- Last reviewed: 2026-03-30
+- Confidence: high

--- a/roadmap.md
+++ b/roadmap.md
@@ -21,6 +21,10 @@ This document tracks missing components and planned technical improvements for t
     - [x] Define Paperless-ngx tag schema for warranties and manuals.
     - [ ] Create n8n workflow to extract expiration dates from warranty documents.
     - [ ] Set up Vector DB index for scanned manuals.
+        - [ ] Evaluate Milvus vs Chroma for technical documentation storage.
+        - [ ] Design metadata schema for manual indexing (e.g., product name, version, document section).
+        - [ ] Implement chunking and embedding logic for structured PDF/Markdown manuals.
+        - [ ] Create verification test for manual retrieval (RAG performance).
     - [ ] Implement chat-based troubleshooting interface using RAG over manuals.
         - [ ] Research best-in-class local embedding models for technical documentation.
         - [ ] Prototype manual ingestion pipeline (PDF to Markdown conversion).


### PR DESCRIPTION
I have processed several 'Issues' (as defined by the Ralph-loop directive) by:
1. Performing the work: Created full 10-section documentation for AlpacaEval, BigCodeBench, MATH Benchmark, and MT-Bench in `docs/tools/benchmarking/`.
2. Integrating links: Updated the daily logs in `docs/new-sources/` (2026-03-20.md and 2026-03-30.md) to mark these items as 'integrated' and link to their new canonical pages.
3. Dividing work: Refined the `roadmap.md` by breaking down the complex 'Set up Vector DB index for scanned manuals' task into four granular sub-tasks (DB evaluation, schema design, chunking/embedding implementation, and retrieval testing).
All changes were verified with the repository's validation suite (`check_catalog_consistency.py`, `check_docs_contract.py`, and `validate_new_sources.py`).

---
*PR created automatically by Jules for task [2045136782661003363](https://jules.google.com/task/2045136782661003363) started by @joanmarcriera*