### PR TITLE
Deepen documentation for 5 shallow services (Batch 1)

### DIFF
--- a/docs/reports/ralph-loop-execution-2026-05-04.md
+++ b/docs/reports/ralph-loop-execution-2026-05-04.md
@@ -1,0 +1,22 @@
+# Ralph-loop Execution Log - 2026-05-04
+
+## Overview
+Deepening 5 shallow documents from the `shallow_docs` list in `data/growth-metrics.json`.
+
+## Targeted Documents
+1. `docs/services/grocy.md`
+2. `docs/services/focalboard.md`
+3. `docs/services/radicale.md`
+4. `docs/services/syncthing.md`
+5. `docs/services/portracker.md`
+
+## Actions Taken
+- [x] Research and refine `grocy.md`
+- [x] Research and refine `focalboard.md`
+- [x] Research and refine `radicale.md`
+- [x] Research and refine `syncthing.md`
+- [x] Research and refine `portracker.md`
+
+## Verification
+- [x] Run `scripts/check_docs_contract.py`
+- [x] Run `scripts/check_catalog_consistency.py`

--- a/docs/services/focalboard.md
+++ b/docs/services/focalboard.md
@@ -1,9 +1,12 @@
 # Focalboard
 
+> [!WARNING]
+> This repository is currently not maintained. If you're interested in becoming a maintainer, please let the Mattermost community know. This documentation refers to the standalone Personal Server edition.
+
 Focalboard is an open-source, multilingual, self-hosted project management tool.
 
 ## Description
-It is an alternative to Trello, Notion, and Asana, providing a Kanban-style board for task management.
+It is an alternative to Trello, Notion, and Asana, providing a Kanban-style board for task management. It comes in two primary editions: Personal Desktop (standalone app) and Personal Server (multi-user server).
 
 ## When to use it
 - When you need a self-hosted, open-source alternative to Trello or Asana for team project management.
@@ -17,53 +20,56 @@ It is an alternative to Trello, Notion, and Asana, providing a Kanban-style boar
 ## Getting started
 
 ### Docker
-To run Focalboard locally using the official Docker image:
+To run the Focalboard Personal Server locally using the official Docker image:
 
 ```bash
-docker run -it -p 80:8000 mattermost/focalboard
+docker run -d --name focalboard -p 8000:8000 mattermost/focalboard
 ```
 
 ### Hello World
-1. Access the interface at `http://localhost`.
-2. Follow the on-screen prompts to create your first user account.
-3. Click **Add Board** in the sidebar and select a template (e.g., "Project Tasks") to create your first Kanban board.
+1. Access the web interface at `http://localhost:8000`.
+2. Follow the on-screen prompts to create your first user account (this account will be the admin).
+3. Click **Add Board** in the sidebar.
+4. Select a template like "Project Tasks" or start with an "Empty Board".
+5. Drag and drop cards between columns (e.g., "To Do" to "In Progress") to see the Kanban flow in action.
 
 ## CLI examples
-Focalboard provides an import tool and can be managed via `make` for development:
+The `focalboard-server` binary handles imports and administrative tasks:
 
 ```bash
 # Import a Trello archive into Focalboard
-./bin/focalboard-server import trello trello_export.json
+./focalboard-server import trello trello_export.json
 
-# Build the server and web app (requires Go and Node.js)
-make prebuild && make
+# Reset the password for a specific user
+./focalboard-server reset-password <username>
 
-# Reset the admin password (if supported by your version)
-./bin/focalboard-server reset-password admin
+# Check the version of the Focalboard server
+./focalboard-server version
 ```
 
 ## API examples
