### PR TITLE
Resolve #186: Layered Data Copilot Text-to-SQL pipeline

### DIFF
--- a/docs/architecture/data-copilot-text-to-sql.md
+++ b/docs/architecture/data-copilot-text-to-sql.md
@@ -110,15 +110,24 @@ To ensure interoperability between layers, we use standardized Pydantic models (
 
 ## Cost & Model Routing
 
-To maintain a "free/cheap-first" stack, we recommend the following model routing:
+To maintain a "free/cheap-first" stack, route each layer to the cheapest model class that can pass that layer's tests, then escalate only the failed layer with the same pruned context. Treat model IDs as configuration, not hard-coded business logic, because hosted catalogs and local model availability change over time.
 
-| Layer | Recommended Model | Rationale |
-| :--- | :--- | :--- |
-| Router | Qwen 2.5 0.8B (Local) | Low latency, simple classification. |
-| Intent | Qwen 2.5 7B or Llama 3.1 8B | Needs better reasoning for metric extraction. |
-| Table Selection | Groq (Llama 3.1 70B) | High accuracy for selection; remains free under Groq limits. |
-| Column Pruning | Qwen 2.5 7B (Local) | Structured output is critical here. |
-| SQL Generation | GPT-4o-mini or Claude 3.5 Haiku | High reliability for syntax at low cost. |
+| Layer | Free / cheap primary route | Escalation route | Token budget control | Rationale |
+| :--- | :--- | :--- | :--- | :--- |
+| Router | Local Ollama small classifier such as `qwen3:1.7b` or another compact open model | Local `qwen3:8b` | Workspace names + 1-line descriptions only | Simple domain classification should not require paid tokens. |
+| Intent | Local `qwen3:8b`, `llama3.1:8b`, or equivalent small instruct model | Low-cost hosted model such as OpenAI GPT-5.4 mini-class or Claude Haiku-class | User question + workspace policy + metric glossary | Metric/date extraction needs stronger reasoning than routing but remains compact. |
+| Table Selection | Hosted free/developer-plan open model on Groq or local 8B model over table summaries | Low-cost hosted mini/Haiku-class model | Top 10 table cards, each with owner, grains, joins, and metric tags | Wrong-table errors are expensive, so this layer gets stronger reasoning and HITL review. |
+| Column Pruning | Local `qwen3:8b` with JSON/schema output validation | Claude Haiku-class or OpenAI mini-class model | Selected table DDL plus PK/FK/metric comments only | Structured pruning is cheap to verify and keeps SQL prompts small. |
+| SQL Generation | Low-cost hosted mini/Haiku-class model | Larger hosted SQL-capable model only after validation failure | Pruned schema + intent JSON + dialect rules; no full database dump | SQL syntax and dialect reliability are worth a small paid call after pruning. |
+
+### Human correction points
+
+Human correction is intentionally placed before the pipeline pays for larger-context SQL generation:
+
+1. **Table review**: The Table Agent returns selected tables, confidence, and a rationale. If confidence is low, too many tables are selected, or a domain expert spots a missing fact table, the reviewer can replace the table list and continue without rerunning routing or intent extraction.
+2. **Column / metric review**: The Column Prune Agent returns per-table column lists and the metric assumptions it inferred. A reviewer can correct ambiguous fields such as `gross_price` versus `net_price`, add required join keys, or send the question back for clarification.
+3. **Post-validation review**: If SQL validation or sample-result checks fail, show the user the intent, table list, pruned schema, generated SQL, and validator error together so the correction targets the smallest broken layer.
+
 
 ## Token Control & Schema Pruning Strategy
 
@@ -128,19 +137,23 @@ To minimize costs and stay within the context limits of smaller models, the foll
 2.  **Column-Level Pruning**: Once tables are selected, only the primary keys, foreign keys, and columns identified by the **Column Prune Agent** are included in the final SQL generation prompt.
     - *Example*: For a table `orders` with 50 columns, if the intent is "Total sales by month", the pruned schema sent to the SQL Generator only contains `[id, total_amount, created_at]`.
 3.  **Schema metadata**: We include short comments in the schema (e.g., `-- type: categorical`) rather than raw data samples to keep token counts low.
-4.  **Fallback Routing**: If a query fails on a local model (e.g. Qwen 2.5 7B), it is automatically routed to a more capable but expensive model (e.g. Claude 3.5 Sonnet) with the same pruned schema.
+4.  **Fallback Routing**: If a query fails on a local model, route only that layer to a more capable hosted model with the same pruned schema. Avoid rerunning the whole pipeline unless the validator proves the earlier interface is wrong.
+5.  **Token ceilings per layer**: Enforce hard maximum prompt sizes for router, intent, table, prune, and SQL layers. If a layer exceeds its budget, summarize or retrieve fewer schema cards before escalating to a bigger model.
 
 ## Failure Modes & Mitigation
 
 1. **Wrong Domain (Router Failure)**:
    - *Symptom*: Question about "eggs" routed to "Home Office" instead of "Grocy".
    - *Mitigation*: Provide a "Unsure" fallback that triggers a human clarification.
-2. **Table Explosion (Table Agent Failure)**:
-   - *Symptom*: Selecting 10+ tables for a simple query.
-   - *Mitigation*: Hard limit on table count (e.g., max 4) and HITL verification.
-3. **Metric Ambiguity**:
-   - *Symptom*: User asks for "Total Sales" but schema has `subtotal`, `tax`, and `total`.
-   - *Mitigation*: Intent agent must request clarification if multiple column matches are found in the metadata.
+2. **Wrong Table / Table Explosion (Table Agent Failure)**:
+   - *Symptom*: Selecting an event-log table instead of the canonical fact table, or selecting 10+ tables for a simple query.
+   - *Mitigation*: Hard limit on table count (e.g., max 4), table-grain metadata, and HITL verification before column pruning.
+3. **Wrong Metric Definition**:
+   - *Symptom*: User asks for "spend" or "total sales" but the schema has `subtotal`, `tax`, `discount`, `gross_price`, and `net_price`.
+   - *Mitigation*: Maintain a metric glossary, require the Intent Agent to emit metric assumptions, and ask for clarification when multiple metric definitions match.
+4. **Unsafe or Overbroad SQL**:
+   - *Symptom*: Generated SQL uses `SELECT *`, unbounded date ranges, write statements, or cross-workspace joins.
+   - *Mitigation*: Run a SQL policy validator before execution, reject write statements, require date limits for large fact tables, and execute only against read-only credentials.
 
 ## When NOT to use Text-to-SQL
 
@@ -158,8 +171,12 @@ To minimize costs and stay within the context limits of smaller models, the foll
 ## Sources / References
 - [Uber Engineering: Text-to-SQL at Scale](https://www.uber.com/en-GB/blog/text-to-sql-at-scale/)
 - [SQL-Coder (Defog.ai)](https://github.com/defog-ai/sqlcoder)
+- [Ollama documentation](https://docs.ollama.com/)
+- [Groq supported models](https://console.groq.com/docs/models)
+- [OpenAI API pricing](https://openai.com/api/pricing)
+- [Claude pricing documentation](https://docs.claude.com/en/docs/about-claude/pricing)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-26
+- Last reviewed: 2026-05-06
 - Confidence: high
 - Related Issues: #186

--- a/docs/reference-implementations/data-copilot/skeleton-guide.md
+++ b/docs/reference-implementations/data-copilot/skeleton-guide.md
@@ -1,6 +1,6 @@
 # Data Copilot: Reference Implementation
 
-This reference implementation provides a Python-based skeleton for the layered Text-to-SQL pipeline. It demonstrates how to use Pydantic for structured data exchange between the different agent layers.
+This reference implementation provides a Python-based skeleton for the layered Text-to-SQL pipeline. It demonstrates how to use Pydantic for structured data exchange between the different agent layers, where to insert human corrections, and how to keep model routing configurable for free/cheap-first deployments.
 
 ## Implementation Skeleton
 
@@ -16,12 +16,17 @@ The following script defines the interfaces for the Workspace Router, Intent Age
 
 - **Asynchronous Execution**: Uses `asyncio` for non-blocking agent calls.
 - **Type Safety**: Leverages Pydantic models to ensure consistent data structures across layers.
-- **Modularity**: Each layer is a distinct method, allowing for independent model routing (e.g., using a small model for routing and a larger one for SQL generation).
+- **Modularity**: Each layer is a distinct method, allowing for independent model routing (e.g., using a local small model for routing and a hosted mini/Haiku-class model for SQL generation).
+- **Human correction points**: `review_table_selection()` and `review_pruned_schema()` show how a reviewer can correct wrong tables or wrong metric columns without restarting the whole pipeline.
+- **Token controls**: `TokenStats` and `ModelRoute` capture estimated schema tokens, pruning ratios, prompt ceilings, and fallback routes.
 
 ## Sources / References
 - [Pydantic Documentation](https://docs.pydantic.dev/)
 - [Python Asyncio](https://docs.python.org/3/library/asyncio.html)
+- [Ollama documentation](https://docs.ollama.com/)
+- [OpenAI API pricing](https://openai.com/api/pricing)
+- [Claude pricing documentation](https://docs.claude.com/en/docs/about-claude/pricing)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-26
+- Last reviewed: 2026-05-06
 - Confidence: high

--- a/docs/reference-implementations/data-copilot/skeleton.py
+++ b/docs/reference-implementations/data-copilot/skeleton.py
@@ -1,95 +1,207 @@
-from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field
+"""Reference skeleton for the layered Data Copilot Text-to-SQL pipeline.
+
+The module intentionally uses deterministic mock logic instead of live LLM calls so
+it can be executed in documentation CI. Replace the methods that return static
+values with provider calls while preserving the Pydantic contracts.
+"""
+
+from __future__ import annotations
+
+import asyncio
 import math
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
 
 # --- 1. Schema Definitions (Pydantic for validation) ---
+
 
 class WorkspaceContext(BaseModel):
     workspace_id: str
     description: str
     db_connection_string: str
 
+
 class IntentOutput(BaseModel):
-    metrics: List[str]
-    dimensions: List[str]
-    filters: Dict[str, str]
-    time_range: Optional[str] = "last_30_days"
+    metrics: list[str]
+    dimensions: list[str]
+    filters: dict[str, str]
+    time_range: str | None = "last_30_days"
+    clarification_needed: str | None = None
+
 
 class TableSelection(BaseModel):
-    selected_tables: List[str]
+    selected_tables: list[str]
     rationale: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
 
 class PrunedSchema(BaseModel):
     table_name: str
-    columns: List[str]
+    columns: list[str]
+
 
 class TokenStats(BaseModel):
     estimated_tokens: int
     pruning_ratio: float
 
+
+class ModelRoute(BaseModel):
+    layer: str
+    primary_model: str
+    fallback_model: str
+    max_prompt_tokens: int
+    reason: str
+
+
+class ReviewStatus(StrEnum):
+    APPROVED = "approved"
+    NEEDS_CORRECTION = "needs_correction"
+    REJECTED = "rejected"
+
+
+class HumanReviewDecision(BaseModel):
+    status: ReviewStatus
+    corrected_tables: list[str] | None = None
+    corrected_columns: dict[str, list[str]] | None = None
+    note: str | None = None
+
+
+class SqlOutput(BaseModel):
+    sql: str
+    assumptions: list[str]
+    model_route: ModelRoute
+    estimated_prompt_tokens: int
+
+
 # --- 2. Token Control & Pruning Utilities ---
 
+
 def estimate_tokens(text: str) -> int:
-    """Rough token estimation (4 chars per token)."""
+    """Rough token estimation for routing decisions (4 chars per token)."""
     return math.ceil(len(text) / 4)
+
 
 def calculate_pruning_ratio(original_cols: int, pruned_cols: int) -> float:
     if original_cols == 0:
         return 0.0
     return 1 - (pruned_cols / original_cols)
 
+
 # --- 3. Agent Interfaces (Skeleton) ---
 
+
 class DataCopilotPipeline:
-    def __init__(self):
-        # In a real implementation, you'd initialize LLM clients here
-        self.full_schema_mock = {
-            "items": ["id", "name", "quantity", "purchase_price", "category_id", "room", "created_at", "updated_at", "tags", "notes", "location_detail"],
+    """Deterministic skeleton showing each Text-to-SQL layer and review point."""
+
+    def __init__(self) -> None:
+        # In production, initialize LLM clients, embeddings, and schema catalogs here.
+        self.full_schema_mock: dict[str, list[str]] = {
+            "items": [
+                "id",
+                "name",
+                "quantity",
+                "purchase_price",
+                "category_id",
+                "room",
+                "created_at",
+                "updated_at",
+                "tags",
+                "notes",
+                "location_detail",
+            ],
             "categories": ["id", "name", "description", "parent_id", "slug", "icon"],
-            "orders": ["id", "order_date", "total_amount", "vendor_id", "status"]
+            "orders": ["id", "order_date", "total_amount", "vendor_id", "status"],
+        }
+        self.model_routes = {
+            "router": ModelRoute(
+                layer="router",
+                primary_model="local:qwen3:1.7b",
+                fallback_model="local:qwen3:8b",
+                max_prompt_tokens=500,
+                reason="The workspace router is a low-token classification task.",
+            ),
+            "intent": ModelRoute(
+                layer="intent",
+                primary_model="local:qwen3:8b",
+                fallback_model="hosted:gpt-5.4-mini",
+                max_prompt_tokens=1_500,
+                reason="Intent extraction needs stronger metric and date reasoning.",
+            ),
+            "table": ModelRoute(
+                layer="table",
+                primary_model="hosted:groq-open-model",
+                fallback_model="hosted:gpt-5.4-mini",
+                max_prompt_tokens=2_000,
+                reason="Table selection benefits from stronger reasoning but only sees table summaries.",
+            ),
+            "prune": ModelRoute(
+                layer="prune",
+                primary_model="local:qwen3:8b",
+                fallback_model="hosted:claude-haiku-4.5",
+                max_prompt_tokens=2_000,
+                reason="Column pruning is structured-output heavy and cheap to verify.",
+            ),
+            "sql": ModelRoute(
+                layer="sql",
+                primary_model="hosted:gpt-5.4-mini",
+                fallback_model="hosted:claude-haiku-4.5",
+                max_prompt_tokens=3_000,
+                reason="SQL syntax generation should use the most reliable low-cost route.",
+            ),
         }
 
     async def workspace_router(self, query: str) -> WorkspaceContext:
         """Layer 1: Route query to a specific domain."""
-        print(f"Routing query: {query}")
-        # Mock logic: Small model (e.g. Qwen 2.5 0.8B) classification
+        print(f"Routing query with {self.model_routes['router'].primary_model}: {query}")
         return WorkspaceContext(
             workspace_id="inventory",
             description="Home Inventory and Assets",
-            db_connection_string="sqlite:///home_inventory.db"
+            db_connection_string="sqlite:///home_inventory.db",
         )
 
     async def intent_agent(self, query: str, context: WorkspaceContext) -> IntentOutput:
         """Layer 2: Extract structured intent."""
-        print(f"Extracting intent for: {query}")
-        # Mock logic: Extract metrics and filters
+        print(f"Extracting intent for workspace {context.workspace_id}: {query}")
         return IntentOutput(
             metrics=["quantity", "purchase_price"],
             dimensions=["category"],
-            filters={"room": "Kitchen"}
+            filters={"room": "Kitchen"},
+            time_range="last_month",
         )
 
     async def table_agent(self, intent: IntentOutput) -> TableSelection:
         """Layer 3: Select relevant tables."""
         print(f"Selecting tables for intent metrics: {intent.metrics}")
-        # In practice, use semantic search over table descriptions.
-        selection = TableSelection(
+        return TableSelection(
             selected_tables=["items", "categories"],
-            rationale="Need 'items' for quantity/price and 'categories' for grouping."
+            rationale="Need 'items' for quantity/price and 'categories' for grouping.",
+            confidence=0.82,
         )
 
-        # HITL Point: Table Approval
-        print(f"\n[HITL] Table Approval: {selection.selected_tables}")
-        print(f"Rationale: {selection.rationale}")
-        print("Human approved tables: Yes\n")
+    def review_table_selection(
+        self,
+        selection: TableSelection,
+        decision: HumanReviewDecision | None = None,
+    ) -> TableSelection:
+        """Human correction point for wrong-table failures."""
+        if decision is None or decision.status == ReviewStatus.APPROVED:
+            return selection
+        if decision.status == ReviewStatus.NEEDS_CORRECTION and decision.corrected_tables:
+            return selection.model_copy(update={"selected_tables": decision.corrected_tables})
+        raise ValueError(f"Table selection rejected: {decision.note or 'no reason provided'}")
 
-        return selection
-
-    async def column_prune_agent(self, tables: List[str], intent: IntentOutput) -> List[PrunedSchema]:
-        """Layer 4: Prune columns to minimize prompt size (Token Control)."""
+    async def column_prune_agent(
+        self,
+        tables: list[str],
+        intent: IntentOutput,
+    ) -> tuple[list[PrunedSchema], TokenStats]:
+        """Layer 4: Prune columns to minimize prompt size."""
         print(f"Pruning columns for tables: {tables}")
 
-        pruned_results = []
+        pruned_results: list[PrunedSchema] = []
         total_original_cols = 0
         total_pruned_cols = 0
 
@@ -97,10 +209,9 @@ class DataCopilotPipeline:
             all_cols = self.full_schema_mock.get(table, [])
             total_original_cols += len(all_cols)
 
-            # Skeletal logic: keep primary keys and columns mentioned in intent.
-            # In a real agent, the LLM would pick these based on the question.
             pruned_cols = [
-                col for col in all_cols
+                col
+                for col in all_cols
                 if col in ["id", "category_id"]
                 or col in intent.metrics
                 or col in intent.dimensions
@@ -112,47 +223,77 @@ class DataCopilotPipeline:
 
         stats = TokenStats(
             estimated_tokens=estimate_tokens(str(pruned_results)),
-            pruning_ratio=calculate_pruning_ratio(total_original_cols, total_pruned_cols)
+            pruning_ratio=calculate_pruning_ratio(total_original_cols, total_pruned_cols),
         )
-        print(f"Pruning Complete. Ratio: {stats.pruning_ratio:.2%}, Estimated Tokens: {stats.estimated_tokens}")
+        print(
+            "Pruning complete. "
+            f"Ratio: {stats.pruning_ratio:.2%}, Estimated Tokens: {stats.estimated_tokens}"
+        )
+        return pruned_results, stats
 
-        # HITL Point: Column Approval
-        print("[HITL] Pruned Schema Approval:")
-        for p in pruned_results:
-            print(f"  - {p.table_name}: {p.columns}")
-        print("Human approved columns: Yes\n")
+    def review_pruned_schema(
+        self,
+        schema: list[PrunedSchema],
+        decision: HumanReviewDecision | None = None,
+    ) -> list[PrunedSchema]:
+        """Human correction point for wrong-column or wrong-metric failures."""
+        if decision is None or decision.status == ReviewStatus.APPROVED:
+            return schema
+        if decision.status == ReviewStatus.NEEDS_CORRECTION and decision.corrected_columns:
+            corrected: list[PrunedSchema] = []
+            for table_schema in schema:
+                columns = decision.corrected_columns.get(table_schema.table_name, table_schema.columns)
+                corrected.append(table_schema.model_copy(update={"columns": columns}))
+            return corrected
+        raise ValueError(f"Pruned schema rejected: {decision.note or 'no reason provided'}")
 
-        return pruned_results
+    async def sql_generator(
+        self,
+        intent: IntentOutput,
+        schema: list[PrunedSchema],
+        stats: TokenStats,
+    ) -> SqlOutput:
+        """Layer 5: Generate the final SQL from only the pruned schema + intent."""
+        prompt_payload: dict[str, Any] = {
+            "intent": intent.model_dump(),
+            "schema": [table.model_dump() for table in schema],
+        }
+        estimated_prompt_tokens = estimate_tokens(str(prompt_payload))
+        route = self.model_routes["sql"]
+        if estimated_prompt_tokens > route.max_prompt_tokens:
+            route = route.model_copy(update={"primary_model": route.fallback_model})
 
-    async def sql_generator(self, intent: IntentOutput, schema: List[PrunedSchema]) -> str:
-        """Layer 5: Generate the final SQL."""
-        print("Generating SQL using pruned schema...")
-        # Input to prompt: Only the pruned schema + intent JSON
-        return "SELECT c.name, SUM(i.quantity) FROM items i JOIN categories c ON i.category_id = c.id WHERE i.room = 'Kitchen' GROUP BY c.name;"
+        print(f"Generating SQL using {route.primary_model} and {stats.estimated_tokens} schema tokens")
+        return SqlOutput(
+            sql=(
+                "SELECT c.name, SUM(i.quantity * i.purchase_price) AS estimated_spend "
+                "FROM items i JOIN categories c ON i.category_id = c.id "
+                "WHERE i.room = 'Kitchen' GROUP BY c.name;"
+            ),
+            assumptions=["purchase_price is the spend proxy because no order line table was selected"],
+            model_route=route,
+            estimated_prompt_tokens=estimated_prompt_tokens,
+        )
+
 
 # --- 4. Example Execution ---
 
-async def main():
+
+async def main() -> None:
     pipeline = DataCopilotPipeline()
 
-    # 1. Route
     query = "How much did I spend on kitchen items last month?"
     workspace = await pipeline.workspace_router(query)
-
-    # 2. Intent
     intent = await pipeline.intent_agent(query, workspace)
-
-    # 3. Tables
     tables = await pipeline.table_agent(intent)
+    reviewed_tables = pipeline.review_table_selection(tables)
+    pruned_schema, stats = await pipeline.column_prune_agent(reviewed_tables.selected_tables, intent)
+    reviewed_schema = pipeline.review_pruned_schema(pruned_schema)
+    sql = await pipeline.sql_generator(intent, reviewed_schema, stats)
 
-    # 4. Prune (Critical Token Control Point)
-    pruned_schema = await pipeline.column_prune_agent(tables.selected_tables, intent)
+    print(f"\nFinal Generated SQL:\n{sql.sql}")
+    print(f"Assumptions: {sql.assumptions}")
 
-    # 5. Generate
-    sql = await pipeline.sql_generator(intent, pruned_schema)
-
-    print(f"\nFinal Generated SQL:\n{sql}")
 
 if __name__ == "__main__":
-    import asyncio
     asyncio.run(main())

--- a/docs/reference-implementations/data-copilot/test_skeleton.py
+++ b/docs/reference-implementations/data-copilot/test_skeleton.py
@@ -1,34 +1,73 @@
-import pytest
 import asyncio
-from skeleton import DataCopilotPipeline, WorkspaceContext, IntentOutput
 
-@pytest.mark.asyncio
-async def test_pipeline_flow():
+from skeleton import (
+    DataCopilotPipeline,
+    HumanReviewDecision,
+    IntentOutput,
+    ReviewStatus,
+    TableSelection,
+    PrunedSchema,
+    WorkspaceContext,
+)
+
+
+def test_pipeline_flow():
+    asyncio.run(_pipeline_flow())
+
+
+async def _pipeline_flow():
     pipeline = DataCopilotPipeline()
     query = "Test query"
 
-    # 1. Router
     workspace = await pipeline.workspace_router(query)
     assert isinstance(workspace, WorkspaceContext)
     assert workspace.workspace_id == "inventory"
 
-    # 2. Intent
     intent = await pipeline.intent_agent(query, workspace)
     assert isinstance(intent, IntentOutput)
     assert "quantity" in intent.metrics
 
-    # 3. Tables
     tables = await pipeline.table_agent(intent)
     assert "items" in tables.selected_tables
 
-    # 4. Prune
-    pruned = await pipeline.column_prune_agent(tables.selected_tables, intent)
+    pruned, stats = await pipeline.column_prune_agent(tables.selected_tables, intent)
     assert len(pruned) > 0
     assert pruned[0].table_name == "items"
+    assert stats.pruning_ratio > 0
 
-    # 5. SQL
-    sql = await pipeline.sql_generator(intent, pruned)
-    assert "SELECT" in sql
+    sql = await pipeline.sql_generator(intent, pruned, stats)
+    assert "SELECT" in sql.sql
+    assert sql.model_route.primary_model.startswith("hosted:")
 
-if __name__ == "__main__":
-    asyncio.run(test_pipeline_flow())
+
+def test_human_table_correction_point():
+    pipeline = DataCopilotPipeline()
+    selection = pipeline.review_table_selection(
+        selection=TableSelection(
+            selected_tables=["orders"],
+            rationale="Ambiguous spend language.",
+            confidence=0.51,
+        ),
+        decision=HumanReviewDecision(
+            status=ReviewStatus.NEEDS_CORRECTION,
+            corrected_tables=["items", "categories"],
+            note="Inventory spend should use item purchase prices.",
+        ),
+    )
+    assert selection.selected_tables == ["items", "categories"]
+
+
+def test_human_column_correction_point():
+    pipeline = DataCopilotPipeline()
+    schema = [
+        {"table_name": "items", "columns": ["id", "quantity"]},
+        {"table_name": "categories", "columns": ["id", "name"]},
+    ]
+    corrected = pipeline.review_pruned_schema(
+        schema=[PrunedSchema.model_validate(item) for item in schema],
+        decision=HumanReviewDecision(
+            status=ReviewStatus.NEEDS_CORRECTION,
+            corrected_columns={"items": ["id", "quantity", "purchase_price", "category_id"]},
+        ),
+    )
+    assert "purchase_price" in corrected[0].columns


### PR DESCRIPTION
### Motivation
- Provide a clear, testable, and cost-conscious layered Text-to-SQL architecture and reference implementation for the Data Copilot workstream. 
- Reduce expensive model usage by adding per-layer routing, token budgets, and pruning so small/local models are used first. 
- Offer explicit human-in-the-loop correction points and stronger failure-mode guidance so outputs are safe and explainable.

### Description
- Update `docs/architecture/data-copilot-text-to-sql.md` to add configurable free/cheap model routing, per-layer token ceilings, explicit human correction points, expanded failure modes, and additional sources and review metadata. 
- Replace/upgrade the reference skeleton at `docs/reference-implementations/data-copilot/skeleton.py` to a deterministic, runnable implementation with Pydantic contracts for `WorkspaceContext`, `IntentOutput`, `TableSelection`, `PrunedSchema`, `ModelRoute`, `HumanReviewDecision`, and `SqlOutput`, plus model routing and review helper methods. 
- Enhance the implementation guide at `docs/reference-implementations/data-copilot/skeleton-guide.md` with guidance on human correction points, token controls, and configurable routing. 
- Add and adapt tests in `docs/reference-implementations/data-copilot/test_skeleton.py` to run without `pytest-asyncio` and to cover pipeline flow plus human table/column correction flows.

### Testing
- Ran `python3 -m pytest docs/reference-implementations/data-copilot/test_skeleton.py` and the test suite passed. 
- Ran repository validation checks `python3 scripts/check_catalog_consistency.py`, `python3 scripts/check_docs_contract.py docs/architecture/data-copilot-text-to-sql.md docs/reference-implementations/data-copilot/skeleton-guide.md`, and `python3 scripts/validate_new_sources.py`, all of which passed. 
- Verified `mkdocs.yml` parse with `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'` and it reported OK. 
- Executed the skeleton script with `python3 docs/reference-implementations/data-copilot/skeleton.py` to exercise example flow and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb229785b08320a78c38399695a6d3)