### PR TITLE
Update AI Tooling Landscape Overview (May 2026)

### DIFF
--- a/docs/knowledge_base/landscape-overview.md
+++ b/docs/knowledge_base/landscape-overview.md
@@ -3,30 +3,35 @@
 This page provides a bird's-eye view of the AI tool catalogue, showing current metrics, connectivity, and recent additions. It is updated monthly to reflect the evolving state of the repository.
 
 ## Overview
-- **Last Generated:** 2026-04-24
-- **Total Tools Documented:** 211 (Significant growth from 150 in the March snapshot)
+- **Last Generated:** 2026-05-01
+- **Total Tools Documented:** 371 (Significant growth from 211 in the April report)
 
 ## Category Breakdown
 
-Current tool count and focus per category, verified against `growth-metrics.json` snapshots:
+Current tool count and focus per category, verified against `all_tools.json`:
 
 | Category | Count | Summary |
 | :--- | :--- | :--- |
-| **Development & Ops** | 54 | Coding assistants, IDEs, and agentic development tools. |
-| **AI Assistants & Knowledge** | 27 | General-purpose chat interfaces, RAG platforms, and knowledge bases. |
-| **Process & Understanding** | 19 | Data extraction, OCR, and document processing. |
-| **Intake & Storage** | 18 | Data collection, self-hosted storage, and document management. |
-| **Automation & Orchestration** | 18 | Workflow automation and tool integration servers. |
-| **Benchmarking** | 15 | Evaluation frameworks and performance measurement tools. |
-| **Agents** | 13 | Multi-agent orchestration frameworks. |
-| **Providers** | 11 | LLM API providers and model marketplaces. |
-| **Infrastructure** | 10 | Model serving, inference engines, and fine-tuning platforms. |
-| **AI & Knowledge** | 8 | Unified platforms for AI interaction and model management. |
-| **Frameworks** | 7 | Development libraries for building AI-powered applications. |
+| **AI Assistants & Knowledge** | 67 | General-purpose chat interfaces, RAG platforms, and knowledge bases. |
+| **Development & Ops** | 57 | Coding assistants, IDEs, and agentic development tools. |
+| **Process & Understanding** | 36 | Data extraction, OCR, and document processing. |
+| **Benchmarking** | 31 | Evaluation frameworks and performance measurement tools. |
+| **Automation & Orchestration** | 29 | Workflow automation and tool integration servers. |
+| **Intake & Storage** | 25 | Data collection, self-hosted storage, and document management. |
+| **Agents** | 25 | Multi-agent orchestration frameworks. |
+| **Frameworks** | 21 | Development libraries for building AI-powered applications. |
+| **Providers** | 20 | LLM API providers and model marketplaces. |
+| **Infrastructure** | 16 | Model serving, inference engines, and fine-tuning platforms. |
+| **Calendar & Tasks** | 13 | Scheduling and task management integrations. |
+| **Enterprise AI** | 9 | Enterprise-grade AI search and productivity suites. |
+| **Patterns** | 5 | Standardized approaches and architectural patterns. |
 | **Media & Entertainment** | 5 | Self-hosted media servers and creative content tools. |
+| **Reference Implementations** | 3 | Skeleton code and reference designs for AI patterns. |
+| **Knowledge Base** | 3 | Deep-dive research and comparison articles. |
 | **Creative & Communication** | 3 | Diagramming and secure messaging services. |
-| **Calendar & Tasks** | 2 | Scheduling and task management integrations. |
-| **Patterns** | 1 | Standardized approaches and architectural patterns. |
+| **Playbooks** | 1 | Step-by-step guides for specific AI implementations. |
+| **Architecture** | 1 | High-level system design and component maps. |
+| **AI & Knowledge** | 1 | Legacy or specialized AI knowledge documentation. |
 
 ## Top 10 Most-Connected Tools
 Based on the number of internal links in their 'Related tools / concepts' sections.
@@ -35,128 +40,33 @@ Based on the number of internal links in their 'Related tools / concepts' sectio
 | :--- | :--- |
 | OpenClaw | 11 |
 | Claude Code | 10 |
-| OpenAI | 8 |
-| Supabase | 8 |
+| OpenAI | 9 |
 | Fine-tuning Open Models | 8 |
+| Supabase | 8 |
 | n8n | 7 |
 | OpenHands | 7 |
-| LiteLLM | 6 |
-| Vercel | 6 |
-| CalDAV | 5 |
+| Runway ML | 7 |
+| TeamOut | 7 |
+| ansigpt | 6 |
 
 ## Underdeveloped Categories
 Categories with fewer than 8 docs are identified as areas where the repository is actively expanding:
-- Frameworks (7)
+- Patterns (5)
 - Media & Entertainment (5)
+- Reference Implementations (3)
+- Knowledge Base (3)
 - Creative & Communication (3)