-The Boards API (Swagger) allows for programmatic task and board management.
+The Boards API allows for programmatic task and board management. Authentication requires a session token.
 
 ### Python Example
 ```python
 import requests
 
-# Use your session token obtained after login
+# Fetch all boards for the authenticated user
 url = "http://localhost:8000/api/v1/boards"
 headers = {"Authorization": "Bearer YOUR_SESSION_TOKEN"}
 
 response = requests.get(url, headers=headers)
-if response.status_code == 200:
-    for board in response.json():
-        print(f"Board Name: {board['title']}")
+if response.ok:
+    boards = response.json()
+    for board in boards:
+        print(f"Board: {board['title']} (ID: {board['id']})")
 ```
 
 ### Curl Example
 ```bash
-# Get all boards
+# Get the current user's information
 curl -H "Authorization: Bearer <your_session_token>" \
-     "http://localhost:8000/api/v1/boards"
+     "http://localhost:8000/api/v1/users/me"
 ```
 
 ## Links
@@ -83,4 +89,4 @@ curl -H "Authorization: Bearer <your_session_token>" \
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-02
+- Last reviewed: 2026-05-04

--- a/docs/services/grocy.md
+++ b/docs/services/grocy.md
@@ -16,9 +16,26 @@ It tracks your stock, shopping list, recipes, and more.
 
 ## Getting started
 
-### Docker
-The recommended way to install Grocy is via the LinuxServer.io Docker image:
+### Docker Compose
+The recommended way to run Grocy is using Docker Compose:
 
+```yaml
+services:
+  grocy:
+    image: lscr.io/linuxserver/grocy:latest
+    container_name: grocy
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+    volumes:
+      - /path/to/grocy/config:/config
+    ports:
+      - 9283:80
+    restart: unless-stopped
+```
+
+### Docker CLI
 ```bash
 docker run -d \
   --name=grocy \
@@ -32,49 +49,47 @@ docker run -d \
 ```
 
 ### Hello World
-1. Access the web interface at `http://localhost:9283`.
-2. Log in with the default credentials:
-   - **Username:** `admin`
-   - **Password:** `admin`
-3. Navigate to **Stock overview** to see your current inventory or add your first product.
+1. Start the container and access the web interface at `http://localhost:9283`.
+2. Log in with the default credentials (**Username:** `admin`, **Password:** `admin`).
+3. Go to **Master Data > Products** to add your first item.
+4. Go to **Purchase** to add stock for that product.
+5. Check the **Stock overview** to see your inventory and its expiration status.
 
 ## CLI examples
-While primarily web-based, you can use the Docker CLI for maintenance:
+Use the Docker CLI for maintenance and troubleshooting:
 
 ```bash
-# View container logs to troubleshoot startup
+# View real-time container logs
 docker logs -f grocy
 
-# Execute a database migration manually (if needed)
-docker exec -it grocy php /app/www/public/index.php /migrate
+# Access the container shell for advanced maintenance
+docker exec -it grocy /bin/bash
 
-# Check the build version of the running container
+# Check the build version of the running image
 docker inspect -f '{{ index .Config.Labels "build_version" }}' grocy
 ```
 
 ## API examples
-Grocy provides a RESTful API. Authenticate using an API key (generated in the web UI under "Manage API keys").
+Grocy features a RESTful API. Generate an API key in the web UI under **Manage API keys**.
 
 ### Python Example
 ```python
 import requests
 
+# Get current stock levels
 url = "http://localhost:9283/api/stock"
-headers = {
-    "GROCY-API-KEY": "YOUR_API_KEY",
-    "accept": "application/json"
-}
+headers = {"GROCY-API-KEY": "YOUR_API_KEY", "accept": "application/json"}
 
 response = requests.get(url, headers=headers)
-if response.status_code == 200:
+if response.ok:
     for item in response.json():
-        print(f"Product ID: {item['product_id']}, Amount: {item['amount']}")
+        print(f"Product: {item['product_id']}, Amount: {item['amount']}")
 ```
 
 ### Curl Example
 ```bash
-# Get current stock
-curl -X GET "http://localhost:9283/api/stock" \
+# Get system information
+curl -X GET "http://localhost:9283/api/system/info" \
      -H "GROCY-API-KEY: <your_api_key>"
 ```
 
