### PR TITLE
Ralph-loop: Triage 2026-04-16 items and integrate Gemini for macOS

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -1578,6 +1578,12 @@
       "doc_path": "docs/tools/ai_knowledge/gemini-flash-tts.md"
     },
     {
+      "id": "gemini-macos",
+      "name": "Gemini for macOS",
+      "category": "AI Assistants & Knowledge",
+      "doc_path": "docs/tools/ai_knowledge/gemini-macos.md"
+    },
+    {
       "id": "skills-in-chrome",
       "name": "Skills in Chrome",
       "category": "AI Assistants & Knowledge",

--- a/docs/new-sources.md
+++ b/docs/new-sources.md
@@ -6,7 +6,7 @@ This index tracks daily source-ingestion files. Each day gets a dedicated log fi
 
 | Date | Log File | New | Integrated | Notes |
 | :--- | :--- | :---: | :---: | :--- |
-| 2026-04-16 | [2026-04-16](/new-sources/2026-04-16/) | 2 | 7 | AI Daily Digest discovery. |
+| 2026-04-16 | [2026-04-16](/new-sources/2026-04-16/) | 18 | 10 | AI Daily Digest discovery. |
 | 2026-04-08 | [2026-04-08](/new-sources/2026-04-08/) | 0 | 29 | Staged General Tools/Services from older logs. |
 | 2026-04-07 | [2026-04-07](/new-sources/2026-04-07/) | 0 | 12 | Staged Benchmarking items; integrated all items. |
 | 2026-04-06 | [2026-04-06](/new-sources/2026-04-06/) | 0 | 1 | Audit of tool documentation related sections and missing local docs. |

--- a/docs/new-sources/2026-04-16.md
+++ b/docs/new-sources/2026-04-16.md
@@ -11,3 +11,22 @@
 | Claude Mythos | https://thenewstack.io/claude-mythos-preview-simulation/ | model, tool | integrated | [Claude Mythos](../tools/ai_knowledge/claude-mythos.md) | Frontier model completing full cyberattack simulations. |
 | VAKRA Benchmark | https://huggingface.co/blog/ibm-research/vakra-benchmark-analysis | benchmark | integrated | [VAKRA Benchmark](../tools/benchmarking/vakra.md) | Inside VAKRA: Reasoning, Tool Use, and Failure Modes of Agents. |
 | Notion Software Factory | https://www.latent.space/p/notion | pattern, agents | integrated | [Notion AI](../tools/ai_knowledge/notion-ai.md) | Notion’s Token Town: 5 Rebuilds, 100+ Tools, MCP vs CLIs and the Software Factory Future. |
+| AI for the Economy Forum | https://blog.google/company-news/outreach-and-initiatives/creating-opportunity/ai-economy-forum/ | event, economy | new | | Bringing people together at AI for the Economy Forum. |
+| RIP Pull Requests | https://www.latent.space/p/ainews-rip-pull-requests-2005-2026 | analysis, dev-ops | new | | [AINews] RIP Pull Requests (2005-2026). |
+| Humanity's Last Gasp | https://www.latent.space/p/ainews-humanitys-last-gasp | analysis, model | new | | [AINews] Humanity's Last Gasp. |
+| Top Local Models - April 2026 | https://www.latent.space/p/ainews-top-local-models-list-april | local-ai, list | new | | [AINews] Top Local Models List - April 2026. |
+| Google Axion Processors | https://thenewstack.io/google-axion-kubernetes-arm/ | infrastructure, hardware | new | | A year in, Google wants its Axion processors to feel like a scheduling decision. |
+| Google Gemini Mac app | https://thenewstack.io/gemini-app-macos-launch/ | tool, macos | integrated | [Gemini for macOS](../tools/ai_knowledge/gemini-macos.md) | Google Gemini Mac app debuts to end the clunky hunt for browser tabs. |
+| Rise of Personal Software | https://thenewstack.io/claude-code-and-the-rise-of-personal-software/ | analysis, tool | new | | Claude Code and the rise of personal software. |
+| Data Stack Consolidation | https://thenewstack.io/data-stack-consolidation-risks/ | analysis, data | new | | What engineering leaders get wrong about data stack consolidation. |
+| Supermetal Benchmark | https://thenewstack.io/postgres-iceberg-cdc-benchmarks/ | tool, benchmark | new | | Postgres to Iceberg in 13 minutes: How Supermetal compares to Flink, Kafka Connect, and Spark. |
+| Cal.com Security | https://thenewstack.io/cal-com-codebase-security-ai/ | news, security | new | | Cal.com goes private: A security reckoning for open source. |
+| Cloud Database Risk | https://thenewstack.io/cloud-database-complacency-research/ | analysis, cloud | new | | Why “good enough” cloud databases are becoming a business risk. |
+| Securing AI Agent Systems | https://thenewstack.io/securing-ai-agent-systems/ | security, agents | new | | Agents are rewriting the rules of security. Here’s what engineering needs to know. |
+| AI Code QA Bottleneck | https://thenewstack.io/ai-code-qa-bottleneck/ | analysis, dev-ops | new | | When AI writes 100K lines of code, QA becomes the whole job. |
+| AI Auditing Tools | https://thenewstack.io/agentic-ai-observability-auditing/ | tool, observability | new | | Why observability platforms are becoming AI auditing tools. |
+| Claude Code Desktop App | https://thenewstack.io/claude-code-desktop-redesign/ | tool, desktop | new | | Anthropic’s redesigned Claude Code desktop app lets you burn through tokens even faster. |
+| Spring Creator on Agents | https://thenewstack.io/spring-creator-java-type-system-agentic-ai-rod-johnson/ | analysis, agents | new | | Spring creator wants Java’s type system to tame agentic AI. |
+| Invisible Kubernetes | https://thenewstack.io/aws-kubernetes-invisible-simplicity/ | cloud, infrastructure | new | | Can you make Kubernetes invisible? Here’s why AWS is on a mission to do it. |
+| Kumo Foundation Models | https://thenewstack.io/kumo-ai-foundation-models/ | tool, model | new | | Kumo’s new foundation model replaces months of data science engineering with plain-English queries. |
+| Real-time Sync Engine | https://thenewstack.io/real-time-sync-engine/ | pattern, sync | new | | From clobbered drafts to real-time sync. |

--- a/docs/tools/ai_knowledge/gemini-macos.md
+++ b/docs/tools/ai_knowledge/gemini-macos.md
@@ -27,4 +27,5 @@ Google Gemini for macOS is a native desktop application designed to provide a se
 - [Google Gemini Mac app debuts to end the clunky hunt for browser tabs](https://thenewstack.io/gemini-app-macos-launch/) (The New Stack, 2026-04-16)
 
 ---
-*Last reviewed: 2026-04-16* | *Confidence: High*
+- Last reviewed: 2026-04-16
+- Confidence: high

--- a/docs/tools/ai_knowledge/gemini-macos.md
+++ b/docs/tools/ai_knowledge/gemini-macos.md
@@ -1,0 +1,30 @@
+# Google Gemini for macOS
+
+Google Gemini for macOS is a native desktop application designed to provide a seamless AI assistant experience directly on the desktop. It integrates with macOS features to enhance productivity and streamline workflows.
+
+## Key Features
+
+- **Native Experience**: A dedicated application that avoids the need to hunt through browser tabs.
+- **Tab Management**: Deep integration with Chrome and other browsers to help manage and search through open tabs.
+- **Quick Access**: Accessible via keyboard shortcuts or the menu bar for immediate AI assistance.
+- **Multi-modal Support**: Supports text, image, and voice interactions (depending on the model tier).
+
+## Use Cases
+
+- **Productivity Booster**: Use Gemini to summarize documents, draft emails, or generate code snippets without leaving your desktop environment.
+- **Browser Companion**: Quickly find information across dozens of open tabs using natural language queries.
+- **Creative Assistant**: Brainstorm ideas or generate images directly within your creative workflow.
+
+## Installation & Setup
+
+1. Download the Gemini for macOS installer from the official Google website.
+2. Drag the application to your `Applications` folder.
+3. Sign in with your Google account.
+4. (Optional) Grant accessibility permissions to enable advanced tab management features.
+
+## Sources / References
+
+- [Google Gemini Mac app debuts to end the clunky hunt for browser tabs](https://thenewstack.io/gemini-app-macos-launch/) (The New Stack, 2026-04-16)
+
+---
+*Last reviewed: 2026-04-16* | *Confidence: High*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Claude Mythos: tools/ai_knowledge/claude-mythos.md
       - Gemini: tools/ai_knowledge/gemini.md
       - Gemini Flash TTS: tools/ai_knowledge/gemini-flash-tts.md
+      - Gemini for macOS: tools/ai_knowledge/gemini-macos.md
       - Copy.ai: tools/ai_knowledge/copy-ai.md
       - DeepSeek: tools/ai_knowledge/deepseek.md
       - Dex: tools/ai_knowledge/dex.md


### PR DESCRIPTION
Triaged 19 missing items from the 2026-04-16 AI Daily Digest into the daily source log, created canonical documentation for "Google Gemini for macOS", and updated the tools catalog and navigation.

---
*PR created automatically by Jules for task [10056322896366710816](https://jules.google.com/task/10056322896366710816) started by @joanmarcriera*