### PR TITLE
Audit and Update Related Tools Sections in Documentation

### DIFF
--- a/docs/new-sources.md
+++ b/docs/new-sources.md
@@ -6,6 +6,7 @@ This index tracks daily source-ingestion files. Each day gets a dedicated log fi
 
 | Date | Log File | New | Integrated | Notes |
 | :--- | :--- | :---: | :---: | :--- |
+| 2026-04-27 | [2026-04-27](/new-sources/2026-04-27/) | 5 | 0 | Audit of tool documentation related sections and missing local docs. |
 | 2026-04-26 | [2026-04-26](/new-sources/2026-04-26/) | 10 | 8 | Decomposed tasks from #360, #299, #296. Integrated 8 items. |
 | 2026-04-16 | [2026-04-16](/new-sources/2026-04-16/) | 0 | 28 | AI Daily Digest discovery. |
 | 2026-04-08 | [2026-04-08](/new-sources/2026-04-08/) | 0 | 29 | Staged General Tools/Services from older logs. |

--- a/docs/new-sources/2026-04-27.md
+++ b/docs/new-sources/2026-04-27.md
@@ -1,0 +1,9 @@
+# New Sources Log — 2026-04-27
+
+| Title | URL | Tags | Status | Canonical Page | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| Kubernetes (K3s) | https://k3s.io/ | tool | new | | Missing doc linked in docs/tools/infrastructure/docker.md |
+| RAG Pattern | https://en.wikipedia.org/wiki/Retrieval-augmented_generation | tool | new | | Missing doc linked in docs/tools/ai_knowledge/colqwen.md, docs/tools/agents/nemo-retriever.md |
+| Model Context Protocol (MCP) | https://modelcontextprotocol.io/ | tool | new | | Missing doc linked in docs/tools/agents/roo-code.md |
+| Promptfoo | https://www.promptfoo.dev/ | tool | new | | Missing doc linked in docs/tools/process_understanding/braintrust.md |
+| Agentic Workflows | https://www.anthropic.com/news/agentic-workflows | tool | new | | Missing doc linked in docs/tools/development_ops/devin.md |

--- a/docs/tools/agents/agency-agents.md
+++ b/docs/tools/agents/agency-agents.md
@@ -38,7 +38,7 @@ It provides "off-the-shelf" expert agents with predefined personalities, process
 ## Related tools / concepts
 - [CrewAI](../frameworks/crewai.md)
 - [AutoGen](../frameworks/autogen.md)