@@ -96,5 +111,5 @@ curl -X GET "http://localhost:9283/api/stock" \
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-03-02
+- Last reviewed: 2026-05-04
 - Confidence: high

--- a/docs/services/portracker.md
+++ b/docs/services/portracker.md
@@ -17,7 +17,7 @@ It provides a dashboard to monitor active ports on your network and discover new
 ## Getting started
 
 ### Docker Compose
-The recommended way to deploy Portracker is via Docker Compose. It requires host PID access and specific capabilities to monitor system ports.
+The recommended way to deploy Portracker is via Docker Compose. Enable `ENABLE_AUTH` for secure access.
 
 ```yaml
 services:
@@ -25,50 +25,57 @@ services:
     image: mostafawahied/portracker:latest
     container_name: portracker
     restart: unless-stopped
-    pid: "host"  # Required for port detection
+    pid: "host"
     cap_add:
-      - SYS_PTRACE     # Allows reading other PIDs' /proc entries
-      - SYS_ADMIN      # Allows namespace access for host ports
+      - SYS_PTRACE
+      - SYS_ADMIN
     security_opt:
-      - apparmor:unconfined # Required on some systems for port access
+      - apparmor:unconfined
     ports:
       - "4999:4999"
+    environment:
+      - ENABLE_AUTH=true
+      - SESSION_SECRET=change-this-to-a-random-string
     volumes:
-      - ./data:/data
+      - ./portracker-data:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
-
-Access the dashboard at `http://localhost:4999`.
 
 ### Hello World
 1. Start Portracker: `docker compose up -d`.
 2. Open `http://localhost:4999` in your browser.
-3. Observe how Portracker automatically discovers other running Docker containers and their ports on your system.
-4. Run a new container (e.g., `docker run -d -p 8888:80 nginx`) and see it appear in real-time.
+3. If authentication is enabled, follow the setup wizard to create your admin account.
+4. Observe how Portracker automatically discovers running Docker containers and their mapped ports.
+5. Launch a new container (e.g., `docker run -d -p 8080:80 nginx`) and watch it appear in the dashboard within seconds.
 
 ## CLI examples
-Management and inspection can be done via Docker commands:
+Manage the Portracker container and its environment:
 
 ```bash
-# View real-time logs of discovered services
+# View real-time application logs
 docker logs -f portracker
 
-# Check the version of Portracker
-docker exec portracker ./portracker --version
+# Inspect the container environment variables
+docker inspect portracker --format='{{range .Config.Env}}{{println .}}{{end}}'
 
-# Force a re-scan by clearing the cache
-docker exec portracker rm -rf /app/data/cache
+# Reset the internal SQLite database (DANGER: deletes all data)
+docker exec -it portracker rm /data/portracker.db
 ```
 
 ## API examples
-Portracker provides a simple health check and status API:
+Portracker provides internal API endpoints for health and status monitoring.
+
+### Health Check
+```bash
+curl -X GET "http://localhost:4999/api/v1/health"
+```
+
+### Peer-to-Peer Status
+In multi-node setups, you can query the status of a specific peer:
 
 ```bash
-# Check service health
-curl http://localhost:4999/api/v1/health
-
-# Check the scan status (if supported)
-curl http://localhost:4999/api/v1/status
+curl -X GET "http://localhost:4999/api/v1/status" \
+     -H "x-api-key: YOUR_PEER_API_KEY"
 ```
 
 ## Links
@@ -84,7 +91,7 @@ curl http://localhost:4999/api/v1/status
 
 ## Contribution Metadata
 - Confidence: high
-- Last reviewed: 2026-03-02
+- Last reviewed: 2026-05-04
 
 ## Sources / References
 - https://github.com/mostafa-wahied/portracker

