### PR TITLE
Ralph-loop: Warranty tags and Microsoft Graph API integration

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -1432,6 +1432,12 @@
       "name": "Joplin",
       "category": "AI Assistants & Knowledge",
       "doc_path": "docs/tools/ai_knowledge/joplin.md"
+    },
+    {
+      "id": "microsoft-graph",
+      "name": "Microsoft Graph API",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/microsoft-graph.md"
     }
   ]
 }

--- a/docs/new-sources/2026-04-08.md
+++ b/docs/new-sources/2026-04-08.md
@@ -2,14 +2,14 @@
 
 | Title | URL | Tags | Status | Canonical Page | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| hvac (Python Vault Client) | https://github.com/hvac/hvac?update=2026-04-08 | tool | new | TBD | Discovered in vault-mcp.md |
+| hvac (Python Vault Client) | https://github.com/hvac/hvac?update=2026-04-08 | tool | integrated | [vault-mcp](../tools/automation_orchestration/vault-mcp.md) | Discovered in vault-mcp.md |
 | PulseMCP | https://pulsemcp.com/?update=2026-04-08 | tool | new | TBD | Discovered in mcp-registry.md |
 | Chronos CalDAV library | https://github.com/democratize-technology/chronos-mcp?update=2026-04-08 | tool | new | TBD | Discovered in chronos-mcp.md |
 | Roam Research | https://roamresearch.com/?update=2026-04-08 | tool | new | TBD | Discovered in logseq.md |
 | Google Search | https://www.google.com?update=2026-04-08 | tool | new | TBD | Discovered in perplexity.md |
 | Genspark | https://www.genspark.ai/?update=2026-04-08 | tool | new | TBD | Discovered in perplexity.md |
 | Proton Calendar | https://proton.me/calendar?update=2026-04-08 | tool | new | TBD | Discovered in google_calendar.md |
-| Microsoft Graph API | https://learn.microsoft.com/en-us/graph/overview?update=2026-04-08 | tool | new | TBD | Discovered in caldav.md |
+| Microsoft Graph API | https://learn.microsoft.com/en-us/graph/overview?update=2026-04-08 | tool | integrated | [microsoft-graph](../tools/providers/microsoft-graph.md) | Discovered in caldav.md |
 | Amazon Textract | https://aws.amazon.com/textract/?update=2026-04-08 | tool | new | [ocrmypdf](../tools/process_understanding/ocrmypdf.md) | Staged from previous logs. |
 | Apple Silicon | https://www.apple.com/silicon/?update=2026-04-08 | tool | new | [mlx](../tools/infrastructure/mlx.md) | Staged from previous logs. |
 | CrossHair | https://github.com/pschanely/CrossHair?update=2026-04-08 | repository | new | [symbolic-mcp](../tools/development_ops/symbolic-mcp.md) | Staged from previous logs. |

--- a/docs/reference-implementations/paperless/tag-taxonomy.md
+++ b/docs/reference-implementations/paperless/tag-taxonomy.md
@@ -7,6 +7,8 @@
 - `automation-failed`: LLM or script hit an error.
 
 ## Category Tags
+- `Admin/Warranty` (receipts/consumer protection)
+- `Admin/Manual` (product manuals/troubleshooting)
 - `Finance/Bill`
 - `School/Correspondence`
 - `Health/Record`
@@ -20,7 +22,7 @@
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-01
+- Last reviewed: 2026-04-18
 
 ## Sources / References
 - https://github.com/joanmarcriera/Home-office-automations

--- a/docs/tools/intake_storage/caldav.md
+++ b/docs/tools/intake_storage/caldav.md
@@ -35,7 +35,7 @@ Provides an open, standardized protocol for calendar synchronization, enabling i
 ## Related tools / concepts
 
 - [Google Calendar API](../calendar_tasks/google_calendar.md)
