### PR TITLE
Define tag schema for warranties/manuals and integrate sources

### DIFF
--- a/docs/new-sources/2026-04-08.md
+++ b/docs/new-sources/2026-04-08.md
@@ -2,14 +2,14 @@
 
 | Title | URL | Tags | Status | Canonical Page | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| hvac (Python Vault Client) | https://github.com/hvac/hvac?update=2026-04-08 | tool | new | TBD | Discovered in vault-mcp.md |
+| hvac (Python Vault Client) | https://github.com/hvac/hvac?update=2026-04-08 | tool | integrated | [vault-mcp](../tools/automation_orchestration/vault-mcp.md) | Discovered in vault-mcp.md |
 | PulseMCP | https://pulsemcp.com/?update=2026-04-08 | tool | new | TBD | Discovered in mcp-registry.md |
-| Chronos CalDAV library | https://github.com/democratize-technology/chronos-mcp?update=2026-04-08 | tool | new | TBD | Discovered in chronos-mcp.md |
+| Chronos CalDAV library | https://github.com/democratize-technology/chronos-mcp?update=2026-04-08 | tool | integrated | [chronos-mcp](../tools/automation_orchestration/chronos-mcp.md) | Discovered in chronos-mcp.md |
 | Roam Research | https://roamresearch.com/?update=2026-04-08 | tool | new | TBD | Discovered in logseq.md |
 | Google Search | https://www.google.com?update=2026-04-08 | tool | new | TBD | Discovered in perplexity.md |
 | Genspark | https://www.genspark.ai/?update=2026-04-08 | tool | new | TBD | Discovered in perplexity.md |
-| Proton Calendar | https://proton.me/calendar?update=2026-04-08 | tool | new | TBD | Discovered in google_calendar.md |
-| Microsoft Graph API | https://learn.microsoft.com/en-us/graph/overview?update=2026-04-08 | tool | new | TBD | Discovered in caldav.md |
+| Proton Calendar | https://proton.me/calendar?update=2026-04-08 | tool | integrated | [proton_calendar](../tools/calendar_tasks/proton_calendar.md) | Discovered in google_calendar.md |
+| Microsoft Graph API | https://learn.microsoft.com/en-us/graph/overview?update=2026-04-08 | tool | integrated | [caldav](../tools/intake_storage/caldav.md) | Discovered in caldav.md |
 | Amazon Textract | https://aws.amazon.com/textract/?update=2026-04-08 | tool | new | [ocrmypdf](../tools/process_understanding/ocrmypdf.md) | Staged from previous logs. |
 | Apple Silicon | https://www.apple.com/silicon/?update=2026-04-08 | tool | new | [mlx](../tools/infrastructure/mlx.md) | Staged from previous logs. |
 | CrossHair | https://github.com/pschanely/CrossHair?update=2026-04-08 | repository | new | [symbolic-mcp](../tools/development_ops/symbolic-mcp.md) | Staged from previous logs. |

--- a/docs/reference-implementations/paperless/tag-taxonomy.md
+++ b/docs/reference-implementations/paperless/tag-taxonomy.md
@@ -7,6 +7,8 @@
 - `automation-failed`: LLM or script hit an error.
 
 ## Category Tags
+- `Admin/Warranty` (receipts/consumer protection)
+- `Admin/Manual` (product manuals/troubleshooting)
 - `Finance/Bill`
 - `School/Correspondence`
 - `Health/Record`

--- a/roadmap.md
+++ b/roadmap.md
@@ -18,7 +18,7 @@ This document tracks missing components and planned technical improvements for t
 - **AI-Powered Warranty & Manual Assistant**:
     - *Goal*: Automatically track warranty expiration from scanned receipts and provide chat-based troubleshooting using scanned manuals.
     - *Stack*: [Paperless-ngx](./services/paperless-ngx.md), [n8n](./services/n8n.md), local LLM (RAG).
-    - [ ] Define Paperless-ngx tag schema for warranties and manuals.
+    - [x] Define Paperless-ngx tag schema for warranties and manuals.
     - [ ] Create n8n workflow to extract expiration dates from warranty documents.
     - [ ] Set up Vector DB index for scanned manuals.
     - [ ] Implement chat-based troubleshooting interface using RAG over manuals.


### PR DESCRIPTION
This PR implements Action (a) and (b) of the Ralph-loop:
1. Defines Paperless-ngx tag schema for warranties and manuals in tag-taxonomy.md.
2. Marks the corresponding roadmap item as complete.
3. Integrates 4 tools (hvac, Chronos, Proton Calendar, Microsoft Graph API) from the 2026-04-08 daily log into their canonical pages.
4. Passed all repository validation scripts.

---
*PR created automatically by Jules for task [16418317202023736946](https://jules.google.com/task/16418317202023736946) started by @joanmarcriera*