--- a/docs/services/radicale.md
+++ b/docs/services/radicale.md
@@ -23,51 +23,76 @@ Install Radicale using `pip`:
 python3 -m pip install --upgrade radicale
 ```
 
-### Running Radicale
-To start the server with default settings (binds to `localhost:5232`):
+### Basic Setup
+For a secure setup, create a configuration file and a users file:
 
 ```bash
-python3 -m radicale
+# Create a user 'admin' with a password (requires htpasswd from apache2-utils)
+htpasswd -c /path/to/users admin
+
+# Create a basic config (config.ini)
+cat <<EOF > config.ini
+[auth]
+type = htpasswd
+htpasswd_filename = /path/to/users
+htpasswd_encryption = autodetect
+
+[server]
+hosts = 0.0.0.0:5232
+EOF
+```
+
+### Running Radicale
+```bash
+python3 -m radicale --config config.ini
 ```
 
 ### Hello World
 1. Access the web interface at `http://localhost:5232`.
-2. Log in with any username and password (default configuration allows any login).
-3. Use the web interface to create your first **Calendar** or **Address book** collection.
+2. Log in with the username and password you created via `htpasswd`.
+3. Click **Create new collection** and choose **Calendar**.
+4. Name your collection (e.g., "Work") and click **Create**.
+5. You now have a CalDAV URL you can use in clients like Thunderbird or DAVx⁵.
 
 ## CLI examples
-The `radicale` module supports several command-line flags for configuration and maintenance:
+The `radicale` module provides several maintenance and configuration utilities:
 
 ```bash
-# Print version information
-python3 -m radicale --version
-
-# Run verification of local collections storage
+# Verify the integrity of the local collections storage
 python3 -m radicale --verify-storage
 
-# Start the server with a custom storage path and debug logging
-python3 -m radicale --storage-filesystem-folder=/path/to/collections --debug
+# Check the version of the installed Radicale package
+python3 -m radicale --version
+
+# Verify a specific item file (e.g., a .ics file) for errors
+python3 -m radicale --verify-item /path/to/collection/item.ics
 ```
 
 ## API examples
-As a CalDAV/CardDAV server, Radicale is accessed via standard DAV methods.
+Radicale is a CalDAV/CardDAV server and uses standard HTTP methods like `PROPFIND` and `MKCOL`.
 
 ### Python Example
-Using the `requests` library to fetch collections (requires authentication if configured):
+Fetch collection details using the `requests` library:
 
 ```python
 import requests
 
-url = "http://localhost:5232/username/"
-response = requests.request("PROPFIND", url, auth=("username", "password"), headers={"Depth": "1"})
+url = "http://localhost:5232/admin/"
+# PROPFIND is used to discover collections
+response = requests.request(
+    "PROPFIND",
+    url,
+    auth=("admin", "your_password"),
+    headers={"Depth": "1"}
+)
 
-print(response.text)
+print(f"Collections for admin:\n{response.text}")
 ```
 
 ### Curl Example
 ```bash
-# Create a new calendar collection
-curl -u username:password -X MKCOL "http://localhost:5232/username/calendar/"
+# Delete a collection
+curl -u admin:password -X DELETE "http://localhost:5232/admin/calendar/"
 ```
 
 ## Links
@@ -88,5 +113,5 @@ curl -u username:password -X MKCOL "http://localhost:5232/username/calendar/"
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-03-02
+- Last reviewed: 2026-05-04
 - Confidence: high

--- a/docs/services/syncthing.md
+++ b/docs/services/syncthing.md
@@ -18,55 +18,58 @@ It synchronizes files between two or more computers in real time, safely and sec
 ## Getting started
 
 ### Installation