-- Calendar & Tasks (2)
-- Patterns (2)
+- Playbooks (1)
+- Architecture (1)
+- AI & Knowledge (1)
 
 ## What's New This Month
-Key tools added or promoted to the tool catalogue in the last 30 days:
-- AI Templates
-- Actual Budget
-- Agentic Automation Canvas (AAC)
-- AnythingLLM
-- Apache Tika
-- Audiobookshelf
-- Authentik
-- Axiom Guardian
-- BigSwitch
-- Changedetection.io
-- Chronos MCP
-- Claude Code Container MCP
-- Claude Code Router
-- Claude Context Mode
-- Claude Cookbooks
-- Claude Hooks
-- Claude Plugins
-- Claude Skills Ecosystem
-- ClawRouter
-- Cloudflare Pages
-- Context7
-- Copy.ai
-- DeerFlow
-- Desktop Commander MCP
-- Diskover
-- Docling MCP
-- Draw.io
-- Element
-- ElevenLabs
-- Excalidraw
-- Fine-tuning Open Models
-- Firebase Studio
-- Focalboard
-- Free Will MCP
-- Fuzzing MCP Server
-- Gemini Canvas
-- GitHub Pages
-- Gitea
-- Google Lyria
-- Google Opal
-- Google Stitch
-- Google Workspace CLI
-- Grocy
-- Habitica
-- Home Assistant
-- Homebox
-- Humanizer
-- IT-Tools
-- Immich
-- Jackett
-- Jasper
-- Jellyfin
-- Jupyter Kernel MCP
-- Kiwix
-- Linkwarden
-- LiteLLM
-- Makefile MCP
-- Mealie
-- MiniMax
-- Mistral AI (Mixtral/Codestral)
-- Moonshot AI
-- NanoClaw
-- Navidrome
-- Netlify
-- Nextcloud
-- NotebookLM
-- Notion AI
-- Ollama
-- Omni Tools
-- Open WebUI
-- OpenBB
-- Paperless-AI
-- Paperless-ngx
-- Picnic
-- Playwright
-- Plex
-- Portracker
-- Qwen3-Coder-Next
-- Radicale
-- Runway ML
-- SearXNG
-- Speedtest Tracker
-- Storj Node
-- Supabase
-- Superpowers
-- Symbolic MCP Server
-- Symphony (OpenAI)
-- Syncthing
-- Synthesia
-- Tavily
-- Trilium Notes
-- Tube Archivist
-- Vault MCP Server
-- Vercel
-- Vercel OSS
-- Vikunja
-- Vikunja MCP Server
-- Whisper
-- llmfit
-- mem0
-- n8n
-- qBittorrent
-- rclone Automation
+Key additions and integrations from the Batch 2 (Agent Frameworks), Batch 3 (SDKs), and Batch 6 (Storage) execution phases:
+- **Agent Frameworks:** AG2, Langflow, Mastra, Rivet, Superinterface, Temporal.
+- **SDKs & Tooling:** LlamaIndex.TS, Vercel AI SDK, Instructor, Google ADK, Firebase Genkit, Portkey.
+- **Storage & Observability:** ClickHouse, Snowflake, S3 Storage, W&B Weave, OpenTelemetry Collector, Webhook.
+- **Enterprise Productivity:** Dashworks, Guru, Curiosity, Coveo, Elastic, AmpCode.
+- **Benchmarking:** Humanity's Last Exam (HLE), SWE-bench Pro, SharpAI Security.
 
 ## Critical Risks & Future Outlook
 The "Humanity's Last Gasp" analysis (April 2026) suggests that the current era of "AI assisting humans to work harder" may be a transient state (the "Turkey Problem"). As benchmarks like SWE-Bench Pro become saturated and AGI superclusters approach, the "Software Factory" pattern and "Prompt Requests" will likely redefine the role of the engineer.
@@ -169,5 +79,5 @@ The "Humanity's Last Gasp" analysis (April 2026) suggests that the current era o
 - [GitHub Repository](https://github.com/joanmarcriera/Home-office-automations)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-24
+- Last reviewed: 2026-05-01
 - Confidence: high


### PR DESCRIPTION
This update refreshes the `docs/knowledge_base/landscape-overview.md` with the latest repository metrics as of May 1, 2026. 

Key changes include:
- Total tool count updated from 211 to 371.
- Updated category breakdown showing 'AI Assistants & Knowledge' (67) and 'Development & Ops' (57) as the largest categories.
- New connectivity rankings with 'OpenClaw' and 'Claude Code' as the most-connected tools.
- A curated 'What's New' section highlighting major additions from Batch 2 (Agent Frameworks), Batch 3 (SDKs), and Batch 6 (Storage) execution phases, avoiding a massive list to maintain readability.
- All changes passed `scripts/check_catalog_consistency.py` and `scripts/check_docs_contract.py`.

---
*PR created automatically by Jules for task [2773531479725782587](https://jules.google.com/task/2773531479725782587) started by @joanmarcriera*