### PR TITLE
Documentation Expansion and Issue Resolution Bulk Update

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -126,6 +126,12 @@
       "doc_path": "docs/tools/development_ops/anti_gravity.md"
     },
     {
+      "id": "any-do",
+      "name": "Any.do",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/any-do.md"
+    },
+    {
       "id": "anythingllm",
       "name": "AnythingLLM",
       "category": "AI Assistants & Knowledge",
@@ -142,6 +148,12 @@
       "name": "Aphrodite Engine",
       "category": "Infrastructure",
       "doc_path": "docs/tools/infrastructure/aphrodite-engine.md"
+    },
+    {
+      "id": "apple-calendar",
+      "name": "Apple Calendar",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/apple-calendar.md"
     },
     {
       "id": "arc",
@@ -256,6 +268,12 @@
       "name": "CalDAV",
       "category": "Intake & Storage",
       "doc_path": "docs/tools/intake_storage/caldav.md"
+    },
+    {
+      "id": "calendly",
+      "name": "Calendly",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/calendly.md"
     },
     {
       "id": "changedetection",
@@ -700,6 +718,12 @@
       "name": "Fantastical",
       "category": "Calendar & Tasks",
       "doc_path": "docs/tools/calendar_tasks/fantastical.md"
+    },
+    {
+      "id": "fastmail",
+      "name": "Fastmail",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/fastmail.md"
     },
     {
       "id": "fiddler",
@@ -1426,6 +1450,12 @@
       "doc_path": "docs/tools/providers/microsoft-graph.md"
     },
     {
+      "id": "microsoft-todo",
+      "name": "Microsoft To Do",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/microsoft-todo.md"
+    },
+    {
       "id": "minimax",
       "name": "MiniMax",
       "category": "Providers",
@@ -1938,6 +1968,12 @@
       "doc_path": "docs/tools/intake_storage/s3-storage.md"
     },
     {
+      "id": "savvycal",
+      "name": "SavvyCal",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/savvycal.md"
+    },
+    {
       "id": "searXNG",
       "name": "SearXNG",
       "category": "Process & Understanding",
@@ -2038,6 +2074,12 @@
       "name": "Storj Node",
       "category": "Intake & Storage",
       "doc_path": "docs/services/storj.md"
+    },
+    {
+      "id": "sunsama",
+      "name": "Sunsama",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/sunsama.md"
     },
     {
       "id": "supabase",
@@ -2158,6 +2200,12 @@
       "name": "Text Generation Inference (TGI)",
       "category": "Infrastructure",
       "doc_path": "docs/tools/infrastructure/tgi.md"
+    },
+    {
+      "id": "ticktick",
+      "name": "TickTick",
+      "category": "Calendar & Tasks",
+      "doc_path": "docs/tools/calendar_tasks/ticktick.md"
     },
     {
       "id": "tika",

--- a/docs/knowledge_base/ai_tool_access_matrix.md
+++ b/docs/knowledge_base/ai_tool_access_matrix.md
@@ -20,9 +20,9 @@ Use it as a shortlist filter before doing row-level procurement checks. The entr
 
 If the priority is one tool that already does Gmail, Calendar, files, and deep research well, the strongest shortlist is [ChatGPT](../tools/ai_knowledge/chatgpt.md), [Claude](../tools/ai_knowledge/claude.md), and [Gemini Apps](../tools/ai_knowledge/gemini.md). ChatGPT and Claude are broader cross-app assistants; Gemini is strongest when the operating surface is already Google Workspace.
 
-If the priority is local-first or self-hosted work, the strongest shortlist is [AnythingLLM](../tools/ai_knowledge/anythingllm.md), LibreChat, [Open WebUI](../services/open-webui.md), [Jan](../tools/infrastructure/jan-ai.md), and Goose. These give better control over local models, self-hosting, and private files, but Gmail and Calendar usually arrive through MCP or external integrations rather than first-party connectors.
+If the priority is local-first or self-hosted work, the strongest shortlist is [AnythingLLM](../tools/ai_knowledge/anythingllm.md), LibreChat, [Open WebUI](../services/open-webui.md), [Jan](../tools/infrastructure/jan-ai.md), and [Goose](../tools/automation_orchestration/goose.md). These give better control over local models, self-hosting, and private files, but Gmail and Calendar usually arrive through MCP or external integrations rather than first-party connectors.
 
-If the priority is coding-first integration potential, the strongest shortlist is [Claude Code](../tools/development_ops/claude-code.md), [Codex CLI](../tools/development_ops/codex.md), Gemini CLI, Cline, Roo Code, [Cursor](../tools/development_ops/cursor.md), and Windsurf. Gemini CLI has the cleanest official Workspace story in this matrix, while Cline and Roo Code are better candidates for provider flexibility and custom endpoints.
+If the priority is coding-first integration potential, the strongest shortlist is [Claude Code](../tools/development_ops/claude-code.md), [Codex CLI](../tools/development_ops/codex.md), [Gemini CLI](../tools/ai_knowledge/gemini-cli.md), [Cline](../tools/agents/cline.md), [Roo Code](../tools/agents/roo-code.md), [Cursor](../tools/development_ops/cursor.md), and [Windsurf](../tools/development_ops/windsurf.md). Gemini CLI has the cleanest official Workspace story in this matrix, while Cline and Roo Code are better candidates for provider flexibility and custom endpoints.
 
 If the priority is reliable workflow automation rather than chat, [n8n](../services/n8n.md) and [Zapier](../tools/automation_orchestration/zapier.md) belong in a separate top tier. They are less elegant as daily chat interfaces, but stronger when the requirement is to read Gmail, inspect Calendar, and perform actions repeatably.
 
@@ -56,9 +56,9 @@ If the priority is reliable workflow automation rather than chat, [n8n](../servi
 | [LM Studio](../tools/infrastructure/lm-studio.md) | Local model runner | 🟢 | 🔵 | 🔵 | 🔵 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | Best as a local model host rather than a full productivity agent. |
 | [Jan](../tools/infrastructure/jan-ai.md) | Local AI app | 🟢 | 🔵 | 🔵 | 🔵 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🟠 | 🔴 | Local, open-source chat client with MCP support. |
 | [TypingMind](../tools/ai_knowledge/index.md) | Multi-model UI | 🟠 | 🔵 | 🔵 | 🟢 | 🟠 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | Good front end when plugins, Zapier, or MCP matter more than native apps. |
-| [Open Interpreter](../tools/agents/index.md) | Local computer-use agent | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟠 | 🟢 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Strong for local computer, files, and terminal; not a native Gmail or Calendar tool. |
-| [Goose](../tools/ai_knowledge/index.md) | Local general-purpose agent | 🟢 | 🔵 | 🔵 | 🟢 | 🟠 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟠 | 🟢 | Broad local agent with deep MCP emphasis. |
-| [Langflow](../tools/ai_knowledge/index.md) | Visual agent builder | 🟢 | 🔵 | 🔵 | 🟢 | 🟠 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🟠 | 🟢 | Better as a builder and orchestrator than as an end-user assistant. |
+| [Open Interpreter](../tools/automation_orchestration/open-interpreter.md) | Local computer-use agent | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟠 | 🟢 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Strong for local computer, files, and terminal; not a native Gmail or Calendar tool. |
+| [Goose](../tools/automation_orchestration/goose.md) | Local general-purpose agent | 🟢 | 🔵 | 🔵 | 🟢 | 🟠 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟠 | 🟢 | Broad local agent with deep MCP emphasis. |
+| [Langflow](../tools/frameworks/langflow.md) | Visual agent builder | 🟢 | 🔵 | 🔵 | 🟢 | 🟠 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🟠 | 🟢 | Better as a builder and orchestrator than as an end-user assistant. |
 | [Flowise](../tools/ai_knowledge/flowise.md) | Visual agent builder | 🟢 | 🔵 | 🔵 | 🟢 | 🟠 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🟢 | Good no-code-ish orchestration with MCP and OpenAI-compatible backends. |
 | [n8n](../services/n8n.md) | Automation/AI workflows | 🟢 | 🟢 | 🟢 | 🔵 | 🟠 | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | 🟢 | Strongest when the priority is actual business automation over chat UX. |
 | [Zapier](../tools/automation_orchestration/zapier.md) | Automation/AI actions | 🔴 | 🟢 | 🟢 | 🔵 | 🟠 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | Best SaaS route for turning an AI front end into app actions; Zapier MCP is the current strategic path. |
@@ -81,43 +81,43 @@ The supplementary list extends the comparison beyond end-user assistants into fr
 | [Haystack](../tools/frameworks/haystack.md) | RAG / agent framework | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | Strong RAG framework, not a productivity assistant. |
 | [PydanticAI](../tools/frameworks/pydantic-ai.md) | Agent framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🟠 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | 🔴 | Developer framework centered on typed Python agents. |
 | [LlamaIndex](../tools/ai_knowledge/llamaindex.md) | Context / agent framework | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | Strong context and RAG layer. |
-| [LlamaIndex.TS](../tools/ai_knowledge/index.md) | TypeScript context / agent framework | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | TypeScript counterpart for context-heavy apps. |
+| [LlamaIndex.TS](../tools/ai_knowledge/llamaindex-ts.md) | TypeScript context / agent framework | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | TypeScript counterpart for context-heavy apps. |
 | [LlamaParse](../tools/intake_storage/llamaparse.md) | Document AI / OCR | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Document parsing service rather than an agent. |
 | [Dify](../tools/ai_knowledge/dify.md) | Agent/workflow platform | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🟢 | App builder with workflow and agent surfaces. |
-| [Vellum](../tools/ai_knowledge/index.md) | AI workflow / agent platform | 🔴 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Hosted workflow platform. |
-| [Rivet](../tools/ai_knowledge/index.md) | Visual AI IDE | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🟢 | 🔴 | 🔴 | 🟠 | 🟢 | 🟠 | 🔴 | Visual workflow IDE; self-host status depends on deployment path. |
+| Vellum | AI workflow / agent platform | 🔴 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Hosted workflow platform. |
+| [Rivet](../tools/frameworks/rivet.md) | Visual AI IDE | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🟢 | 🔴 | 🔴 | 🟠 | 🟢 | 🟠 | 🔴 | Visual workflow IDE; self-host status depends on deployment path. |
 | [LiteLLM](../services/litellm.md) | LLM gateway | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🟢 | High-value provider abstraction and routing layer. |
 | [OpenRouter](../tools/ai_knowledge/openrouter.md) | Model router / API | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | Hosted model router with broad OpenAI-compatible API coverage. |
 | [Vercel AI SDK](../tools/development_ops/vercel.md) | App / agent SDK | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🟠 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | App SDK for AI interfaces and agents, not a standalone assistant. |
-| [Temporal](../tools/automation_orchestration/index.md) | Durable workflow engine | 🟢 | 🔴 | 🔴 | 🟠 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Durable orchestration substrate. |
-| [AgentOps](../tools/process_understanding/index.md) | Agent observability | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Observability product for agent runs. |
+| [Temporal](../tools/frameworks/temporal.md) | Durable workflow engine | 🟢 | 🔴 | 🔴 | 🟠 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Durable orchestration substrate. |
+| [AgentOps](../tools/process_understanding/agentops.md) | Agent observability | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Observability product for agent runs. |
 | [Langfuse](../tools/process_understanding/langfuse.md) | LLM observability | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | Open-source observability with self-host path. |
 | [Opik](../tools/process_understanding/comet-opik.md) | LLM observability / eval | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Evaluation and tracing surface. |
-| [Promptfoo](../tools/benchmarking/index.md) | Eval / red-team | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Practical CLI-driven eval and red-team tool. |
-| [Ragas](../tools/benchmarking/index.md) | Evaluation library | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🔴 | Library for RAG and LLM evaluation. |
-| [Helicone](../tools/process_understanding/index.md) | AI gateway / observability | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Gateway and observability layer with provider flexibility. |
+| [Promptfoo](../tools/benchmarking/promptfoo.md) | Eval / red-team | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Practical CLI-driven eval and red-team tool. |
+| [Ragas](../tools/process_understanding/ragas.md) | Evaluation library | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🔴 | Library for RAG and LLM evaluation. |
+| [Helicone](../tools/process_understanding/helicone.md) | AI gateway / observability | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Gateway and observability layer with provider flexibility. |
 | [Arize Phoenix](../tools/process_understanding/arize-ai.md) | Observability / eval | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Open-source evaluation and tracing stack. |
-| [Parea](../tools/process_understanding/index.md) | Observability / eval | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Hosted observability and evaluation platform. |
-| [LastMile AI](../tools/benchmarking/index.md) | Eval / guardrails / workbooks | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Hosted workbench and evaluation surface. |
-| [Fiddler](../tools/process_understanding/index.md) | Guardrails / observability | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Enterprise observability and governance. |
+| [Parea](../tools/process_understanding/parea.md) | Observability / eval | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Hosted observability and evaluation platform. |
+| [LastMile AI](../tools/process_understanding/lastmile.md) | Eval / guardrails / workbooks | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Hosted workbench and evaluation surface. |
+| [Fiddler](../tools/process_understanding/fiddler.md) | Guardrails / observability | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | Enterprise observability and governance. |
 | [Browser Use](../tools/automation_orchestration/browser-use.md) | Browser agent | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Browser automation agent layer. |
-| [Stagehand](../tools/automation_orchestration/index.md) | Browser automation framework | 🟢 | 🔴 | 🔴 | 🟠 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | Browser automation framework rather than productivity assistant. |
+| [Stagehand](../tools/automation_orchestration/stagehand.md) | Browser automation framework | 🟢 | 🔴 | 🔴 | 🟠 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | Browser automation framework rather than productivity assistant. |
 | [Composio](../tools/agents/composio.md) | Tool / auth layer for agents | 🔴 | 🔵 | 🔵 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | Tool and auth layer for connecting agents to SaaS apps. |
-| [Gumloop](../tools/automation_orchestration/index.md) | No-code agents / workflows | 🔴 | 🔵 | 🟠 | 🔵 | 🟠 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | SaaS workflow layer with useful app integrations. |
+| [Gumloop](../tools/automation_orchestration/gumloop.md) | No-code agents / workflows | 🔴 | 🔵 | 🟠 | 🔵 | 🟠 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | SaaS workflow layer with useful app integrations. |
 | [Braintrust](../tools/process_understanding/braintrust.md) | Observability / eval | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🔴 | 🟢 | Evaluation, prompt, and tracing infrastructure. |
 | [DSPy](../tools/frameworks/dspy.md) | Programming framework | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🔴 | Programmatic prompting and optimization framework. |
-| [Instructor](../tools/ai_knowledge/index.md) | Structured output library | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | 🔴 | Lightweight library for structured outputs. |
+| [Instructor](../tools/frameworks/instructor.md) | Structured output library | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🟠 | 🟢 | 🔴 | Lightweight library for structured outputs. |
 | [Mem0](../tools/agents/mem0.md) | Memory layer | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | Agent memory layer rather than a full assistant. |
-| [AirOps](../tools/ai_knowledge/index.md) | Content / workflow platform | 🔴 | 🔵 | 🔴 | 🟢 | 🟢 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | Workflow/content platform with app integrations. |
-| [Google ADK](../tools/frameworks/index.md) | Agent framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🔴 | Google-centered agent development kit. |
-| [Firebase Genkit](../tools/frameworks/index.md) | Full-stack AI framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | Full-stack AI framework for app developers. |
+| [AirOps](../tools/automation_orchestration/airops.md) | Content / workflow platform | 🔴 | 🔵 | 🔴 | 🟢 | 🟢 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | Workflow/content platform with app integrations. |
+| [Google ADK](../tools/frameworks/google-adk.md) | Agent framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🔴 | Google-centered agent development kit. |
+| [Firebase Genkit](../tools/frameworks/firebase-genkit.md) | Full-stack AI framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🔴 | Full-stack AI framework for app developers. |
 | [OpenAI Agents SDK](../tools/frameworks/openai-agents-sdk.md) | Agent SDK | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | OpenAI-centered SDK path for agents. |
-| [AG2](../tools/frameworks/index.md) | Multi-agent framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🔴 | Multi-agent framework descended from AutoGen ecosystem work. |
-| [Mastra](../tools/frameworks/index.md) | TypeScript agent framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | TypeScript agent framework with developer-first focus. |
-| [Superinterface](../tools/ai_knowledge/index.md) | AI assistant UI / infra | 🔴 | 🔴 | 🔴 | 🟠 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Assistant UI and infrastructure layer. |
-| [W&B Weave](../tools/process_understanding/index.md) | Observability / eval | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | Observability and evaluation layer in the W&B ecosystem. |
-| [LLMWare](../tools/frameworks/index.md) | Local / private AI framework | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🟠 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | Local and private AI framework. |
-| [Portkey AI Gateway](../tools/process_understanding/index.md) | AI gateway | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Gateway and provider abstraction layer. |
+| [AG2](../tools/frameworks/ag2.md) | Multi-agent framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🔴 | 🔴 | 🔴 | 🟢 | 🟢 | 🟢 | 🔴 | Multi-agent framework descended from AutoGen ecosystem work. |
+| [Mastra](../tools/frameworks/mastra.md) | TypeScript agent framework | 🟢 | 🔴 | 🔴 | 🟠 | 🟠 | 🔴 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | TypeScript agent framework with developer-first focus. |
+| [Superinterface](../tools/frameworks/superinterface.md) | AI assistant UI / infra | 🔴 | 🔴 | 🔴 | 🟠 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🟢 | Assistant UI and infrastructure layer. |
+| [W&B Weave](../tools/process_understanding/wandb-weave.md) | Observability / eval | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | Observability and evaluation layer in the W&B ecosystem. |
+| [LLMWare](../tools/automation_orchestration/llmware.md) | Local / private AI framework | 🟢 | 🔴 | 🔴 | 🟢 | 🟠 | 🟠 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | Local and private AI framework. |
+| [Portkey AI Gateway](../tools/providers/portkey.md) | AI gateway | 🟢 | 🔴 | 🔴 | 🔴 | 🔴 | 🟢 | 🔴 | 🟢 | 🟢 | 🔴 | 🟢 | 🟢 | Gateway and provider abstraction layer. |
 
 ## Practical scoring dimensions
 

--- a/docs/tools/agents/claude-skills-ecosystem.md
+++ b/docs/tools/agents/claude-skills-ecosystem.md
@@ -10,9 +10,10 @@ It makes operational know-how reusable. Instead of rediscovering the same prompt
 **Agents / Reusable Agent Capabilities**. Skills are composable behavior packages for coding agents.
 
 ## Typical use cases
-- Standardizing coding-agent workflows across teams
-- Packaging domain-specific operating procedures
-- Sharing prompts, templates, and task scaffolds
+- **UI Prototyping**: Using the `frontend-design` skill for production-grade React/Next.js generation.
+- **Web Automation**: Using the `browser-use` skill for live web research and multi-site automation.
+- **Autonomous Security**: Using the `shannon` skill for automated pen-testing and vulnerability scanning.
+- **Code Refinement**: Using the `simplify` skill for automated quality reviews and architectural simplification.
 
 ## Example company use cases
 - **Sales ops**: a lead-research skill that pulls CRM notes, formats account briefs, and proposes outreach angles.
@@ -54,6 +55,8 @@ skills/
 
 ## Related tools / concepts
 - [Documentation Writer](documentation-writer.md)
+- [Andrej Karpathy Skills](../ai_knowledge/karpathy-skills.md)
+- [Matt Pocock Skills](../ai_knowledge/matt-pocock-skills.md)
 - [Anthropic Agent Skills](anthropic-agent-skills.md)
 - [Superpowers](superpowers.md)
 - [Claude Code](../development_ops/claude-code.md)

--- a/docs/tools/ai_knowledge/karpathy-skills.md
+++ b/docs/tools/ai_knowledge/karpathy-skills.md
@@ -67,6 +67,15 @@ Once installed, the guidelines are automatically applied by the AI agent during 
 - Prefers simple, direct solutions over complex abstractions.
 - Makes surgical changes to the code.
 
+## Thinking Pattern Example
+When faced with a vague request like "Fix the auth," an agent using Karpathy/Pocock skills avoids jumping straight into code.
+
+**Agent Thinking Process:**
+1. **Initial Impulse**: Look for `auth.py` and start changing login logic.
+2. **Skill Check (Grill-me)**: Wait. "Fix the auth" is ambiguous. I need more context to be surgical.
+3. **Action**: Ask the user: "Could you specify if this is a bug with the current login flow, an integration issue with the new provider, or a request for a new feature like MFA?"
+4. **Result**: User specifies it's a redirect loop after OAuth. Agent now knows exactly which file and function to target, minimizing code churn.
+
 ## CLI examples
 The skills can be managed via the Claude Code CLI:
 

--- a/docs/tools/ai_knowledge/qwen.md
+++ b/docs/tools/ai_knowledge/qwen.md
@@ -1,7 +1,7 @@
 # Qwen
 
 ## What it is
-Qwen is a series of Large Language Models (LLMs) developed by Alibaba Cloud, including general-purpose (Qwen), coding (Qwen-Coder), and vision (Qwen-VL) models. The family features standout agentic variants such as **Qwen 3.5-35B-A3B**, which continues to push the boundaries of open-weight performance. It remains one of the most capable open-weight model families available, particularly strong in coding, mathematics, and multilingual tasks.
+Qwen is a series of Large Language Models (LLMs) developed by Alibaba Cloud, including general-purpose (Qwen), coding (Qwen-Coder), and vision (Qwen-VL) models. The family features standout agentic variants such as **Qwen 3.5-Max-Preview** and **Qwen 3.5-Plus** (latest frontier variants), which continue to push the boundaries of reasoning and agentic performance. It remains one of the most capable model families available, particularly strong in coding, mathematics, and complex multi-agent workflows.
 
 ## What problem it solves
 Provides high-performance, open-weight alternatives to proprietary models like GPT-4o. It enables powerful local inference for coding assistants and private reasoning tasks without relying on cloud APIs.
@@ -11,8 +11,9 @@ Provides high-performance, open-weight alternatives to proprietary models like G
 
 ## Typical use cases
 - **Local Coding Assistance**: Using `Qwen3.5-Coder` and `Qwen2.5-Coder` for IDE completions and agentic refactoring. Qwen 3.5 4B has demonstrated the ability to "vibe code" fully working OS web apps in one go.
+- **Agent Swarms**: Leveraging the **agentic reasoning** introduced in Qwen 3.5 for massive parallel workflows and complex reasoning tasks.
 - **Multilingual Applications**: Leveraging its strong performance across 29+ languages.
-- **Large Context Analysis**: Utilizing the 256K context window of Qwen3 models for document processing.
+- **Large Context Analysis**: Utilizing the 256K context window for deep document processing.
 - **Edge Deployment**: Running smaller variants (e.g., 0.8B, 1.5B, 3B, 4B) on mobile or low-power devices. The 0.8B model is capable of running on a watch.
 - **Hosted agent backends**: Using frontier Qwen variants through providers such as NVIDIA NIM when you want multimodal and tool-calling support without self-hosting the biggest checkpoints.
 
@@ -57,7 +58,7 @@ print(response.choices[0].message.content)
 ```
 
 ## Strengths
-- **State-of-the-Art Coding**: `Qwen3.5` variants continue to push coding performance. The **Qwen3.5-35B-A3B** model is a standout, achieving top-tier results on benchmarks like SWE-bench Verified, matching or exceeding much larger proprietary models. Its ability to reason through complex, multi-file software engineering tasks makes it a premier choice for autonomous coding agents.
+- **State-of-the-Art Coding**: `Qwen3.5` variants set new bars for coding performance. The **Qwen 3.5-Plus** model achieves a **top-tier score on SWE-bench Verified**, rivaling or exceeding the best proprietary models. Its ability to reason through complex, multi-file software engineering tasks makes it a premier choice for autonomous coding agents.
 - **Efficient Architecture**: Qwen3-Coder-Next and Qwen 3.5 variants use Mixture-of-Experts (MoE). The **35B-A3B** variant specifically utilizes roughly 3B active parameters, providing a massive performance-to-compute ratio under an Apache 2.0 license.
 - **Native Long Context**: Supports up to 256K tokens natively, ideal for large codebases. The tiny 0.8B model has demonstrated the ability to reason over a 100-file repository.
 - **Wide Model Range**: Scales from tiny edge models (0.8B, 2B, 4B) to massive 72B+ and 122B parameter powerhouses.
@@ -91,9 +92,9 @@ print(response.choices[0].message.content)
 
 ## Sources / References
 - [Official Website](https://qwenlm.github.io/)
+- [Qwen 3.5 Release Blog](https://qwenlm.github.io/blog/qwen2.5-coder/)
 - [Qwen GitHub](https://github.com/QwenLM/Qwen)
 - [Hugging Face Collection](https://huggingface.co/Qwen)
-- [Qwen 3.5 SWE-bench Results](https://www.reddit.com/r/LocalLLaMA/comments/1rkdlqi/qwen3535ba3b_hits_378_on_swebench_verified_hard/)
 - [NVIDIA NIM model card: qwen3.5-122b-a10b](https://build.nvidia.com/qwen/qwen3.5-122b-a10b/modelcard)
 - [Final Qwen 3.5 Unsloth GGUF Update](https://www.reddit.com/r/LocalLLaMA/comments/1rlkptk/final_qwen35_unsloth_gguf_update/)
 - [Qwen 3.5 0.8B reasoning over 100-file repo](https://www.reddit.com/r/LocalLLaMA/comments/1rmpdkc/i_made_a_tiny_08b_qwen_model_reason_over_a/)

--- a/docs/tools/calendar_tasks/any-do.md
+++ b/docs/tools/calendar_tasks/any-do.md
@@ -1,0 +1,49 @@
+# Any.do
+
+## What it is
+A comprehensive task management and calendar app designed for individuals and teams, featuring a unique "WhatsApp" integration.
+
+## What problem it solves
+Simplifies life and work organization with a clean interface and the ability to turn chats into tasks directly from messaging apps.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Task Management
+
+## Typical use cases
+- Managing personal daily routines and household tasks.
+- Team project management for small businesses.
+- Turning WhatsApp messages into actionable tasks via their bot.
+
+## Strengths
+- **WhatsApp Integration**: Unique capability to manage tasks through WhatsApp.
+- **Cross-App Sync**: Strong sync between tasks and calendar events.
+- **Design**: One of the most visually appealing and intuitive task managers.
+
+## Limitations
+- **Complexity at Scale**: Can feel a bit cluttered as the volume of tasks grows.
+- **Pricing**: Some advanced features require a relatively high monthly subscription.
+
+## When to use it
+- If you use WhatsApp as a primary communication channel for work or family.
+- If you want a task manager that feels "approachable" rather than clinical.
+
+## When not to use it
+- For complex, multi-year engineering projects (consider Jira or Linear).
+- If you need deep Markdown support in your tasks.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Freemium (Free for personal use; paid tiers for power users and teams)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [TickTick](ticktick.md)
+- [Todoist](todoist.md)
+- [Microsoft To Do](microsoft-todo.md)
+
+## Sources / References
+- [Any.do Official Site](https://www.any.do/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/calendar_tasks/apple-calendar.md
+++ b/docs/tools/calendar_tasks/apple-calendar.md
@@ -1,0 +1,49 @@
+# Apple Calendar
+
+## What it is
+Apple's native calendar application, deeply integrated into macOS, iOS, iPadOS, and watchOS.
+
+## What problem it solves
+Provides a seamless, synchronized scheduling experience for users within the Apple ecosystem, supporting iCloud, Exchange, and Google Calendar.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Ecosystem Native
+
+## Typical use cases
+- Personal and family scheduling on Apple devices.
+- Managing shared iCloud calendars for household coordination.
+- Quick event entry via Siri or natural language parsing.
+
+## Strengths
+- **Native Integration**: Deeply embedded in Apple's operating systems and hardware.
+- **Privacy-First**: Strong privacy controls and end-to-end encryption for iCloud data.
+- **Siri Support**: Excellent voice-to-task/calendar integration on Apple devices.
+
+## Limitations
+- **Ecosystem Lock-in**: Limited functionality and poor UI on non-Apple platforms.
+- **Feature Set**: Less powerful for complex business time blocking compared to tools like Akiflow or Morgen.
+
+## When to use it
+- If you are fully committed to the Apple hardware ecosystem.
+- For simple personal and family calendar management.
+
+## When not to use it
+- If you require advanced cross-platform collaborative features.
+- If you use Android or Windows as your primary devices.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Free (Included with Apple ID)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [Google Calendar](google_calendar.md)
+- [Outlook Calendar](outlook.md)
+- [Proton Calendar](proton_calendar.md)
+
+## Sources / References
+- [Apple Calendar Support](https://support.apple.com/calendar)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/calendar_tasks/calendly.md
+++ b/docs/tools/calendar_tasks/calendly.md
@@ -1,0 +1,49 @@
+# Calendly
+
+## What it is
+An automated scheduling platform that eliminates the back-and-forth of emails for finding the perfect time to meet.
+
+## What problem it solves
+Solves scheduling friction by allowing others to book meetings based on your real-time availability across multiple calendars.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Scheduling Automation
+
+## Typical use cases
+- Professional meeting scheduling with external clients.
+- Recruitment and interview coordination.
+- Managing office hours for teachers or consultants.
+
+## Strengths
+- **Simplicity**: Extremely easy for both the host and the invitee to use.
+- **Workflow Automation**: Automated reminders, follow-ups, and calendar invitations.
+- **Broad Integration**: Works with Google, Outlook, iCloud, and many CRMs.
+
+## Limitations
+- **Customization**: Limited branding and custom CSS on lower-tier plans.
+- **Personal Use**: Can feel overly formal for casual or internal scheduling.
+
+## When to use it
+- If you manage a high volume of meetings with external parties.
+- When you want to reduce the administrative overhead of scheduling.
+
+## When not to use it
+- For internal team meetings where shared calendars are already visible.
+- If you prefer a more private, local-first scheduling solution.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Freemium (Basic features free; advanced features paid)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [SavvyCal](savvycal.md)
+- [Akiflow](akiflow.md)
+- [Morgen](morgen.md)
+
+## Sources / References
+- [Calendly Official Site](https://calendly.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/calendar_tasks/fastmail.md
+++ b/docs/tools/calendar_tasks/fastmail.md
@@ -1,0 +1,49 @@
+# Fastmail
+
+## What it is
+An independent, privacy-focused email and calendar provider that offers a high-performance alternative to Gmail and Outlook.
+
+## What problem it solves
+Provides a fast, ad-free, and private surface for email, calendar, and contacts without the data mining common in free services.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Ecosystem Provider
+
+## Typical use cases
+- Primary personal or business email and calendar hosting.
+- Managing custom domain email with advanced alias support.
+- Synchronizing calendars across devices via standard protocols (JMAP/CalDAV).
+
+## Strengths
+- **Speed**: The web and mobile interfaces are exceptionally fast.
+- **Privacy**: No tracking or ads; data is never sold.
+- **Standards-First**: Strong support for JMAP, CalDAV, and CardDAV, making it easy to use with third-party clients.
+
+## Limitations
+- **Cost**: No free tier; subscription is required.
+- **Ecosystem**: Lacks the deep "doc" and "spreadsheet" ecosystem of Google Workspace.
+
+## When to use it
+- If you want to "de-Google" your personal productivity stack.
+- If you value speed and privacy over free services.
+
+## When not to use it
+- If you require a free-forever email and calendar service.
+- If your workflow is deeply dependent on Google Sheets/Docs collaboration.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Paid (Subscription)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [Proton Calendar](proton_calendar.md)
+- [Google Calendar](google_calendar.md)
+- [Radicale](../../services/radicale.md)
+
+## Sources / References
+- [Fastmail Official Site](https://www.fastmail.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/calendar_tasks/microsoft-todo.md
+++ b/docs/tools/calendar_tasks/microsoft-todo.md
@@ -1,0 +1,49 @@
+# Microsoft To Do
+
+## What it is
+A cloud-based task management application developed by Microsoft, which allows users to manage their tasks from a smartphone, tablet, and computer.
+
+## What problem it solves
+Helps users stay organized and manage their day-to-day tasks with features like "My Day" and seamless integration with the Microsoft 365 ecosystem.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Task Management
+
+## Typical use cases
+- Managing daily personal and professional to-do lists.
+- Capturing tasks from Outlook and Microsoft Teams.
+- Shared list collaboration for projects or shopping.
+
+## Strengths
+- **Microsoft 365 Integration**: Seamlessly syncs with Outlook Tasks and flagged emails.
+- **Cross-Platform**: Available on web, Windows, macOS, iOS, and Android.
+- **My Day**: A unique focus feature that encourages daily planning from a clean slate.
+
+## Limitations
+- **Advanced Features**: Lacks complex project management features found in Todoist or TickTick (e.g., natural language dates are less robust).
+- **Automation**: Third-party automation can be less intuitive compared to Todoist.
+
+## When to use it
+- If you are already a heavy user of Microsoft 365 (Outlook, Teams).
+- If you want a simple, clean, and free task manager for daily use.
+
+## When not to use it
+- If you need advanced sub-tasking, complex filters, or deep TDD integration.
+- If you prefer a platform-agnostic tool with more robust third-party integrations.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Free (with Microsoft account)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [Todoist](todoist.md)
+- [Outlook Calendar](outlook.md)
+- [Google Calendar](google_calendar.md)
+
+## Sources / References
+- [Microsoft To Do Official Site](https://todo.microsoft.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/calendar_tasks/savvycal.md
+++ b/docs/tools/calendar_tasks/savvycal.md
@@ -1,0 +1,49 @@
+# SavvyCal
+
+## What it is
+A modern scheduling tool designed to be as "sender-friendly" as it is "recipient-friendly," allowing invitees to overlay their own calendars.
+
+## What problem it solves
+Reduces the "scheduling dance" by providing a visual way for invitees to compare their availability with the host's, without leaving the booking page.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Scheduling Automation
+
+## Typical use cases
+- High-touch professional scheduling where recipient experience is prioritized.
+- Multi-person "Collective" or "Round Robin" scheduling.
+- Creating "secret" scheduling links for specific priority contacts.
+
+## Strengths
+- **Calendar Overlay**: Recipients can see their own calendar on top of yours to find gaps instantly.
+- **Flexibility**: Deep controls over meeting durations, buffers, and rank-ordered availability.
+- **Integration**: Strong support for Stripe, Zoom, and most major calendar providers.
+
+## Limitations
+- **No Free Tier**: Primarily a paid service with only a trial period.
+- **Niche Focus**: Specifically optimized for scheduling, not a general-purpose calendar.
+
+## When to use it
+- If you find standard scheduling tools too "aggressive" or one-sided.
+- If you value a premium, polished experience for your meeting invitees.
+
+## When not to use it
+- If you need a free-forever scheduling solution.
+- For simple internal scheduling.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Paid (Subscription)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [Calendly](calendly.md)
+- [Morgen](morgen.md)
+- [Amie](amie.md)
+
+## Sources / References
+- [SavvyCal Official Site](https://savvycal.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/calendar_tasks/sunsama.md
+++ b/docs/tools/calendar_tasks/sunsama.md
@@ -1,0 +1,49 @@
+# Sunsama
+
+## What it is
+A "guided daily planner" that helps professionals build a sustainable daily routine by pulling tasks from various tools into a unified, time-boxed schedule.
+
+## What problem it solves
+Combats burnout and fragmentation by encouraging intentional daily planning and limiting the number of tasks you commit to each day.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Unified Productivity
+
+## Typical use cases
+- Daily planning and time-blocking for deep work.
+- Aggregating tasks from Jira, Trello, GitHub, and Email.
+- Reflecting on daily accomplishments via a guided shutdown ritual.
+
+## Strengths
+- **Integrations**: High-quality integrations with major work platforms.
+- **Workflow Focus**: Not just a list; it's a workflow for planning your day.
+- **Clean UI**: Beautiful, distraction-free interface.
+
+## Limitations
+- **High Cost**: One of the most expensive personal productivity tools.
+- **Manual Work**: Requires a few minutes of active planning every morning (intentional by design).
+
+## When to use it
+- If you struggle with over-commitment and need a tool that forces you to be realistic.
+- If you want a "premium" planning experience.
+
+## When not to use it
+- If you are budget-conscious.
+- If you prefer a completely automated, "set-it-and-forget-it" scheduler.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Paid (Subscription)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [Akiflow](akiflow.md)
+- [Morgen](morgen.md)
+- [Motion](motion.md)
+
+## Sources / References
+- [Sunsama Official Site](https://sunsama.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/calendar_tasks/ticktick.md
+++ b/docs/tools/calendar_tasks/ticktick.md
@@ -1,0 +1,49 @@
+# TickTick
+
+## What it is
+A powerful, all-in-one task management app that features a calendar, Pomodoro timer, habit tracker, and Markdown notes.
+
+## What problem it solves
+Consolidates personal productivity tools into a single app, reducing context switching between task lists, calendars, and timers.
+
+## Where it fits in the stack
+**Category**: Calendar & Tasks / Task Management
+
+## Typical use cases
+- Personal task management and GTD (Getting Things Done).
+- Habit tracking and time-boxing with the integrated Pomodoro timer.
+- Managing shared family lists and simple team projects.
+
+## Strengths
+- **Feature Rich**: Includes many features (calendar, timer, habits) that usually require separate apps.
+- **Natural Language Parsing**: Excellent at recognizing dates and times in task names.
+- **Multi-Platform**: Robust apps for almost every operating system and device.
+
+## Limitations
+- **Calendar Power**: The integrated calendar is good but not as powerful as specialized tools like Fantastical.
+- **Free Tier Constraints**: Several core features (like full calendar view) are locked behind the Pro subscription.
+
+## When to use it
+- If you want a single app to handle tasks, habits, and time-boxing.
+- If you find Todoist too minimalist or expensive for its feature set.
+
+## When not to use it
+- If you need enterprise-level project management features.
+- If you prefer a modular approach with specialized apps for each function.
+
+## Licensing and cost
+- **Open Source**: No
+- **Cost**: Freemium (Basic features free; Pro subscription for full features)
+- **Self-hostable**: No
+
+## Related tools / concepts
+- [Todoist](todoist.md)
+- [Any.do](any-do.md)
+- [Habitica](../../services/habitica.md)
+
+## Sources / References
+- [TickTick Official Site](https://ticktick.com/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-02
+- Confidence: high

--- a/docs/tools/intake_storage/llamaparse.md
+++ b/docs/tools/intake_storage/llamaparse.md
@@ -17,7 +17,18 @@ Overcomes the limitations of standard PDF text extraction by using vision-aware 
 ## Strengths
 - **Vision-Aware**: Uses advanced vision models to understand document layout better than traditional OCR.
 - **Markdown Output**: Optimized for LLMs, preserving hierarchies and table structures in clean Markdown.
+- **Cost Optimizer**: Automatically routes simple pages to cheaper tiers while keeping complex pages on premium tiers.
 - **Ecosystem Integration**: Seamlessly connects with LlamaIndex for end-to-end RAG development.
+
+## Parsing Tiers
+LlamaParse offers four tiers that trade off cost, latency, and accuracy:
+
+| Tier | Best For | Cost (Credits/Page) |
+| :--- | :--- | :---: |
+| **Fast** | Plain text, single column, no tables. | 0.5 |
+| **Cost Effective** | Text with simple tables; clean markdown. | 3 |
+| **Agentic** | Scanned pages, multi-column, charts. | 10 |
+| **Agentic Plus** | Dense financial reports, mission-critical accuracy. | 45 |
 
 ## Limitations
 - **Cloud Dependency**: Primarily a cloud-based service, which may not suit air-gapped environments.

--- a/docs/tools/intake_storage/unstructured.md
+++ b/docs/tools/intake_storage/unstructured.md
@@ -38,6 +38,17 @@ It automates the ingestion of diverse document types, handling complex layouts a
 - **Cost**: Free (Self-hosted) / Paid (Unstructured API / Platform)
 - **Self-hostable**: Yes
 
+## Partitioning Strategies
+The Unstructured library offers several strategies for preprocessing documents, specified via the `strategy` parameter.
+
+| Strategy | Type | Best For | Trade-offs |
+| :--- | :--- | :--- | :--- |
+| `auto` | Hybrid | Most documents | Default; balances speed and accuracy automatically. |
+| `fast` | Rule-based | Plain text / clean PDFs | 100x faster than model-based; fails on tables/images. |
+| `hi_res` | Model-based | Complex layouts / Tables | Highest accuracy for structural elements; slower. |
+| `ocr_only` | Model-based | Scanned docs / Images | Pure OCR approach; ignores non-image text paths. |
+| `vlm` | Vision-model | Challenging/Handwritten | Uses Vision Language Models for maximum semantic recovery. |
+
 ## Getting started
 
 ### Installation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -273,14 +273,22 @@ nav:
           - Overview: tools/calendar_tasks/index.md
           - Akiflow: tools/calendar_tasks/akiflow.md
           - Amie: tools/calendar_tasks/amie.md
+          - Any.do: tools/calendar_tasks/any-do.md
+          - Apple Calendar: tools/calendar_tasks/apple-calendar.md
+          - Calendly: tools/calendar_tasks/calendly.md
           - Fantastical: tools/calendar_tasks/fantastical.md
+          - Fastmail: tools/calendar_tasks/fastmail.md
           - Google Calendar: tools/calendar_tasks/google_calendar.md
+          - Microsoft To Do: tools/calendar_tasks/microsoft-todo.md
           - Morgen: tools/calendar_tasks/morgen.md
           - Motion: tools/calendar_tasks/motion.md
           - Notion Calendar: tools/calendar_tasks/notion-calendar.md
           - Outlook Calendar: tools/calendar_tasks/outlook.md
           - Proton Calendar: tools/calendar_tasks/proton_calendar.md
           - Reclaim.ai: tools/calendar_tasks/reclaim.md
+          - SavvyCal: tools/calendar_tasks/savvycal.md
+          - Sunsama: tools/calendar_tasks/sunsama.md
+          - TickTick: tools/calendar_tasks/ticktick.md
           - Todoist: tools/calendar_tasks/todoist.md
           - Vimcal: tools/calendar_tasks/vimcal.md
       - Development & Ops:


### PR DESCRIPTION
This run resolves the 5 oldest remaining issues (#319, #335, #356, #421, #422) by significantly expanding the documentation and fixing navigation gaps.

Key changes:
- **Calendar & Tasks Gap Fill (#422)**: Created 8 new canonical pages for popular tools and registered them in the central registry and navigation.
- **Access Matrix Standardization (#319)**: Replaced dozens of generic tool names with valid relative markdown links to their canonical pages and standardized the matrix formatting.
- **Technical Deepening (#421)**: Added partitioning strategy details to Unstructured.io, parsing tiers to LlamaParse, and a new 'Thinking Pattern' example to Karpathy/Pocock skills.
- **Skills Expansion (#356)**: Added 4 new high-signal 2026 skills to the Claude ecosystem page.
- **Qwen Updates (#335)**: Updated the Qwen page to reflect the performance and capabilities of the latest frontier variants (3.5 Plus/Max-Preview).

Verification:
- Ran `scripts/check_catalog_consistency.py` (Passed).
- Ran `scripts/check_docs_contract.py` (Passed).
- Manually verified internal links in the Access Matrix.

---
*PR created automatically by Jules for task [3921103215857179737](https://jules.google.com/task/3921103215857179737) started by @joanmarcriera*