### PR TITLE
Resolve Issue #186: Data Copilot Layered Architecture Documentation

### DIFF
--- a/docs/architecture/data-copilot-text-to-sql.md
+++ b/docs/architecture/data-copilot-text-to-sql.md
@@ -65,6 +65,15 @@ To maintain a "free/cheap-first" stack, we recommend the following model routing
 | Column Pruning | Qwen 2.5 7B (Local) | Structured output is critical here. |
 | SQL Generation | GPT-4o-mini or Claude 3.5 Haiku | High reliability for syntax at low cost. |
 
+## Token Control & Schema Pruning Strategy
+
+To minimize costs and stay within the context limits of smaller models, the following pruning strategies are used:
+
+1.  **Semantic Table Filtering**: Instead of sending all table schemas, we use an embedding-based search (RAG) to find the top $N$ (usually 3-5) most relevant tables for the intent.
+2.  **Column-Level Pruning**: Once tables are selected, only the primary keys, foreign keys, and columns identified by the **Column Prune Agent** are included in the final SQL generation prompt.
+3.  **Schema metadata**: We include short comments in the schema (e.g., `-- type: categorical`) rather than raw data samples to keep token counts low.
+4.  **Fallback Routing**: If a query fails on a local model (e.g. Qwen 2.5 7B), it is automatically routed to a more capable but expensive model (e.g. Claude 3.5 Sonnet) with the same pruned schema.
+
 ## Failure Modes & Mitigation
 
 1. **Wrong Domain (Router Failure)**:


### PR DESCRIPTION
I have systematically verified the deliverables for issue #186 (Layered Text-to-SQL architecture). 

While the core architecture was already present in `docs/architecture/data-copilot-text-to-sql.md` and a reference implementation in `docs/reference-implementations/data-copilot/skeleton.py`, the specific requirement for documented 'token controls and schema pruning' (Deliverable #3) was not explicitly handled.

I have updated `docs/architecture/data-copilot-text-to-sql.md` to include a dedicated 'Token Control & Schema Pruning Strategy' section, covering semantic filtering, column-level pruning, and fallback routing.

I have also confirmed that at least 3 failure modes and a 'when not to use' section are present as per the acceptance criteria.

This is the first step in resolving the five oldest open issues in the repository.

---
*PR created automatically by Jules for task [6196703998792070642](https://jules.google.com/task/6196703998792070642) started by @joanmarcriera*