### PR TITLE
Integrate Benchmarks and Break Down Roadmap Tasks

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -660,6 +660,24 @@
       "doc_path": "docs/tools/benchmarking/evalplus.md"
     },
     {
+      "id": "alpaca-eval",
+      "name": "AlpacaEval",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/alpaca-eval.md"
+    },
+    {
+      "id": "mt-bench",
+      "name": "MT-Bench",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/mt-bench.md"
+    },
+    {
+      "id": "math-benchmark",
+      "name": "MATH Benchmark",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/math-benchmark.md"
+    },
+    {
       "id": "actual-budget",
       "name": "Actual Budget",
       "category": "Intake & Storage",

--- a/docs/new-sources/2026-04-07.md
+++ b/docs/new-sources/2026-04-07.md
@@ -3,11 +3,11 @@
 | Title | URL | Tags | Status | Canonical Page | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | MMLU | https://github.com/hendrycks/test?update=2026-04-07 | tool | integrated | [mmlu](../tools/benchmarking/mmlu.md) | Discovered in humanitys-last-exam.md |
-| AlpacaEval | https://github.com/tatsu-lab/alpaca_eval?update=2026-04-07 | tool | new | TBD | Discovered in chatbot-arena.md |
-| MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge?update=2026-04-07 | tool | new | TBD | Discovered in chatbot-arena.md |
+| AlpacaEval | https://github.com/tatsu-lab/alpaca_eval?update=2026-04-07 | tool | integrated | [alpaca-eval](../tools/benchmarking/alpaca-eval.md) | Discovered in chatbot-arena.md |
+| MT-Bench | https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge?update=2026-04-07 | tool | integrated | [mt-bench](../tools/benchmarking/mt-bench.md) | Discovered in chatbot-arena.md |
 | InterCode | https://github.com/princeton-nlp/intercode?update=2026-04-07 | tool | new | TBD | Discovered in terminal-bench.md |
 | Simple `time` command with `curl` | https://github.com/ollama/ollama/blob/main/docs/api.md?update=2026-04-07 | tool | new | TBD | Discovered in ollama-benchmark-cli.md |
-| MATH Benchmark | https://github.com/hendrycks/math?update=2026-04-07 | tool | new | TBD | Discovered in gsm8k.md |
+| MATH Benchmark | https://github.com/hendrycks/math?update=2026-04-07 | tool | integrated | [math-benchmark](../tools/benchmarking/math-benchmark.md) | Discovered in gsm8k.md |
 | ASDiv | https://github.com/chiahsuan/ASDiv?update=2026-04-07 | tool | integrated | [asdiv](../tools/benchmarking/asdiv.md) | Discovered in gsm8k.md |
 | ARC (AI2 Reasoning Challenge) | https://github.com/allenai/ARC-benchmark?update=2026-04-07 | tool | integrated | [arc](../tools/benchmarking/arc.md) | Discovered in gpqa.md |
 | BigCodeBench | https://github.com/bigcode-project/bigcodebench?update=2026-04-07 | tool | integrated | [bigcodebench](../tools/benchmarking/bigcodebench.md) | Discovered in human-eval.md |

--- a/docs/tools/benchmarking/alpaca-eval.md
+++ b/docs/tools/benchmarking/alpaca-eval.md
@@ -1,0 +1,49 @@
+# AlpacaEval
+
+## What it is
+AlpacaEval is an automatic evaluator for instruction-following language models. It is designed to be fast, cheap, and highly correlated with human preferences. It measures the win rate of a model's outputs against a reference model (typically GPT-4 or GPT-4 Turbo) using an LLM-based automatic annotator.
+
+## What problem it solves
+Evaluation of instruction-following models typically requires human interaction, which is time-consuming, expensive, and difficult to replicate. AlpacaEval provides a replicable, automated proxy that allows developers to iterate quickly on model development.
+
+## Where it fits in the stack
+**Benchmarking**. It serves as a middle-ground evaluation tool between static, objective benchmarks (like MMLU) and slow, expensive human evaluations (like Chatbot Arena).
+
+## Typical use cases
+- **Model Development**: Running frequent evaluations during the training or fine-tuning process.
+- **Comparative Analysis**: Measuring how a new model performs against established baselines like GPT-4.
+- **Prompt Engineering**: Testing the impact of different system prompts on model performance.
+
+## Strengths
+- **Speed and Cost**: Can run in less than 5 minutes for under $10.
+- **Human Correlation**: AlpacaEval 2.0 (with length-controlled win rates) has a 0.98 Spearman correlation with Chatbot Arena.
+- **Length Normalization**: Includes a "Length-Controlled" win rate to mitigate the common LLM bias of preferring longer outputs.
+- **Reproducibility**: Uses fixed evaluation sets and cached annotations.
+
+## Limitations
+- **Style over Substance**: Like many LLM-based evaluators, it may favor the style and tone of a response over its factual accuracy.
+- **Instruction Breadth**: The evaluation set might not be representative of extremely complex or niche professional tasks.
+- **Safety**: It does not measure model safety, toxicity, or potential for harm.
+
+## When to use it
+- When you need quick, automated feedback on model quality during development.
+- When you want to see how a model's conversational performance aligns with human-perceived quality.
+
+## When not to use it
+- For high-stakes decisions regarding model safety or final production release.
+- When you need to evaluate specific technical domains (e.g., medical, legal) that require expert verification.
+
+## Related tools / concepts
+- [Chatbot Arena](chatbot-arena.md)
+- [MT-Bench](mt-bench.md)
+- [GPQA](gpqa.md)
+- [MMLU](mmlu.md)
+
+## Sources / references
+- [GitHub Repository](https://github.com/tatsu-lab/alpaca_eval)
+- [AlpacaEval 2.0 Paper (Dubois et al., 2024)](https://arxiv.org/abs/2404.04475)
+- [AlpacaFarm Project](https://github.com/tatsu-lab/alpaca_farm)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-08
+- Confidence: high

--- a/docs/tools/benchmarking/chatbot-arena.md
+++ b/docs/tools/benchmarking/chatbot-arena.md
@@ -34,8 +34,8 @@ Provides a human-preference-based ranking of LLMs that captures subjective quali
 
 ## Related tools / concepts
 
-- [AlpacaEval](https://github.com/tatsu-lab/alpaca_eval)
-- [MT-Bench](https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge)
+- [AlpacaEval](alpaca-eval.md)
+- [MT-Bench](mt-bench.md)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [SWE-bench](swe-bench.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)

--- a/docs/tools/benchmarking/gsm8k.md
+++ b/docs/tools/benchmarking/gsm8k.md
@@ -34,8 +34,8 @@ Provides a standardized way to measure whether LLMs can perform multi-step arith
 
 ## Related tools / concepts
 
-- [MATH Benchmark](https://github.com/hendrycks/math)
-- [ASDiv](https://github.com/chiahsuan/ASDiv)
+- [MATH Benchmark](math-benchmark.md)
+- [ASDiv](asdiv.md)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [SWE-bench](swe-bench.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)

--- a/docs/tools/benchmarking/math-benchmark.md
+++ b/docs/tools/benchmarking/math-benchmark.md
@@ -1,0 +1,48 @@
+# MATH Benchmark
+
+## What it is
+The MATH benchmark is a dataset of 12,500 challenging competition mathematics problems. Each problem has a step-by-step solution and a final answer formatted in LaTeX. The problems range from introductory algebra to calculus and are drawn from various high school math competitions.
+
+## What problem it solves
+Traditional math benchmarks (like GSM8K) often focus on elementary arithmetic and simple word problems. The MATH benchmark provides a much higher "ceiling" for evaluation, testing a model's ability to perform complex symbolic reasoning, multi-step proofs, and advanced problem-solving across diverse mathematical fields.
+
+## Where it fits in the stack
+**Benchmarking**. It is the gold standard for evaluating high-level mathematical reasoning and symbolic logic in LLMs.
+
+## Typical use cases
+- **Deep Reasoning Evaluation**: Testing a model's ability to solve problems that require more than just arithmetic (e.g., number theory, geometry).
+- **Prompt Engineering for Logic**: Evaluating the effectiveness of Chain-of-Thought (CoT) or program-aided reasoning on difficult tasks.
+- **Model Specialized Training**: Using the MATH dataset (or the associated AMPS pretraining dataset) to fine-tune models for mathematical proficiency.
+
+## Strengths
+- **High Difficulty**: Challenges even the most capable models, providing a clear differentiation in reasoning ability.
+- **Diverse Subjects**: Includes Algebra, Counting & Probability, Geometry, Number Theory, Prealgebra, Precalculus, and Intermediate Algebra.
+- **Rich Context**: Every problem includes a full step-by-step human-written solution, not just the final answer.
+
+## Limitations
+- **Format Sensitivity**: Models often struggle with the LaTeX formatting required for answers.
+- **Data Contamination**: As a widely used public dataset, there is a high risk that problems and solutions have leaked into the training data of newer models.
+- **Rigid Scoring**: Typically uses Exact Match (EM) for the final LaTeX string, which can penalize models for mathematically correct but differently formatted answers.
+
+## When to use it
+- When comparing the reasoning capabilities of "frontier" models.
+- When evaluating models specifically for scientific or mathematical applications.
+
+## When not to use it
+- For evaluating general conversational quality or creative writing.
+- When testing basic arithmetic (use [GSM8K](gsm8k.md) instead).
+
+## Related tools / concepts
+- [GSM8K](gsm8k.md)
+- [ASDiv](asdiv.md)
+- [GPQA](gpqa.md)
+- [HumanEval](human-eval.md)
+
+## Sources / references
+- [GitHub Repository](https://github.com/hendrycks/math)
+- [MATH Dataset Paper: "Measuring Mathematical Problem Solving" (Hendrycks et al., 2021)](https://arxiv.org/abs/2103.03874)
+- [Hugging Face Dataset](https://huggingface.co/datasets/competition_math)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-08
+- Confidence: high

--- a/docs/tools/benchmarking/mt-bench.md
+++ b/docs/tools/benchmarking/mt-bench.md
@@ -1,0 +1,49 @@
+# MT-Bench
+
+## What it is
+MT-Bench is a benchmark designed to evaluate the multi-turn conversational capabilities of Large Language Models (LLMs). It consists of 80 high-quality, multi-turn questions across eight categories: writing, roleplay, extraction, reasoning, math, coding, knowledge I (STEM), and knowledge II (humanities/social science).
+
+## What problem it solves
+Many traditional benchmarks only evaluate single-turn responses, failing to capture a model's ability to maintain context, follow instructions across multiple exchanges, and handle the dynamic nature of real-world conversations.
+
+## Where it fits in the stack
+**Benchmarking**. It is a core component of the LMSYS FastChat evaluation framework, providing a more rigorous test of conversational flow than single-turn evaluations.
+
+## Typical use cases
+- **Conversational AI Evaluation**: Assessing how well a chatbot handles follow-up questions and maintains context.
+- **Model Comparison**: Ranking chat-tuned models based on their ability to handle complex, multi-step instructions.
+- **LLM-as-a-Judge Validation**: MT-Bench is often used with GPT-4 as a judge to provide automated, scalable scoring that correlates with human judgment.
+
+## Strengths
+- **Multi-turn Focus**: Specifically designed to test conversation depth.
+- **Diverse Categories**: Covers a wide range of tasks from coding to roleplay.
+- **Strong Human Correlation**: GPT-4 based scoring on MT-Bench shows over 80% agreement with human experts.
+- **Open Dataset**: The questions and human judgments are publicly available for research.
+
+## Limitations
+- **Judge Bias**: If using an LLM as a judge, it may inherit the biases of that judge (e.g., preference for certain styles or lengths).
+- **Scale**: With 80 questions, it is smaller than some "massive" benchmarks, though the multi-turn nature adds complexity.
+- **Static Nature**: Like all fixed benchmarks, it risks data contamination over time.
+
+## When to use it
+- When evaluating chat-tuned models where multi-turn interaction is a primary use case.
+- When you need an automated conversational benchmark that aligns closely with human preference.
+
+## When not to use it
+- For evaluating base (non-chat-tuned) models that are not designed for dialogue.
+- When you only need to measure narrow technical capabilities like raw code execution or mathematical proof (use specialized benchmarks instead).
+
+## Related tools / concepts
+- [Chatbot Arena](chatbot-arena.md)
+- [AlpacaEval](alpaca-eval.md)
+- [GSM8K](gsm8k.md)
+- [HumanEval](human-eval.md)
+
+## Sources / references
+- [FastChat GitHub (LLM Judge)](https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge)
+- [MT-Bench Paper: "Judging LLM-as-a-judge" (Zheng et al., 2023)](https://arxiv.org/abs/2306.05685)
+- [LMSYS Leaderboard](https://arena.lmsys.org/leaderboard)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-08
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,6 +217,9 @@ nav:
       - ARC (AI2 Reasoning Challenge): tools/benchmarking/arc.md
       - ASDiv: tools/benchmarking/asdiv.md
       - BigCodeBench: tools/benchmarking/bigcodebench.md
+      - AlpacaEval: tools/benchmarking/alpaca-eval.md
+      - MT-Bench: tools/benchmarking/mt-bench.md
+      - MATH Benchmark: tools/benchmarking/math-benchmark.md
     - Calendar & Tasks:
       - Overview: tools/calendar_tasks/index.md
       - Google Calendar: tools/calendar_tasks/google_calendar.md

--- a/roadmap.md
+++ b/roadmap.md
@@ -4,6 +4,10 @@ This document tracks missing components and planned technical improvements for t
 
 ## Missing Pieces (Must-Haves)
 - **Centralized Error Queue**: A unified dashboard (e.g. specialized Home Assistant view) to see all failed n8n workflows.
+    - [ ] Research dashboard tools for n8n error visualization (e.g., Home Assistant, custom Grafana dashboard).
+    - [ ] Define a standardized error schema for n8n sub-workflows (status, model, workflow_id, timestamp).
+    - [ ] Implement a "Push to Error Queue" sub-workflow in n8n for global reuse.
+    - [ ] Create a basic Home Assistant dashboard to display the error queue via REST sensor or MQTT.
 - **Human-in-the-Loop (HITL) UI**: A simple web interface to approve or correct AI-extracted dates before they hit the calendar.
 - [x] **Audit Trail**: Logging which LLM version and prompt version was used for every document extraction (see [Standards](docs/standards.md)).
 
@@ -29,9 +33,10 @@ This document tracks missing components and planned technical improvements for t
 - **Smart Energy Anomaly Detection**:
     - *Goal*: Use local reasoning to detect unusual power spikes or appliances left on, providing proactive alerts.
     - *Stack*: [Home Assistant](./services/home-assistant.md), [Ollama](./services/ollama.md).
-    - [ ] Research Home Assistant power monitoring sensors in `docs/services/home-assistant.md`.
-    - [ ] Define baseline vs anomaly logic in a new reference implementation file.
-    - [ ] Create n8n workflow for LLM-based reasoning using Ollama node.
+    - [ ] Identify candidate power monitoring sensors in Home Assistant for key appliances (Washer, Fridge, EV).
+    - [ ] Research Home Assistant "Utility Meter" and "Derivative" sensors for baseline usage patterns.
+    - [ ] Define baseline vs anomaly logic (e.g., spike duration, time-of-day weighting) in a new reference implementation file.
+    - [ ] Create n8n workflow for LLM-based reasoning using Ollama node to classify spikes as "Normal" or "Anomaly".
 
 ### Family Knowledge Management
 - **Personalized Family "Daily Briefing"**:


### PR DESCRIPTION
I have processed multiple items from the repository backlog as part of the Ralph-loop:

1. **"Do the work"**: I researched and integrated three major LLM benchmarking tools (`AlpacaEval`, `MT-Bench`, and `MATH Benchmark`) that were pending in the `docs/new-sources/2026-04-07.md` log. This included creating full 10-section documentation for each, updating the global tool registry and site navigation, and establishing internal cross-links.

2. **"Divide the work"**: I identified two complex roadmap items ("Centralized Error Queue" and "Smart Energy Anomaly Detection") and broke them down into 4 specific technical sub-tasks each in `roadmap.md`. This provides a clearer path for implementation in future loops.

All changes have been validated using the repository's consistency scripts and adhere to the `AGENTS.md` and `docs/standards.md` contracts.

---
*PR created automatically by Jules for task [4715068849840068993](https://jules.google.com/task/4715068849840068993) started by @joanmarcriera*