### PR TITLE
Finalize and catalog Data Copilot ecosystem (#186-#190)

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -432,10 +432,28 @@
       "doc_path": "docs/architecture/data-copilot-text-to-sql.md"
     },
     {
+      "id": "data-copilot-agentic-rag",
+      "name": "Data Copilot Agentic RAG",
+      "category": "Patterns",
+      "doc_path": "docs/knowledge_base/patterns/data-copilot-agentic-rag.md"
+    },
+    {
       "id": "data-copilot-mcp",
       "name": "Data Copilot MCP Tooling",
       "category": "Patterns",
       "doc_path": "docs/knowledge_base/patterns/data-copilot-mcp-tooling.md"
+    },
+    {
+      "id": "data-copilot-sql-validation",
+      "name": "Data Copilot SQL Validation",
+      "category": "Playbooks",
+      "doc_path": "docs/playbooks/data-copilot-sql-validation.md"
+    },
+    {
+      "id": "data-copilot-answer-synthesis",
+      "name": "Data Copilot Answer Synthesis",
+      "category": "Reference Implementations",
+      "doc_path": "docs/reference-implementations/data-copilot/answer-synthesis-schema.md"
     },
     {
       "id": "data-copilot-skeleton",

--- a/docs/architecture/data-copilot-text-to-sql.md
+++ b/docs/architecture/data-copilot-text-to-sql.md
@@ -32,26 +32,69 @@ flowchart TD
 - **Role**: Identifies which "workspace" (database or domain) the question belongs to (e.g., Finance, Home Automation, Inventory).
 - **Benefit**: Prevents the LLM from being overwhelmed by the entire repository's schema.
 - **Model Recommendation**: Small/Fast (e.g., Qwen 2.5 0.8B or 2B via Ollama).
+- **Interface**:
+```json
+{
+  "workspace_id": "inventory",
+  "description": "Home Inventory and Assets",
+  "db_connection_string": "sqlite:///home_inventory.db"
+}
+```
 
 ### 2. Intent Agent
 - **Role**: Refines the raw user question into a structured intent, identifying metrics, time ranges, and filters.
 - **Input**: User question + Workspace context.
 - **Output**: JSON object with intent parameters.
+- **Interface**:
+```json
+{
+  "metrics": ["quantity", "purchase_price"],
+  "dimensions": ["category"],
+  "filters": {"room": "Kitchen"},
+  "time_range": "last_30_days"
+}
+```
 
 ### 3. Table Agent
 - **Role**: Selects the minimal set of tables required to answer the intent.
 - **HITL Point**: Optional user approval of selected tables to prevent joined-table explosions.
 - **Pruning Strategy**: Semantic search over table descriptions (RAG) instead of dumping all table names.
+- **Interface**:
+```json
+{
+  "selected_tables": ["items", "categories"],
+  "rationale": "Need 'items' for quantity/price and 'categories' for grouping."
+}
+```
 
 ### 4. Column Prune Agent
 - **Role**: For the selected tables, identifies only the columns needed for the query.
 - **Benefit**: Drastically reduces the prompt size for the final SQL generation, staying within small model context limits.
 - **HITL Point**: Verification of critical columns (e.g., "Are you sure you want 'net_price' instead of 'gross_price'?").
+- **Interface**:
+```json
+[
+  {
+    "table_name": "items",
+    "columns": ["name", "quantity", "purchase_price", "category_id", "room"]
+  },
+  {
+    "table_name": "categories",
+    "columns": ["id", "name"]
+  }
+]
+```
 
 ### 5. SQL Generator
 - **Role**: Produces the final SQL query using the pruned schema and refined intent.
 - **Input**: Intent JSON + Pruned Schema (Tables + Columns).
-- **Output**: Valid SQL.
+- **Output**: Valid SQL string.
+- **Interface**:
+```json
+{
+  "sql": "SELECT c.name, SUM(i.quantity) FROM items i JOIN categories c ON i.category_id = c.id WHERE i.room = 'Kitchen' GROUP BY c.name;"
+}
+```
 
 ## Cost & Model Routing
 

--- a/docs/knowledge_base/patterns/index.md
+++ b/docs/knowledge_base/patterns/index.md
@@ -15,6 +15,8 @@ Recurring architectural and design patterns in AI/LLM systems — RAG, tool call
 - [LLM Trust Boundaries Pattern](llm-trust-boundaries.md)
 - [Software Factories Pattern](software-factories.md) — Non-interactive development via seed, validation, and feedback loops
 - [Filesystem-as-Interface Pattern](filesystem-context.md) — Filesystem as the primary interface and persistence layer for agents
+- [Data Copilot MCP Tooling](data-copilot-mcp-tooling.md) — Standardizing data access for Text-to-SQL pipelines using MCP
+- [Data Copilot Agentic RAG](data-copilot-agentic-rag.md) — Hybrid retrieval pattern for diagnostic analytics
 
 ## Common Patterns
 

--- a/docs/reference-implementations/index.md
+++ b/docs/reference-implementations/index.md
@@ -12,5 +12,9 @@ Workflow exports, prompt templates, and config standards.
 ## n8n
 - [Overview](n8n/README.md)
 
+## Data Copilot
+- [Skeleton Guide](data-copilot/skeleton-guide.md)
+- [Answer Synthesis Schema](data-copilot/answer-synthesis-schema.md)
+
 ## Paperless
 - [Tag Taxonomy](paperless/tag-taxonomy.md)


### PR DESCRIPTION
I have addressed the 5 oldest issues in the repository (#186-#190), which form the core of the Data Copilot ecosystem. 

Key changes:
1. **Issue #186 (Architecture)**: Refined `docs/architecture/data-copilot-text-to-sql.md` to include explicit JSON/Pydantic interface definitions for all 5 layers (Router, Intent, Table, Prune, SQL Generator), ensuring consistency and testability.
2. **Issue #187 (MCP Tooling)**: Verified the standardization blueprint and ensured it is correctly linked.
3. **Issue #188 (Agentic RAG)**: Verified the hybrid retrieval pattern, added it to the tool catalog (`data/all_tools.json`), and updated the patterns index.
4. **Issue #189 (SQL Validation)**: Verified the validation and repair playbook and registered it in the tool catalog.
5. **Issue #190 (Answer Synthesis)**: Verified the synthesis schema, registered it in the tool catalog, and updated the reference implementations index.

All consistency checks (`check_catalog_consistency.py`, `check_docs_contract.py`, `validate_new_sources.py`) and `mkdocs.yml` validation passed successfully.

---
*PR created automatically by Jules for task [6519992978391624435](https://jules.google.com/task/6519992978391624435) started by @joanmarcriera*