-- [OpenClaw](../agents/openclaw.md)
+- [OpenClaw](../development_ops/openclaw.md)
 
 ## Sources / References
 - [GitHub](https://github.com/msitarzewski/agency-agents)

--- a/docs/tools/agents/agency-swarm.md
+++ b/docs/tools/agents/agency-swarm.md
@@ -92,7 +92,7 @@ agency.get_completion("CEO, please ask the developer to calculate the square of 
 - [OpenAI](../ai_knowledge/openai.md)
 - [Agent Protocols (MCP)](../../knowledge_base/agent_protocols.md)
 - [CrewAI](../frameworks/crewai.md)
-- [LangGraph](langgraph.md)
+- [LangGraph](../frameworks/langgraph.md)
 
 ## Sources / References
 - [GitHub Repository](https://github.com/VRSEN/agency-swarm)

--- a/docs/tools/agents/agno.md
+++ b/docs/tools/agents/agno.md
@@ -76,7 +76,7 @@ agent.print_response("Tell me about the Agno framework and its search capabiliti
 ## Related tools / concepts
 - [Phidata](phidata.md) (Predecessor)
 - [Agent Protocols (MCP)](../../knowledge_base/agent_protocols.md)
-- [LangGraph](langgraph.md)
+- [LangGraph](../frameworks/langgraph.md)
 - [FastAPI](https://fastapi.tiangolo.com/)
 
 ## Sources / References

--- a/docs/tools/agents/autoreason.md
+++ b/docs/tools/agents/autoreason.md
@@ -17,6 +17,14 @@ It addresses the limitations of standard chain-of-thought prompting by providing
 ## Getting started
 Refer to the official repository for installation and usage instructions.
 
+## Related tools / concepts
+
+- [Agency Swarm](agency-swarm.md)
+- [Agency-Agents](agency-agents.md)
+- [Agentic Automation Canvas (AAC)](agentic-automation-canvas.md)
+- [Agno](agno.md)
+- [Anthropic Agent Skills](anthropic-agent-skills.md)
+
 ## Sources / references
 - [NousResearch/autoreason](https://github.com/NousResearch/autoreason)
 

--- a/docs/tools/agents/bee-agent-framework.md
+++ b/docs/tools/agents/bee-agent-framework.md
@@ -90,10 +90,11 @@ It focuses on agent reliability and observability. It provides "Requirement Agen
 ## Related tools / concepts
 
 - [Agent Protocols (MCP)](../../knowledge_base/agent_protocols.md)
-- [LangGraph](langgraph.md)
+- [LangGraph](../frameworks/langgraph.md)
 - [Claude Skills Ecosystem](claude-skills-ecosystem.md)
 - [Phidata](phidata.md)
 - [Superpowers](superpowers.md)
+
 ## Sources / References
 - [GitHub Repository](https://github.com/i-am-bee/beeai-framework)
 - [IBM Research Blog](https://research.ibm.com/blog/ai-agent-reliability-beeai)

--- a/docs/tools/agents/cline.md
+++ b/docs/tools/agents/cline.md
@@ -50,7 +50,7 @@ It eliminates the "copy-paste" loop between an IDE and an AI chat interface. Ins
 
 ## Related tools / concepts
 - [Roo Code](roo-code.md) (Popular fork/alternative)
-- [Aider](aider.md) (Terminal-based agent)
+- [Aider](../development_ops/aider.md) (Terminal-based agent)
 - [Cursor](https://cursor.com/) (AI-native IDE)
 - [Windsurf](../development_ops/windsurf.md) (Agentic IDE)
 

--- a/docs/tools/agents/gpt-researcher.md
+++ b/docs/tools/agents/gpt-researcher.md
@@ -21,6 +21,14 @@ Available as a Python package or via Docker.
 pip install gpt-researcher
 ```
 
+## Related tools / concepts
+
+- [Agency Swarm](agency-swarm.md)
+- [Agency-Agents](agency-agents.md)
+- [Agentic Automation Canvas (AAC)](agentic-automation-canvas.md)
+- [Agno](agno.md)
+- [Anthropic Agent Skills](anthropic-agent-skills.md)
+
 ## Sources / references
 - [GPT Researcher GitHub](https://github.com/assafelovic/gpt-researcher)
 

--- a/docs/tools/agents/home-admin-tools.md
+++ b/docs/tools/agents/home-admin-tools.md
@@ -71,6 +71,14 @@ These tools require the following environment variables to be set:
 | `HOME_ASSISTANT_URL` | Base URL for HA API | `http://localhost:8123/api` |
 | `HOME_ASSISTANT_TOKEN` | Long-lived access token for HA | (Required) |
 
+## Related tools / concepts
+
+- [Agency Swarm](agency-swarm.md)
+- [Agency-Agents](agency-agents.md)
+- [Agentic Automation Canvas (AAC)](agentic-automation-canvas.md)
+- [Agno](agno.md)
+- [Anthropic Agent Skills](anthropic-agent-skills.md)
+
 ## Sources / References
 
 - [Vikunja API Documentation](https://vikunja.io/docs/api/)

--- a/docs/tools/agents/letta.md
+++ b/docs/tools/agents/letta.md
@@ -19,6 +19,14 @@ It enables long-lived agents that remember past interactions and information ove
 pip install letta
 ```
 
+## Related tools / concepts
+
+- [Agency Swarm](agency-swarm.md)
+- [Agency-Agents](agency-agents.md)
+- [Agentic Automation Canvas (AAC)](agentic-automation-canvas.md)
+- [Agno](agno.md)
+- [Anthropic Agent Skills](anthropic-agent-skills.md)
+
 ## Sources / references
 - [Letta Official Site](https://www.letta.com/)
 - [Letta GitHub](https://github.com/letta-ai/letta)

--- a/docs/tools/agents/open-agents.md
+++ b/docs/tools/agents/open-agents.md
@@ -17,6 +17,14 @@ It provides a set of ready-to-use agents and a framework for building new ones, 
 ## Getting started
 Check the GitHub repository for the latest setup guides and examples.
 
+## Related tools / concepts
+
+- [Agency Swarm](agency-swarm.md)
+- [Agency-Agents](agency-agents.md)
+- [Agentic Automation Canvas (AAC)](agentic-automation-canvas.md)
+- [Agno](agno.md)
+- [Anthropic Agent Skills](anthropic-agent-skills.md)
+
 ## Sources / references
 - [vercel-labs/open-agents](https://github.com/vercel-labs/open-agents)
 

--- a/docs/tools/agents/roo-code.md
+++ b/docs/tools/agents/roo-code.md
@@ -50,7 +50,7 @@ Like its predecessor, Roo Code solves the context-switching problem by integrati
 
 ## Related tools / concepts
 - [Cline](cline.md) (The project it was forked from)
-- [Aider](aider.md) (Terminal-based agent)
+- [Aider](../development_ops/aider.md) (Terminal-based agent)
 - [Model Context Protocol (MCP)](../knowledge_base/mcp.md)
 
 ## Sources / References

--- a/docs/tools/agents/symphony.md
+++ b/docs/tools/agents/symphony.md
@@ -59,10 +59,11 @@ Symphony offers two primary paths:
 
 - [Harness Engineering (OpenAI Blog)](https://openai.com/index/harness-engineering/)
 - [OpenCode](../development_ops/opencode.md)
-- [LangGraph](langgraph.md)
+- [LangGraph](../frameworks/langgraph.md)
 - [Bee Agent Framework](bee-agent-framework.md)
 - [Claude Skills Ecosystem](claude-skills-ecosystem.md)
 - [NanoClaw](../development_ops/nanoclaw.md)
+
 ## Sources / References
 
 - [Official GitHub Repository](https://github.com/openai/symphony)

--- a/docs/tools/ai_knowledge/claude-mythos.md
+++ b/docs/tools/ai_knowledge/claude-mythos.md
@@ -38,6 +38,14 @@ Use Claude Mythos when:
 - [Claude Code](../development_ops/claude-code.md)
 - [Model Routing Guide](../../knowledge_base/model_routing_guide.md)
 
+## Related tools / concepts
+
+- [AI Templates](aitmpl.md)
+- [Andrej Karpathy Skills](karpathy-skills.md)
+- [AnythingLLM](anythingllm.md)
+- [ChatGPT](chatgpt.md)
+- [Claude](claude.md)
+
 ## Sources / References
 - [Claude Mythos Preview completes full cyberattack simulation for the first time](https://thenewstack.io/claude-mythos-preview-simulation/)
 

--- a/docs/tools/ai_knowledge/claude.md
+++ b/docs/tools/ai_knowledge/claude.md
@@ -44,7 +44,7 @@ AI Model and Conversational Assistant. It can be accessed via the Claude.ai web 
 - [ChatGPT](chatgpt.md)
 - [Gemini](gemini.md)
 - [Anthropic](../providers/anthropic.md)
-- [Claude Code](../development_ops/claude_code.md)
+- [Claude Code](../development_ops/claude-code.md)
 
 ## Sources / References
 - [Official Website](https://claude.ai/)

--- a/docs/tools/ai_knowledge/everything-claude-code.md
+++ b/docs/tools/ai_knowledge/everything-claude-code.md
@@ -14,6 +14,14 @@ It provides a production-ready setup for agents, moving beyond simple configurat
 - **Security Scanning**: Integrated hooks for safe development.
 - **Multi-platform Support**: Works across Claude Code, Codex, Cursor, Gemini, and more.
 
+## Related tools / concepts
+
+- [AI Templates](aitmpl.md)
+- [Andrej Karpathy Skills](karpathy-skills.md)
+- [AnythingLLM](anythingllm.md)
+- [ChatGPT](chatgpt.md)
+- [Claude](claude.md)
+
 ## Sources / references
 - [Everything Claude Code (GitHub)](https://github.com/affaan-m/everything-claude-code)
 

--- a/docs/tools/ai_knowledge/fish-audio.md
+++ b/docs/tools/ai_knowledge/fish-audio.md
@@ -17,6 +17,14 @@ It provides a powerful alternative to proprietary TTS services, offering researc
 ## Getting started
 Available on GitHub and Hugging Face.
 
+## Related tools / concepts
+
+- [AI Templates](aitmpl.md)
+- [Andrej Karpathy Skills](karpathy-skills.md)
+- [AnythingLLM](anythingllm.md)
+- [ChatGPT](chatgpt.md)
+- [Claude](claude.md)
+
 ## Sources / references
 - [Fish Audio GitHub](https://github.com/fishaudio/fish-speech)
 

--- a/docs/tools/ai_knowledge/gemini-cli.md
+++ b/docs/tools/ai_knowledge/gemini-cli.md
@@ -59,7 +59,7 @@ gemini setup-github
 
 ## Related tools / concepts
 - [Google Gemini](google-gemini.md) (Underlying Model)
-- [Aider](../agents/aider.md) (Terminal-based agent)
+- [Aider](../development_ops/aider.md) (Terminal-based agent)
 - [Claude Code](../development_ops/claude-code.md) (Anthropic's equivalent)
 
 ## Sources / References

--- a/docs/tools/ai_knowledge/gemini-macos.md
+++ b/docs/tools/ai_knowledge/gemini-macos.md
@@ -22,6 +22,14 @@ Google Gemini for macOS is a native desktop application designed to provide a se
 3. Sign in with your Google account.
 4. (Optional) Grant accessibility permissions to enable advanced tab management features.
 
+## Related tools / concepts
+
+- [AI Templates](aitmpl.md)
+- [Andrej Karpathy Skills](karpathy-skills.md)
+- [AnythingLLM](anythingllm.md)
+- [ChatGPT](chatgpt.md)
+- [Claude](claude.md)
+
 ## Sources / References
 
 - [Google Gemini Mac app debuts to end the clunky hunt for browser tabs](https://thenewstack.io/gemini-app-macos-launch/) (The New Stack, 2026-04-16)

--- a/docs/tools/ai_knowledge/google-gemini.md
+++ b/docs/tools/ai_knowledge/google-gemini.md
@@ -42,7 +42,7 @@ It provides state-of-the-art reasoning across text, code, images, audio, and vid
 ## Related tools / concepts
 - [OpenAI](./openai.md)
 - [Anthropic](../providers/anthropic.md)
-- [DeepSeek](./deepseek.md)
+- [DeepSeek](../providers/deepseek.md)
 - [OpenRouter](./openrouter.md)
 
 ## Sources / References

--- a/docs/tools/ai_knowledge/karpathy-skills.md
+++ b/docs/tools/ai_knowledge/karpathy-skills.md
@@ -9,6 +9,14 @@ It codifies high-signal development habits and "instincts" into actionable patte
 ## Where it fits in the stack
 **Category**: AI & Knowledge / Best Practices
 
+## Related tools / concepts
+
+- [AI Templates](aitmpl.md)
+- [AnythingLLM](anythingllm.md)
+- [ChatGPT](chatgpt.md)
+- [Claude](claude.md)
+- [Claude Mythos](claude-mythos.md)
+
 ## Sources / references
 - [Andrej Karpathy Skills (GitHub)](https://github.com/forrestchang/andrej-karpathy-skills)
 

--- a/docs/tools/ai_knowledge/local_llms.md
+++ b/docs/tools/ai_knowledge/local_llms.md
@@ -101,10 +101,11 @@ print(response.json()['message']['content'])
 ## Related tools / concepts
 
 - [Ollama (Service)](../../services/ollama.md)
-- [DeepSeek](deepseek.md)
+- [DeepSeek](../providers/deepseek.md)
 - [SSH Execution Patterns](../../architecture/ssh_execution_patterns.md)
 - [AI Templates](aitmpl.md)
 - [Google Gemini](google-gemini.md)
+
 ## Sources / References
 
 - [Reference](https://github.com/joanmarcriera/Home-office-automations)

--- a/docs/tools/ai_knowledge/matt-pocock-skills.md
+++ b/docs/tools/ai_knowledge/matt-pocock-skills.md
@@ -12,6 +12,14 @@ Extends agent capabilities with domain-specific execution scaffolds and critical
 ## Key Skills
 - **Grill-me**: A skill used to cross-examine and verify a proposed plan before execution.
 
+## Related tools / concepts
+
+- [AI Templates](aitmpl.md)
+- [Andrej Karpathy Skills](karpathy-skills.md)
+- [AnythingLLM](anythingllm.md)
+- [ChatGPT](chatgpt.md)
+- [Claude](claude.md)
+
 ## Sources / references
 - [Matt Pocock Skills (GitHub)](https://github.com/mattpocock/skills)
 

--- a/docs/tools/ai_knowledge/qwen.md
+++ b/docs/tools/ai_knowledge/qwen.md
@@ -86,7 +86,7 @@ print(response.choices[0].message.content)
 ## Related tools / concepts
 - [Whisper](../../services/whisper.md) (Qwen3 ASR has been noted to outperform Whisper in almost every aspect)
 - [Ollama (Service)](../../services/ollama.md)
-- [DeepSeek](deepseek.md)
+- [DeepSeek](../providers/deepseek.md)
 - [Local LLMs](local_llms.md)
 
 ## Sources / References

--- a/docs/tools/benchmarking/langsmith.md
+++ b/docs/tools/benchmarking/langsmith.md
@@ -42,7 +42,7 @@ Benchmarking / Observability
 
 ## Related tools / concepts
 - [LangChain](../ai_knowledge/langchain.md)
-- [LangGraph](../agents/langgraph.md)
+- [LangGraph](../frameworks/langgraph.md)
 - [Benchmarking](./index.md)
 
 ## Sources / References

--- a/docs/tools/enterprise/ampcode.md
+++ b/docs/tools/enterprise/ampcode.md
@@ -14,6 +14,12 @@ It provides the infrastructure needed to transition from experimental agent prot
 - Secure agentic workflows
 - Scaling agent deployments
 
+## Related tools / concepts
+
+- [Fyxer AI](fyxer.md)
+- [Glean](glean.md)
+- [Hebbia](hebbia.md)
+
 ## Sources / references
 - [AmpCode Official Site](https://ampcode.com/)
 

--- a/docs/tools/frameworks/openai-agents-sdk.md
+++ b/docs/tools/frameworks/openai-agents-sdk.md
@@ -37,10 +37,10 @@ It simplifies the process of creating agents that can use tools, maintain state,
 - **Self-hostable**: Yes (SDK logic)
 
 ## Related tools / concepts
-- [Symphony (OpenAI)](./symphony.md)
+- [Symphony (OpenAI)](../agents/symphony.md)
 - [LangGraph](./langgraph.md)
-- [Agency Swarm](./agency-swarm.md)
-- [Agentic Automation Canvas (AAC)](./agentic-automation-canvas.md)
+- [Agency Swarm](../agents/agency-swarm.md)
+- [Agentic Automation Canvas (AAC)](../agents/agentic-automation-canvas.md)
 
 ## Sources / References
 - [The next evolution of the Agents SDK](https://openai.com/index/the-next-evolution-of-the-agents-sdk)

--- a/docs/tools/intake_storage/anytype.md
+++ b/docs/tools/intake_storage/anytype.md
@@ -36,7 +36,7 @@ It provides a unified "operating system for your life," allowing you to store no
 
 ## Related tools / concepts
 - [Obsidian](../ai_knowledge/obsidian.md)
-- [Logseq](logseq.md)
+- [Logseq](../ai_knowledge/logseq.md)
 
 ## Sources / References
 - [Official Website](https://anytype.io/)

--- a/docs/tools/intake_storage/llamaparse.md
+++ b/docs/tools/intake_storage/llamaparse.md
@@ -9,6 +9,14 @@ Overcomes the limitations of standard PDF text extraction by using vision-aware 
 ## Where it fits in the stack
 **Category**: Intake & Storage / Data Processing
 
+## Related tools / concepts
+
+- [Actual Budget](../../services/actual-budget.md)
+- [AnyType](anytype.md)
+- [CalDAV](caldav.md)
+- [Diskover](../../services/diskover.md)
+- [Focalboard](../../services/focalboard.md)
+
 ## Sources / references
 - [LlamaParse (LlamaIndex)](https://www.llamaindex.ai/llamaparse)
 

--- a/docs/tools/intake_storage/silverbullet.md
+++ b/docs/tools/intake_storage/silverbullet.md
@@ -35,7 +35,7 @@ It combines the simplicity of Markdown with the power of a programmable environm
 - **Self-hostable**: Yes
 
 ## Related tools / concepts
-- [Logseq](logseq.md)
+- [Logseq](../ai_knowledge/logseq.md)
 - [Trilium Notes](../../services/trilium.md)
 
 ## Sources / References

--- a/docs/tools/intake_storage/unstructured.md
+++ b/docs/tools/intake_storage/unstructured.md
@@ -9,6 +9,14 @@ It automates the ingestion of diverse document types, handling complex layouts a
 ## Where it fits in the stack
 **Category**: Intake & Storage / Data Processing
 
+## Related tools / concepts
+
+- [Actual Budget](../../services/actual-budget.md)
+- [AnyType](anytype.md)
+- [CalDAV](caldav.md)
+- [Diskover](../../services/diskover.md)
+- [Focalboard](../../services/focalboard.md)
+
 ## Sources / references
 - [Unstructured.io Website](https://unstructured.io/)
 

--- a/docs/tools/process_understanding/langfuse.md
+++ b/docs/tools/process_understanding/langfuse.md
@@ -14,6 +14,14 @@ It allows developers to debug complex LLM interactions, track costs, monitor lat
 - **Evaluation**: Automates model-based grading of responses.
 - **OpenRouter Integration**: Native support for receiving logs from OpenRouter.
 
+## Related tools / concepts
+
+- [AI Auditing Tools](ai-auditing-tools.md)
+- [Apache Tika](../../services/tika.md)
+- [Arize AI](arize-ai.md)
+- [Braintrust](braintrust.md)
+- [Changedetection.io](../../services/changedetection.md)
+
 ## Sources / references
 - [Langfuse Website](https://langfuse.com/)
 

--- a/docs/tools/process_understanding/opendataloader-pdf.md
+++ b/docs/tools/process_understanding/opendataloader-pdf.md
@@ -37,7 +37,7 @@ It automates PDF accessibility and parsing, ensuring that complex PDF structures
 - **Self-hostable**: Yes
 
 ## Related tools / concepts
-- [LlamaParse](../agents/llamaparse.md)
+- [LlamaParse](../intake_storage/llamaparse.md)
 - [Marker](https://github.com/VikParuchuri/marker)
 
 ## Sources / References

--- a/docs/tools/process_understanding/posthog.md
+++ b/docs/tools/process_understanding/posthog.md
@@ -13,6 +13,14 @@ It helps teams understand how users interact with their applications and allows 
 - **LLM Observability**: Track agent behavior alongside traditional product metrics.
 - **OpenRouter Integration**: Can receive event logs from OpenRouter sessions.
 
+## Related tools / concepts
+
+- [AI Auditing Tools](ai-auditing-tools.md)
+- [Apache Tika](../../services/tika.md)
+- [Arize AI](arize-ai.md)
+- [Braintrust](braintrust.md)
+- [Changedetection.io](../../services/changedetection.md)
+
 ## Sources / references
 - [PostHog Website](https://posthog.com/)
 

--- a/docs/tools/providers/mistral.md
+++ b/docs/tools/providers/mistral.md
@@ -88,7 +88,7 @@ Mistral provides a first-class Agents API that goes beyond simple completions:
 
 - [Ollama](../../services/ollama.md)
 - [Model Context Protocol (MCP)](../../knowledge_base/agent_protocols.md)
-- [DeepSeek](../ai_knowledge/deepseek.md)
+- [DeepSeek](deepseek.md)
 - [vLLM](../infrastructure/vllm.md)
 
 ## Sources / References

--- a/docs/tools/providers/moonshot.md
+++ b/docs/tools/providers/moonshot.md
@@ -38,11 +38,12 @@ Enables the processing and analysis of massive documents, entire codebases, or l
 
 ## Related tools / concepts
 
-- [DeepSeek](../ai_knowledge/deepseek.md)
+- [DeepSeek](deepseek.md)
 - [OpenAI](../ai_knowledge/openai.md)
 - [Replicate](replicate.md)
 - [MiniMax](minimax.md)
 - [Groq](groq.md)
+
 ## Sources / References
 - [Official Website](https://www.moonshot.cn/)
 - [Developer Platform](https://platform.moonshot.cn/)

--- a/docs/tools/providers/vercel-ai-gateway.md
+++ b/docs/tools/providers/vercel-ai-gateway.md
@@ -54,7 +54,7 @@ print(completion.choices[0].message.content)
 - **Overhead**: Adds another network hop, though usually mitigated by edge execution.
 
 ## Related tools / concepts
-- [OpenRouter](openrouter.md) (Alternative model aggregator)
+- [OpenRouter](../ai_knowledge/openrouter.md) (Alternative model aggregator)
 - [LiteLLM](../../services/litellm.md) (Self-hosted gateway alternative)
 
 ## Sources / References


### PR DESCRIPTION
I have completed an audit of all tool documentation in `docs/tools/`. 

Key accomplishments:
1.  **Populated Related Sections**: Any tool page with an empty or 'TBD' `## Related tools / concepts` section was updated with 3-5 related tools from the same category (referenced from `data/all_tools.json`).
2.  **Fixed Broken Links**: Identified and corrected several broken internal links (e.g., pointing to the wrong subdirectory or using incorrect filenames for Aider, LangGraph, etc.).
3.  **Tracked Missing Docs**: Created `docs/new-sources/2026-04-27.md` to log tools mentioned in "Related" sections that do not yet have their own canonical pages (e.g., Kubernetes, RAG Pattern, MCP).
4.  **Updated Index**: Registered the new daily log in `docs/new-sources.md`.
5.  **Validation**: Verified all changes using `check_catalog_consistency.py`, `validate_new_sources.py`, and `mkdocs.yml` validation.

The changes improve the navigational quality and consistency of the documentation while providing a clear backlog for future doc creation.

---
*PR created automatically by Jules for task [13382355184292043133](https://jules.google.com/task/13382355184292043133) started by @joanmarcriera*