### PR TITLE
Integrate VAKRA Benchmark and Notion Software Factory Insights

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -570,6 +570,12 @@
       "doc_path": "docs/tools/benchmarking/terminal-bench.md"
     },
     {
+      "id": "vakra",
+      "name": "VAKRA Benchmark",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/vakra.md"
+    },
+    {
       "id": "ollama-benchmark-cli",
       "name": "Ollama Benchmark CLI",
       "category": "Benchmarking",

--- a/docs/knowledge_base/patterns/software-factories.md
+++ b/docs/knowledge_base/patterns/software-factories.md
@@ -12,9 +12,10 @@ The Software Factory is an architectural pattern for non-interactive software de
 **Pattern**. This belongs in the upper layers of the agentic stack, specifically under **Orchestration** and **Quality Assurance**. It defines the workflow loop for high-autonomy coding agents.
 
 ## Typical use cases
-- Developing complex security software with unreviewed code.
-- Building high-fidelity clones (Digital Twins) of SaaS services (Okta, Slack, Jira) for safe, high-volume testing.
-- "Gene Transfusion": Extracting patterns from legacy systems and porting them to new architectures autonomously.
+- **Continuous Maintenance**: Agents that automatically monitor, debug, and patch production codebases.
+- **Enterprise System-of-Record**: Turning collaboration tools (like Notion) into agent-native environments where agents spec, code, and verify work in a shared database.
+- **Digital Twin Development**: Building high-fidelity clones of SaaS services (Okta, Slack, Jira) for safe, high-volume testing.
+- **Gene Transfusion**: Extracting patterns from legacy systems and porting them to new architectures autonomously.
 
 ## Strengths
 - **Compounding Correctness**: Long-horizon agentic workflows can self-correct when guided by a strong validation loop.
@@ -54,17 +55,27 @@ To implement the Software Factory pattern in local, free-as-in-beer environments
 - Implement **Red/Green TDD** loops where the local agent must first make a failing test pass before moving to the next scenario.
 - Use **Scenario-as-Holdout**: Store end-to-end user stories in a local directory that the agent only sees during the validation phase, not during the implementation phase.
 
+## Lessons from "Token Town" (Notion's Journey)
+Building a software factory at scale (as seen in Notion's 2026 "Custom Agents" rollout) reveals several critical requirements:
+- **Iterative Rebuilds**: Success often requires 4–5 architectural shifts as model capabilities (context window, tool-calling reliability) evolve.
+- **Specification Layer**: A robust factory needs a human-readable spec layer (e.g., Markdown files, Notion pages, or structured databases) that agents can commit to and humans can review.
+- **Self-Verification Loop**: Agents must be able to download datasets, run evals, iterate on failures, and implement fixes autonomously within a "rigorous outer system."
+- **Progressive Disclosure**: When a system has hundreds of tools, agents need mechanisms to discover and load only relevant tools to avoid "nerfing" model performance or wasting tokens.
+- **Bootstrapping Power**: The most capable agents can configure themselves, inspect their own failures, and even edit their own system instructions when blocked.
+
 ## Related tools / concepts
 - [Agentic Engineering Patterns](https://simonwillison.net/guides/agentic-engineering-patterns/)
 - [Digital Twin Universe](https://factory.strongdm.ai/techniques/dtu)
 - [Qwen 2.5 Coder](../../tools/ai_knowledge/qwen.md)
 - [Jules](../../tools/ai_knowledge/jules.md) (The autonomous coding agent used in this hub)
+- [Notion AI](../../tools/ai_knowledge/notion-ai.md) (Implementing Agent-Native systems of record)
 
 ## Sources / References
+- [Latent Space: Notion's Token Town & The Software Factory Future](https://www.latent.space/p/notion)
 - [Simon Willison: Software Factories and the Agentic Moment](https://simonwillison.net/2026/Feb/7/software-factory/)
 - [StrongDM Software Factory Principles](https://factory.strongdm.ai/principles)
 - [StrongDM Techniques](https://factory.strongdm.ai/techniques)
 
 ## Contribution Metadata
-- Last reviewed: 2026-03-09
+- Last reviewed: 2026-04-16
 - Confidence: high

--- a/docs/new-sources/2026-04-16.md
+++ b/docs/new-sources/2026-04-16.md
@@ -9,5 +9,5 @@
 | Claude Code Updates | https://thenewstack.io/claude-code-can-now-do-your-job-overnight/ | tool, development | integrated | [Claude Code](../tools/development_ops/claude-code.md) | Claude Code redesign and overnight task capabilities. |
 | Cloudflare Mesh | https://thenewstack.io/cloudflare-mesh-agent-networking/ | service, networking | integrated | [Cloudflare Mesh](../services/cloudflare-mesh.md) | Private network for AI agents. |
 | Claude Mythos | https://thenewstack.io/claude-mythos-preview-simulation/ | model, tool | integrated | [Claude Mythos](../tools/ai_knowledge/claude-mythos.md) | Frontier model completing full cyberattack simulations. |
-| VAKRA Benchmark | https://huggingface.co/blog/ibm-research/vakra-benchmark-analysis | benchmark | new | | Inside VAKRA: Reasoning, Tool Use, and Failure Modes of Agents. |
-| Notion Software Factory | https://www.latent.space/p/notion | pattern, agents | new | | Notion’s Token Town: 5 Rebuilds, 100+ Tools, MCP vs CLIs and the Software Factory Future. |
+| VAKRA Benchmark | https://huggingface.co/blog/ibm-research/vakra-benchmark-analysis | benchmark | integrated | [VAKRA Benchmark](../tools/benchmarking/vakra.md) | Inside VAKRA: Reasoning, Tool Use, and Failure Modes of Agents. |
+| Notion Software Factory | https://www.latent.space/p/notion | pattern, agents | integrated | [Notion AI](../tools/ai_knowledge/notion-ai.md) | Notion’s Token Town: 5 Rebuilds, 100+ Tools, MCP vs CLIs and the Software Factory Future. |

--- a/docs/tools/ai_knowledge/notion-ai.md
+++ b/docs/tools/ai_knowledge/notion-ai.md
@@ -10,16 +10,17 @@ Bridges the gap between a knowledge base and an AI assistant, allowing users to 
 AI & Knowledge — integrated productivity and workspace assistant.
 
 ## Typical use cases
-- Summarizing meeting notes and project documents
-- Drafting content, emails, and brainstorm lists
-- Extracting action items from unstructured text
-- Improving writing (editing for tone, length, or clarity)
-- Q&A over the entire workspace knowledge base
+- **Summarizing meeting notes and project documents**: Meeting Notes act as a high-signal data capture point for the whole workspace.
+- **Drafting content, emails, and brainstorm lists**: High-velocity drafting within the context of a team's shared knowledge.
+- **Extracting action items from unstructured text**: Automating follow-ups and task creation.
+- **Custom Agents**: Building specialized agents that triage email, enrich applicants with web search, and write structured data to databases.
+- **Q&A and Agentic Search**: Natural language search over the entire workspace knowledge base, optimized for agent retrieval (Top-K over CTR).
 
 ## Strengths
-- Seamlessly integrated into an existing popular workspace tool
-- Context-aware; can reference other pages and data within Notion
-- Easy to use with "Ask AI" prompts and contextual menus
+- **Seamless Integration**: AI lives where collaboration data (pages, databases) already exists.
+- **Agent-Native System of Record**: Pages and databases serve as "memory" for agents, accessible by both humans and LLMs.
+- **Usage-Based Credits**: A pricing model (Notion Credits) that allows customers to pay for what they use across different model tiers and tool capabilities.
+- **Context-Awareness**: Agents can reference other pages and data within Notion for high-fidelity multi-hop reasoning.
 
 ## Limitations
 - Requires a paid add-on to the standard Notion subscription
@@ -41,8 +42,9 @@ AI & Knowledge — integrated productivity and workspace assistant.
 
 ## Sources / references
 - [Official Website](https://www.notion.so/product/ai)
+- [Latent Space: Notion's Token Town & The Software Factory Future](https://www.latent.space/p/notion)
 - [SmartAIToolsHub](https://www.smartaitoolshub.online/2026/03/ai-tools-replacing-human-jobs-2026.html)
 
 ## Contribution Metadata
-- Last reviewed: 2026-03-08
+- Last reviewed: 2026-04-16
 - Confidence: high

--- a/docs/tools/benchmarking/index.md
+++ b/docs/tools/benchmarking/index.md
@@ -17,3 +17,4 @@ For a conceptual overview of model comparison platforms and evaluation metrics, 
 - [Pa Bench](pa-bench.md)
 - [Swe Bench](swe-bench.md)
 - [Terminal Bench](terminal-bench.md)
+- [VAKRA Benchmark](vakra.md)

--- a/docs/tools/benchmarking/vakra.md
+++ b/docs/tools/benchmarking/vakra.md
@@ -1,0 +1,44 @@
+# VAKRA: Executable Benchmark for Enterprise Agents
+
+## What it is
+VAKRA is a tool-grounded, executable benchmark designed to evaluate how well AI agents reason and act in enterprise-like environments. Unlike traditional benchmarks that test isolated skills, VAKRA measures **compositional reasoning** across APIs and documents, using full execution traces to assess multi-step workflow completion.
+
+## What problem it solves
+It addresses the gap between surface-level tool competence and robust, end-to-end agent reliability. VAKRA provides an executable environment with over 8,000 locally hosted APIs across 62 domains, preventing models from relying on memorized outputs and forcing them to navigate real API interactions, multi-hop reasoning, and policy constraints.
+
+## Where it fits in the stack
+**Benchmarking**. It is used to evaluate the reasoning, tool-use, and failure modes of high-autonomy agents.
+
+## Core Capabilities
+VAKRA evaluates agents across four distinct task types:
+
+1.  **API Chaining (Business Intelligence)**: Uses SLOT-BIRD (generic tools) and SEL-BIRD (specialized tools) collections to test the ability to sequence 1–12 tool calls.
+2.  **Tool Selection (Dashboard APIs)**: Requires selecting the correct API from sets ranging from 6 to 328 tools (REST-BIRD collection).
+3.  **Multi-Hop Reasoning**: Tests logical hops (1–5) using dashboard APIs to combine multiple pieces of evidence.
+4.  **Multi-Hop Multi-Source Reasoning & Policy Adherence**: The most complex tier, involving RAG (Document Retrieval), API calls, multi-turn dialog, and plain-text tool-usage policies (e.g., "only use document retrievers for Technology topics").
+
+## Evaluation Framework
+VAKRA uses a waterfall-style evaluation pipeline:
+- **Policy Verification**: Programmatically checks if tool-use constraints were followed.
+- **Trajectory Comparison**: Executes predicted tool calls and compares intermediate results against ground truth. It supports alternative valid reasoning paths using a secondary LLM-based judge.
+- **Final Response Evaluation**: An LLM judge ensures the final answer is grounded in tool outputs and factually consistent with the ground truth.
+
+## Key Insights
+- **Compositional Failure**: Models frequently break down when required to combine APIs, documents, and policy requirements.
+- **Policy Struggles**: Agents often struggle to incorporate external constraints (policies) into their reasoning process.
+- **Hop Degradation**: Performance markedly drops as the number of logical hops increases, especially beyond 3 hops.
+
+## Related tools / concepts
+- [SWE-bench](swe-bench.md)
+- [HumanEval](human-eval.md)
+- [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
+- [Agent Skills Best Practices](../../knowledge_base/patterns/skills-best-practices.md)
+
+## Sources / References
+- [Hugging Face Blog: Inside VAKRA](https://huggingface.co/blog/ibm-research/vakra-benchmark-analysis)
+- [VAKRA Dataset on Hugging Face](https://huggingface.co/datasets/ibm-research/VAKRA)
+- [VAKRA GitHub Repository](https://github.com/IBM/vakra)
+
+## Contribution Metadata
+- Last reviewed: 2026-04-16
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,6 +224,7 @@ nav:
       - Ollama Benchmark Cli: tools/benchmarking/ollama-benchmark-cli.md
       - Pa Bench: tools/benchmarking/pa-bench.md
       - Swe Bench: tools/benchmarking/swe-bench.md
+      - VAKRA Benchmark: tools/benchmarking/vakra.md
       - Terminal Bench: tools/benchmarking/terminal-bench.md
       - MMLU: tools/benchmarking/mmlu.md
       - ARC (AI2 Reasoning Challenge): tools/benchmarking/arc.md


### PR DESCRIPTION
This PR integrates two key pending items from the source logs: the IBM VAKRA Benchmark and Notion's Software Factory implementation insights. 

Key changes:
- New canonical page for VAKRA: Detailed documentation of the executable benchmark for enterprise agents, covering its core capabilities (API Chaining, Tool Selection, Multi-Hop Reasoning, Policy Adherence).
- Software Factory pattern update: Added insights from Notion's journey, including the importance of iterative rebuilds, human-readable spec layers, and progressive tool disclosure.
- Notion AI tool update: Integrated new features like Custom Agents for background automation and Meeting Notes as a data capture primitive.
- Metadata and tracking synchronization: Updated `data/all_tools.json`, `mkdocs.yml`, and `docs/new-sources/2026-04-16.md` to reflect the integrated status.

---
*PR created automatically by Jules for task [3119535520346358386](https://jules.google.com/task/3119535520346358386) started by @joanmarcriera*