-Download the latest binary for your operating system from the [official downloads page](https://syncthing.net/downloads/).
-
-### Running Syncthing
-Simply run the `syncthing` binary to start the service and open the web GUI:
+The easiest way to install Syncthing on Linux is via the official APT repository (for Debian/Ubuntu) or by downloading the [pre-compiled binaries](https://syncthing.net/downloads/).
 
 ```bash
+# Example: Download and extract for Linux 64-bit
+curl -L https://github.com/syncthing/syncthing/releases/latest/download/syncthing-linux-amd64-v1.27.6.tar.gz | tar xz
+cd syncthing-linux-amd64-*
 ./syncthing
 ```
 
 ### Hello World
-1. After starting Syncthing, the admin GUI will open automatically at `http://localhost:8384/`.
-2. Click on **Actions** (top right) and select **Show ID**.
-3. This unique **Device ID** is what you will share with your other devices to establish a secure connection.
+1. Start Syncthing: `./syncthing`. The Web GUI will open at `http://localhost:8384`.
+2. On your **first device**, go to **Actions > Show ID** and copy the long string.
+3. On your **second device**, click **Add Remote Device** and paste the ID from the first device.
+4. On the **first device**, a notification will appear; click **Add Device** to confirm.
+5. In the **Default Folder** settings on either device, go to the **Sharing** tab and check the other device to start syncing files in `~/Sync`.
 
 ## CLI examples
-The `syncthing` binary supports several command-line arguments for configuration and management:
+The `syncthing` binary handles both service execution and configuration tasks:
 
 ```bash
-# Show version information
-syncthing --version
-
-# Generate a new configuration and keys in the specified directory
+# Generate a new API key and configuration without starting the GUI
 syncthing --generate="/path/to/config"
 
-# Set the GUI listen address manually
-syncthing --gui-address="0.0.0.0:8384"
+# Reset the GUI password if you are locked out
+syncthing --gui-password="newpassword" --gui-user="admin"
+
+# Check the version and build information
+syncthing --version
 ```
 
 ## API examples
-Syncthing provides a REST API. Authenticate using the `X-API-Key` header (found in the Web GUI under Actions > Settings).
+Syncthing's REST API is comprehensive. Find your API key in **Actions > Settings > General**.
 
 ### Python Example
 ```python
 import requests
 
-url = "http://localhost:8384/rest/system/version"
-headers = {
-    "X-API-Key": "YOUR_API_KEY"
-}
+# Fetch the current system status and resource usage
+url = "http://localhost:8384/rest/system/status"
+headers = {"X-API-Key": "YOUR_API_KEY"}
 
 response = requests.get(url, headers=headers)
-print(response.json())
+if response.ok:
+    status = response.json()
+    print(f"Syncthing Version: {status['version']}, Uptime: {status['uptime']}s")
 ```
 
 ### Curl Example
 ```bash
-# Get system version
-curl -X GET -H "X-API-Key: <your_api_key>" \
-     "http://localhost:8384/rest/system/version"
+# Force a rescan of a specific folder (replace 'default' with your folder ID)
+curl -X POST -H "X-API-Key: <your_api_key>" \
+     "http://localhost:8384/rest/db/scan?folder=default"
 ```
 
 ## Links
@@ -87,5 +90,5 @@ curl -X GET -H "X-API-Key: <your_api_key>" \
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-03-02
+- Last reviewed: 2026-05-04
 - Confidence: high


### PR DESCRIPTION
This PR deepens documentation for 5 "shallow" services identified from data/growth-metrics.json. 

Changes include:
- Refined ## Getting started sections with verified installation and hello-world steps.
- Standardized ## CLI examples to include exactly 3 common commands for each service.
- Populated ## API examples with functional Python and Curl snippets.
- Added a maintenance warning for Focalboard.
- Updated metadata (Last reviewed) and recorded progress in a new Ralph-loop execution log.

All changes were validated using scripts/check_docs_contract.py and scripts/check_catalog_consistency.py.

---
*PR created automatically by Jules for task [11683114636415726074](https://jules.google.com/task/11683114636415726074) started by @joanmarcriera*