-- [Microsoft Graph API](https://learn.microsoft.com/en-us/graph/overview)
+- [Microsoft Graph API](../providers/microsoft-graph.md)
 - [llama.cpp](../infrastructure/llama-cpp.md)
 - [Text Generation Inference (TGI)](../infrastructure/tgi.md)
 - [Aphrodite Engine](../infrastructure/aphrodite-engine.md)

--- a/docs/tools/providers/microsoft-graph.md
+++ b/docs/tools/providers/microsoft-graph.md
@@ -1,0 +1,46 @@
+# Microsoft Graph API
+
+## What it is
+Microsoft Graph is the gateway to data and intelligence in Microsoft 365. It provides a unified programmability model that you can use to access the tremendous amount of data in Microsoft 365, Windows, and Enterprise Mobility + Security.
+
+## What problem it solves
+It simplifies developer interaction with Microsoft services by providing a single endpoint (`https://graph.microsoft.com`) to access data across multiple services like Outlook, OneDrive, Teams, and Microsoft Entra (formerly Azure AD), rather than requiring separate APIs for each.
+
+## Where it fits in the stack
+**Providers / API Gateway**. It serves as the primary integration point for applications needing to interact with the Microsoft 365 ecosystem.
+
+## Typical use cases
+- Synchronizing calendars (Outlook) and files (OneDrive).
+- Managing users and groups in Microsoft Entra.
+- Automating workflows in Microsoft Teams.
+- Extracting insights from organizational data (e.g., meeting schedules, reporting lines).
+
+## Strengths
+- **Unified Endpoint**: Access a wide range of services through one API.
+- **Rich Relationships**: Navigate between related resources (e.g., from a user to their manager, then to their files).
+- **Extensive Documentation**: Well-supported with SDKs for multiple languages and a powerful Graph Explorer for testing.
+
+## Limitations
+- **Complexity**: The sheer breadth of the API can be overwhelming for simple tasks.
+- **Throttling**: Strict rate limits apply, especially for large-scale data extraction.
+- **Permission Granularity**: Managing OAuth scopes and permissions can be complex.
+
+## When to use it
+- When building applications that need to read or write data within Microsoft 365 services.
+- When you need a standardized way to manage identity and access in a Microsoft-centric environment.
+
+## When not to use it
+- For small-scale, personal automation where simpler, service-specific tools might suffice.
+- When working entirely outside the Microsoft ecosystem.
+
+## Related tools / concepts
+- [CalDAV](../intake_storage/caldav.md)
+- [Google Calendar API](../calendar_tasks/google_calendar.md)
+- [Nextcloud](../../services/nextcloud.md)
+
+## Sources / references
+- [Microsoft Graph Overview](https://learn.microsoft.com/en-us/graph/overview)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-18
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -300,6 +300,7 @@ nav:
       - Moonshot AI: tools/providers/moonshot.md
       - BigSwitch: tools/providers/bigswitch.md
       - Tavily: tools/providers/tavily.md
+      - Microsoft Graph API: tools/providers/microsoft-graph.md
       - AWS Bedrock: tools/providers/aws-bedrock.md
       - Hugging Face: tools/providers/huggingface.md
     - Agents:

--- a/roadmap.md
+++ b/roadmap.md
@@ -18,7 +18,7 @@ This document tracks missing components and planned technical improvements for t
 - **AI-Powered Warranty & Manual Assistant**:
     - *Goal*: Automatically track warranty expiration from scanned receipts and provide chat-based troubleshooting using scanned manuals.
     - *Stack*: [Paperless-ngx](./services/paperless-ngx.md), [n8n](./services/n8n.md), local LLM (RAG).
-    - [ ] Define Paperless-ngx tag schema for warranties and manuals.
+    - [x] Define Paperless-ngx tag schema for warranties and manuals.
     - [ ] Create n8n workflow to extract expiration dates from warranty documents.
     - [ ] Set up Vector DB index for scanned manuals.
     - [ ] Implement chat-based troubleshooting interface using RAG over manuals.


### PR DESCRIPTION
This PR addresses multiple tasks from the Ralph-loop:
1. Defines the Paperless-ngx tag schema for warranties and manuals as requested in the roadmap.
2. Integrates the Microsoft Graph API from the intake log (2026-04-08) by creating a canonical documentation page, updating the tool catalog, and updating navigation.
3. Cleans up the intake log by marking integrated items.
4. Updates cross-links in existing documentation.
All changes have been validated using the repository's consistency and contract check scripts.

---
*PR created automatically by Jules for task [14543594930134937266](https://jules.google.com/task/14543594930134937266) started by @joanmarcriera*