### PR TITLE
Expand orchestration tool coverage

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -103,6 +103,18 @@
       "doc_path": "docs/tools/ai_knowledge/ansigpt.md"
     },
     {
+      "id": "apache-airflow",
+      "name": "Apache Airflow",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/apache-airflow.md"
+    },
+    {
+      "id": "apache-hamilton",
+      "name": "Apache Hamilton",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/apache-hamilton.md"
+    },
+    {
       "id": "anthropic",
       "name": "Anthropic (Claude)",
       "category": "Providers",
@@ -154,6 +166,12 @@
       "name": "Apple Calendar",
       "category": "Calendar & Tasks",
       "doc_path": "docs/tools/calendar_tasks/apple-calendar.md"
+    },
+    {
+      "id": "argo-workflows",
+      "name": "Argo Workflows",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/argo-workflows.md"
     },
     {
       "id": "arc",
@@ -564,6 +582,12 @@
       "doc_path": "docs/playbooks/data-copilot-sql-validation.md"
     },
     {
+      "id": "dagster",
+      "name": "Dagster",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/dagster.md"
+    },
+    {
       "id": "datadog",
       "name": "Datadog",
       "category": "Process & Understanding",
@@ -760,6 +784,12 @@
       "name": "Firecrawl",
       "category": "Process & Understanding",
       "doc_path": "docs/tools/process_understanding/firecrawl.md"
+    },
+    {
+      "id": "flyte",
+      "name": "Flyte",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/flyte.md"
     },
     {
       "id": "fireworks-ai",
@@ -1178,6 +1208,12 @@
       "name": "Kubernetes (K3s)",
       "category": "Infrastructure",
       "doc_path": "docs/tools/infrastructure/k3s.md"
+    },
+    {
+      "id": "kestra",
+      "name": "Kestra",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/kestra.md"
     },
     {
       "id": "karpathy-skills",
@@ -1811,6 +1847,12 @@
       "name": "NVIDIA PersonaPlex",
       "category": "AI Assistants & Knowledge",
       "doc_path": "docs/tools/ai_knowledge/personaplex.md"
+    },
+    {
+      "id": "prefect",
+      "name": "Prefect",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/prefect.md"
     },
     {
       "id": "phidata",
@@ -2464,6 +2506,12 @@
       "name": "Zapier",
       "category": "Automation & Orchestration",
       "doc_path": "docs/tools/automation_orchestration/zapier.md"
+    },
+    {
+      "id": "zenml",
+      "name": "ZenML",
+      "category": "Orchestration",
+      "doc_path": "docs/tools/orchestration/zenml.md"
     },
     {
       "id": "zed",

--- a/docs/new-sources.md
+++ b/docs/new-sources.md
@@ -7,6 +7,7 @@ This index tracks daily source-ingestion files. Each day gets a dedicated log fi
 | Date | Log File | New | Integrated | Notes |
 | :--- | :--- | :---: | :---: | :--- |
 | 2026-05-07 | [2026-05-07](/new-sources/2026-05-07/) | 0 | 6 | Integrated 6 agent frameworks for Batch 2. |
+| 2026-05-06 | [2026-05-06](/new-sources/2026-05-06/) | 0 | 8 | Expanded orchestration category for issue #468. |
 | 2026-05-02 | [2026-05-02](/new-sources/2026-05-02/) | 0 | 8 | Integrated 8 calendar & task tools for #422. |
 | 2026-04-27 | [2026-04-27](/new-sources/2026-04-27/) | 0 | 5 | Integrated RAG and Agentic Workflows patterns. |
 | 2026-04-26 | [2026-04-26](/new-sources/2026-04-26/) | 10 | 8 | Decomposed tasks from #360, #299, #296. Integrated 8 items. |

--- a/docs/new-sources/2026-05-06.md
+++ b/docs/new-sources/2026-05-06.md
@@ -1,0 +1,12 @@
+# New Sources Log — 2026-05-06
+
+| Title | URL | Tags | Status | Canonical Page | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| Apache Airflow | https://airflow.apache.org/ | orchestration | integrated | [Apache Airflow](../tools/orchestration/apache-airflow.md) | Mature Python DAG scheduler and workflow monitor. |
+| Argo Workflows | https://argoproj.github.io/workflows/ | orchestration | integrated | [Argo Workflows](../tools/orchestration/argo-workflows.md) | Kubernetes-native container workflow engine. |
+| Dagster | https://dagster.io/ | orchestration | integrated | [Dagster](../tools/orchestration/dagster.md) | Asset-aware data and AI pipeline orchestrator. |
+| Flyte | https://flyte.org/ | orchestration | integrated | [Flyte](../tools/orchestration/flyte.md) | AI and ML workflow orchestration platform. |
+| Apache Hamilton | https://hamilton.dagworks.io/ | orchestration | integrated | [Apache Hamilton](../tools/orchestration/apache-hamilton.md) | Python dataflow framework for function-derived DAGs. |
+| Kestra | https://kestra.io/ | orchestration | integrated | [Kestra](../tools/orchestration/kestra.md) | Declarative scheduled and event-driven workflow platform. |
+| Prefect | https://www.prefect.io/ | orchestration | integrated | [Prefect](../tools/orchestration/prefect.md) | Python-native workflow orchestration engine. |
+| ZenML | https://www.zenml.io/ | orchestration | integrated | [ZenML](../tools/orchestration/zenml.md) | MLOps pipeline framework with swappable orchestrators. |

--- a/docs/tools/orchestration/apache-airflow.md
+++ b/docs/tools/orchestration/apache-airflow.md
@@ -1,0 +1,58 @@
+# Apache Airflow
+
+## What it is
+Apache Airflow is an open-source platform for authoring, scheduling, and monitoring workflows as Python-defined DAGs. It is a mature general-purpose orchestrator with a large provider ecosystem for databases, warehouses, cloud services, and infrastructure systems.
+
+## What problem it solves
+Airflow turns recurring operational work into versioned workflow code with dependencies, schedules, retries, logs, and a web UI. For AI and data systems, it is useful when the main problem is coordinating batch jobs, extraction steps, model refreshes, report generation, or integration tasks across many existing services.
+
+## Where it fits in the stack
+**Orchestration / Batch workflow scheduler**.
+
+## Typical use cases
+- Scheduled ETL, ELT, and reverse-ETL pipelines.
+- Periodic model training, embedding refresh, or report generation jobs.
+- Coordinating tasks across cloud warehouses, storage buckets, notebooks, APIs, and internal services.
+- Auditable workflow operations where teams need logs, retry controls, and ownership boundaries.
+
+## Strengths
+- Very broad ecosystem of providers and operational knowledge.
+- Workflows are Python code, which makes them reviewable and testable in normal development workflows.
+- Strong scheduling, retry, backfill, logging, and UI support for batch workloads.
+- Can run self-hosted and has many managed-service options.
+
+## Limitations
+- DAG-centric design is less natural for highly dynamic, stateful, or conversational agent loops.
+- Operational footprint can be heavy compared with lighter Python-native orchestrators.
+- Poor fit for low-latency request/response AI services.
+- Complex deployments require careful executor, metadata database, and worker configuration.
+
+## When to use it
+- You already operate Airflow or need compatibility with a mature data-platform standard.
+- Workloads are scheduled, dependency-driven, and mostly batch-oriented.
+- You need many prebuilt integrations and a familiar UI for operations teams.
+
+## When not to use it
+- You need durable function semantics for long-running stateful workflows.
+- The workflow shape is highly dynamic at runtime.
+- You want a small embedded library inside an application rather than a platform service.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free self-hosted; paid managed offerings available from vendors.
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [Temporal](temporal.md)
+- [Prefect](prefect.md)
+- [Dagster](dagster.md)
+- [n8n](../../services/n8n.md)
+
+## Sources / References
+- [Official website](https://airflow.apache.org/)
+- [Official documentation](https://airflow.apache.org/docs/)
+- [GitHub](https://github.com/apache/airflow)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/apache-hamilton.md
+++ b/docs/tools/orchestration/apache-hamilton.md
@@ -1,0 +1,58 @@
+# Apache Hamilton
+
+## What it is
+Apache Hamilton is an open-source Python framework for creating dataflows from ordinary Python functions. Each function represents a transformation, and Hamilton infers the directed graph from function names, parameters, and type annotations.
+
+## What problem it solves
+Hamilton helps teams structure feature engineering, data transformation, and AI data-preparation code as explicit, inspectable dataflows without requiring a heavyweight external scheduler. It is especially useful where the dependency graph should be derived from well-scoped Python functions and reused across notebooks, services, batch jobs, and orchestration systems.
+
+## Where it fits in the stack
+**Orchestration / Dataflow definition and execution layer**.
+
+## Typical use cases
+- Feature and metric computation pipelines.
+- Retrieval, ranking, and evaluation data preparation.
+- Reusable data transformation graphs embedded in services or batch jobs.
+- Documenting and visualizing dependencies between Python-derived datasets.
+
+## Strengths
+- Encourages small, testable Python functions.
+- Automatically builds a DAG from regular Python code.
+- Can complement rather than replace Airflow, Prefect, Dagster, or other schedulers.
+- Useful for lineage, visualization, and collaboration around transformation logic.
+
+## Limitations
+- It is not primarily a full platform scheduler like Airflow or Prefect.
+- Teams may still need an external orchestrator for deployment, scheduling, and retries.
+- Best suited to Python-centric transformation logic.
+- Less appropriate for broad SaaS or infrastructure automation.
+
+## When to use it
+- You want clear Python dataflow structure without a large platform migration.
+- Pipeline logic needs to run in multiple contexts: notebooks, APIs, and batch workflows.
+- You want function-level testability and dependency visibility.
+
+## When not to use it
+- You need a complete workflow operations platform by itself.
+- Workflows are mostly shell, container, or SaaS integration tasks.
+- Your team does not use Python for transformation logic.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free open-source framework; hosted DAGWorks/Hamilton UI has paid options.
+- **Self-hostable**: Yes for the open-source framework.
+
+## Related tools / concepts
+- [Dagster](dagster.md)
+- [Prefect](prefect.md)
+- [Apache Airflow](apache-airflow.md)
+- [Model Comparison & Evaluation](../../knowledge_base/model_comparison_and_evaluation.md)
+
+## Sources / References
+- [Official documentation](https://hamilton.dagworks.io/)
+- [DAGWorks documentation](https://docs.dagworks.io/)
+- [GitHub](https://github.com/apache/hamilton)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/argo-workflows.md
+++ b/docs/tools/orchestration/argo-workflows.md
@@ -1,0 +1,58 @@
+# Argo Workflows
+
+## What it is
+Argo Workflows is an open-source, Kubernetes-native workflow engine for running containerized DAG and step-based workflows. Workflows are represented as Kubernetes custom resources, and each step typically runs as a container.
+
+## What problem it solves
+Argo Workflows gives Kubernetes teams a native way to run parallel, compute-heavy, and dependency-aware jobs without bolting a separate scheduler beside the cluster. For AI systems, it is useful for batch inference, evaluation sweeps, data processing, training jobs, and other workloads that benefit from Kubernetes scheduling and isolation.
+
+## Where it fits in the stack
+**Orchestration / Kubernetes-native workflow engine**.
+
+## Typical use cases
+- Parallel data processing or ML jobs on Kubernetes.
+- Batch inference and evaluation workflows.
+- CI/CD-style workflows that should run inside the same Kubernetes control plane.
+- Containerized pipelines that need resource limits, secrets, volumes, and cluster scheduling.
+
+## Strengths
+- Deep Kubernetes integration through custom resources.
+- Good fit for highly parallel container jobs.
+- Cloud-agnostic when the underlying Kubernetes platform is portable.
+- Works naturally with GitOps and Kubernetes-native operational controls.
+
+## Limitations
+- Requires Kubernetes fluency and cluster operations.
+- YAML-heavy workflow authoring can become difficult for complex application logic.
+- Less suited to interactive or long-running conversational agents.
+- Not the right abstraction for simple local automations.
+
+## When to use it
+- Your workloads are already containerized and run on Kubernetes.
+- You need high parallelism and cluster-native scheduling.
+- Platform teams want workflows controlled through Kubernetes APIs and GitOps.
+
+## When not to use it
+- You do not run Kubernetes.
+- The team wants Python-native workflow code as the primary authoring surface.
+- You need a SaaS automation product for non-technical users.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free self-hosted; infrastructure costs depend on the Kubernetes environment.
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [Flyte](flyte.md)
+- [Apache Airflow](apache-airflow.md)
+- [Temporal](temporal.md)
+- [Kubernetes (K3s)](../infrastructure/k3s.md)
+
+## Sources / References
+- [Official documentation](https://argoproj.github.io/workflows/)
+- [GitHub](https://github.com/argoproj/argo-workflows)
+- [Argo project](https://argoproj.github.io/)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/dagster.md
+++ b/docs/tools/orchestration/dagster.md
@@ -1,0 +1,58 @@
+# Dagster
+
+## What it is
+Dagster is a data orchestrator for building, observing, and operating data and AI pipelines. It centers the model around data assets, lineage, metadata, testing, and operational visibility rather than only task execution order.
+
+## What problem it solves
+Dagster helps teams understand what data products exist, how they are produced, when they are fresh, and which upstream assets affect them. For AI systems, this is valuable when models, agents, or retrieval pipelines depend on reliable datasets, embeddings, features, documents, or evaluation tables.
+
+## Where it fits in the stack
+**Orchestration / Data and AI pipeline control plane**.
+
+## Typical use cases
+- Data asset orchestration for analytics, ML, and AI products.
+- Embedding, feature, or evaluation dataset refresh pipelines.
+- dbt, Spark, warehouse, notebook, and Python job coordination.
+- Data quality, freshness, and lineage tracking for AI-ready datasets.
+
+## Strengths
+- Asset-oriented model makes lineage and ownership more explicit.
+- Strong local development, testing, metadata, and observability story.
+- Good fit for modern data teams that need both orchestration and catalog context.
+- Managed Dagster+ option reduces platform operations for teams that want SaaS.
+
+## Limitations
+- Less focused on arbitrary SaaS automation than tools such as n8n or Zapier.
+- Teams moving from classic task DAGs may need to learn asset-first modeling.
+- The managed product introduces vendor dependency for hosted capabilities.
+- Not a general-purpose durable function engine for application workflows.
+
+## When to use it
+- You need to orchestrate data and AI pipelines where lineage, freshness, and observability matter.
+- Data products are first-class operational objects.
+- You want Python-based development with production-grade metadata.
+
+## When not to use it
+- The workload is mostly office SaaS automation.
+- You need Kubernetes-native YAML workflows.
+- You need long-running application transactions with durable event history.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free open-source edition; paid Dagster+ managed platform.
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [Prefect](prefect.md)
+- [Apache Airflow](apache-airflow.md)
+- [Flyte](flyte.md)
+- [Vector DB Comparison](../../knowledge_base/vector-db-comparison.md)
+
+## Sources / References
+- [Official website](https://dagster.io/)
+- [Official documentation](https://docs.dagster.io/)
+- [GitHub](https://github.com/dagster-io/dagster)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/flyte.md
+++ b/docs/tools/orchestration/flyte.md
@@ -1,0 +1,58 @@
+# Flyte
+
+## What it is
+Flyte is an open-source workflow orchestration platform for AI, machine learning, and data workflows. It uses Python authoring with strongly typed tasks and workflows, while executing at scale on cloud or Kubernetes-backed infrastructure.
+
+## What problem it solves
+Flyte helps teams move ML and AI workflows from notebooks and scripts into reproducible, versioned, and scalable pipelines. It is designed for workloads where compute, data movement, caching, lineage, and reproducibility matter as much as the execution graph.
+
+## Where it fits in the stack
+**Orchestration / AI and ML workflow platform**.
+
+## Typical use cases
+- Model training and evaluation pipelines.
+- Batch inference, data processing, and feature generation.
+- Agentic or long-running AI workflows that need durable execution and infrastructure awareness.
+- Reproducible experimentation that later runs at production scale.
+
+## Strengths
+- Python-first authoring with typed interfaces.
+- Designed for ML and AI workloads rather than only generic scheduling.
+- Strong reproducibility, caching, and versioning model.
+- Can bridge local development and scalable production execution.
+
+## Limitations
+- Platform setup can be heavier than lightweight local orchestrators.
+- Best value appears when teams already need production ML infrastructure.
+- Less useful for simple office automation or SaaS app chaining.
+- Requires learning Flyte concepts and operational model.
+
+## When to use it
+- You need production-grade AI or ML pipelines with strong reproducibility.
+- Workloads need scalable infrastructure and clear artifact lineage.
+- Python developers need a path from local workflow development to production.
+
+## When not to use it
+- You only need scheduled scripts or small automations.
+- Your organization is not ready to operate an ML workflow platform.
+- A visual SaaS automation builder would serve the users better.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free open-source edition; paid enterprise platform available through Union.ai.
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [Dagster](dagster.md)
+- [Argo Workflows](argo-workflows.md)
+- [ZenML](zenml.md)
+- [Kubernetes (K3s)](../infrastructure/k3s.md)
+
+## Sources / References
+- [Official website](https://flyte.org/)
+- [Official documentation](https://docs.flyte.org/)
+- [GitHub](https://github.com/flyteorg/flyte)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/index.md
+++ b/docs/tools/orchestration/index.md
@@ -12,8 +12,16 @@ Orchestration tools manage the execution flow of AI workloads, from simple linea
 
 | Tool | Focus | UI | Self-hostable | Best for... |
 | :--- | :--- | :---: | :---: | :--- |
+| [Apache Airflow](apache-airflow.md) | Batch DAG Scheduling | 🟢 | 🟢 | Mature scheduled data and operations workflows. |
+| [Apache Hamilton](apache-hamilton.md) | Python Dataflows | 🟢 | 🟢 | Function-derived transformation DAGs inside Python systems. |
+| [Argo Workflows](argo-workflows.md) | Kubernetes Workflows | 🟢 | 🟢 | Highly parallel container jobs on Kubernetes. |
+| [Dagster](dagster.md) | Data Asset Orchestration | 🟢 | 🟢 | Data and AI pipelines with lineage and freshness context. |
+| [Flyte](flyte.md) | AI/ML Workflows | 🟢 | 🟢 | Reproducible ML and AI workflows at scale. |
+| [Kestra](kestra.md) | Declarative Automation | 🟢 | 🟢 | Event-driven workflows across data, infra, and approvals. |
 | [n8n](../../services/n8n.md) | Visual Automation | 🟢 | 🟢 | Home/Office automation with local AI nodes. |
+| [Prefect](prefect.md) | Python Workflow Engine | 🟢 | 🟢 | Python scripts moving into observable production workflows. |
 | [Temporal](temporal.md) | Durable Workflows | 🟢 | 🟢 | Mission-critical, stateful execution at scale. |
+| [ZenML](zenml.md) | MLOps Pipelines | 🟢 | 🟢 | Portable ML and agent pipelines across infrastructure stacks. |
 | [Zapier](../automation_orchestration/zapier.md) | SaaS Integration | 🟢 | 🔴 | Rapidly connecting cloud apps via AI actions. |
 | [Goose](../automation_orchestration/goose.md) | Local Agentic | 🟢 | 🟢 | Terminal-friendly local agent orchestration. |
 | [Vellum](../automation_orchestration/vellum.md) | Prompt/Workflow Ops | 🟢 | 🔴 | Collaborative prompt engineering and hosting. |
@@ -25,3 +33,16 @@ Orchestration tools manage the execution flow of AI workloads, from simple linea
 - [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md)
 - [Model Context Protocol (MCP)](../automation_orchestration/mcp.md)
 - [LiteLLM](../../services/litellm.md)
+
+## Sources / References
+
+- [Apache Airflow documentation](https://airflow.apache.org/docs/)
+- [Argo Workflows documentation](https://argoproj.github.io/workflows/)
+- [Dagster documentation](https://docs.dagster.io/)
+- [Flyte documentation](https://docs.flyte.org/)
+- [Prefect documentation](https://docs.prefect.io/)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/kestra.md
+++ b/docs/tools/orchestration/kestra.md
@@ -1,0 +1,58 @@
+# Kestra
+
+## What it is
+Kestra is an open-source orchestration platform for declarative, scheduled, event-driven, and business-critical workflows. It uses YAML-defined flows, a web UI, plugins, and Git/Terraform-friendly operations.
+
+## What problem it solves
+Kestra gives engineering and operations teams a shared platform for running workflows that span data pipelines, infrastructure automation, approvals, scripts, APIs, and event triggers. In AI stacks, it can coordinate data refreshes, evaluation jobs, integration tasks, and human approval steps around model or agent workflows.
+
+## Where it fits in the stack
+**Orchestration / Declarative automation platform**.
+
+## Typical use cases
+- Scheduled and event-driven data pipelines.
+- Infrastructure and platform automation.
+- Human-in-the-loop approval workflows.
+- Coordinating Python, dbt, API, and cloud-service tasks.
+
+## Strengths
+- Declarative workflow definitions are easy to version and review.
+- UI support makes runs, logs, and operational status visible.
+- Broad plugin approach can cover data, infrastructure, and business workflows.
+- Open-source core with enterprise options.
+
+## Limitations
+- YAML authoring can be less expressive than Python for complex branching logic.
+- Teams need to evaluate plugin maturity for their exact systems.
+- Not a specialized AI agent framework.
+- Operational model may be more platform-like than necessary for small scripts.
+
+## When to use it
+- You want a declarative orchestration layer for scheduled and event-driven operations.
+- Workflows span data, infrastructure, and approval steps.
+- GitOps and UI observability both matter.
+
+## When not to use it
+- You need a Python library embedded directly in application code.
+- You primarily need durable long-running application workflows.
+- Non-technical users need a consumer SaaS automation builder.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0 for the community edition)
+- **Cost**: Free community edition; paid enterprise features available.
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [Apache Airflow](apache-airflow.md)
+- [Prefect](prefect.md)
+- [n8n](../../services/n8n.md)
+- [Zapier](../automation_orchestration/zapier.md)
+
+## Sources / References
+- [Official website](https://kestra.io/)
+- [Official documentation](https://kestra.io/docs/)
+- [GitHub](https://github.com/kestra-io/kestra)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/prefect.md
+++ b/docs/tools/orchestration/prefect.md
@@ -1,0 +1,58 @@
+# Prefect
+
+## What it is
+Prefect is an open-source Python workflow orchestration engine for turning Python functions into observable, scheduled, and recoverable workflows. It supports local development, self-hosted operations, and Prefect Cloud.
+
+## What problem it solves
+Prefect helps teams move from ad hoc scripts to production workflows without abandoning normal Python control flow. For AI and data work, it is useful for orchestrating retrieval refreshes, batch jobs, evaluations, API calls, and operational tasks that need retries, state tracking, caching, and run visibility.
+
+## Where it fits in the stack
+**Orchestration / Python workflow engine**.
+
+## Typical use cases
+- Python data pipelines with schedules, retries, and observability.
+- LLM evaluation, scraping, embedding, and batch inference jobs.
+- Event-driven automations that still benefit from Python logic.
+- Lightweight platform engineering around shared workflow deployments.
+
+## Strengths
+- Python-native authoring with low ceremony.
+- Handles state, retries, caching, scheduling, and observability.
+- Easier entry point than heavier data-platform orchestrators for many Python teams.
+- Supports self-hosted use and managed Prefect Cloud.
+
+## Limitations
+- Less mature as a legacy enterprise default than Apache Airflow.
+- Highly regulated environments may need to validate Prefect Cloud controls before use.
+- Not a visual no-code automation platform.
+- Complex distributed deployments still require infrastructure decisions.
+
+## When to use it
+- You have Python scripts that need production workflow behavior.
+- You want orchestration without forcing every workflow into a static DAG style.
+- Developers need fast local iteration plus run tracking.
+
+## When not to use it
+- The team already has a standardized Airflow platform and no need to change.
+- Workflows are primarily Kubernetes-native container jobs.
+- Non-developers need to build most automations visually.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free open-source engine; paid Prefect Cloud plans available.
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [Apache Airflow](apache-airflow.md)
+- [Dagster](dagster.md)
+- [Kestra](kestra.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
+
+## Sources / References
+- [Official website](https://www.prefect.io/)
+- [Official documentation](https://docs.prefect.io/)
+- [GitHub](https://github.com/PrefectHQ/prefect)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/docs/tools/orchestration/zenml.md
+++ b/docs/tools/orchestration/zenml.md
@@ -1,0 +1,58 @@
+# ZenML
+
+## What it is
+ZenML is an open-source MLOps framework for building portable machine learning, AI, and agent pipelines across local and production infrastructure. It uses stack components, including orchestrators, artifact stores, experiment trackers, model deployers, and cloud integrations.
+
+## What problem it solves
+ZenML helps teams standardize the path from experimentation to production for ML and AI workflows. It separates pipeline code from the underlying infrastructure, making it easier to run the same pipeline locally, on Kubernetes, or through managed cloud services.
+
+## Where it fits in the stack
+**Orchestration / MLOps pipeline framework**.
+
+## Typical use cases
+- End-to-end ML pipelines from preprocessing through training and deployment.
+- LLMOps workflows for evaluation, retrieval, and model lifecycle management.
+- Multi-environment pipelines that should move from local development to cloud execution.
+- Agent or AI workflows that need metadata, artifacts, and stack portability.
+
+## Strengths
+- Explicit MLOps stack abstraction keeps infrastructure choices swappable.
+- Supports multiple orchestrator backends, including local, Kubernetes, Airflow, Kubeflow, Vertex AI, SageMaker, AzureML, and Tekton.
+- Good fit for teams standardizing ML lifecycle practices.
+- Includes concepts for artifacts, metadata, deployments, and production pipeline execution.
+
+## Limitations
+- More ML-platform oriented than general office or SaaS automation.
+- Requires understanding ZenML stack components and integrations.
+- Actual orchestration behavior depends on the chosen backend.
+- May be more structure than needed for simple Python scripts.
+
+## When to use it
+- You need a portable MLOps framework across local, cloud, and Kubernetes environments.
+- AI or ML pipelines require metadata, artifact, and deployment discipline.
+- The team wants to avoid hard-coding one orchestrator into pipeline logic.
+
+## When not to use it
+- You only need a single workflow scheduler.
+- Workflows are not ML or AI lifecycle focused.
+- A direct Airflow, Prefect, or Dagster setup would be simpler for the team.
+
+## Licensing and cost
+- **Open Source**: Yes (Apache License 2.0)
+- **Cost**: Free open-source framework; paid ZenML Pro/managed options available.
+- **Self-hostable**: Yes
+
+## Related tools / concepts
+- [Flyte](flyte.md)
+- [Dagster](dagster.md)
+- [Apache Airflow](apache-airflow.md)
+- [Model Routing Guide](../../knowledge_base/model_routing_guide.md)
+
+## Sources / References
+- [Official website](https://www.zenml.io/)
+- [Official documentation](https://docs.zenml.io/)
+- [GitHub](https://github.com/zenml-io/zenml)
+
+## Contribution Metadata
+- Last reviewed: 2026-05-06
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - Overview: new-sources.md
       - Daily Logs:
           - '2026-05-07': new-sources/2026-05-07.md
+          - '2026-05-06': new-sources/2026-05-06.md
           - '2026-05-02': new-sources/2026-05-02.md
           - '2026-04-27': new-sources/2026-04-27.md
           - '2026-04-26': new-sources/2026-04-26.md
@@ -473,7 +474,15 @@ nav:
           - Home Admin Agent Tools: tools/agents/home-admin-tools.md
       - Orchestration:
           - Overview: tools/orchestration/index.md
+          - Apache Airflow: tools/orchestration/apache-airflow.md
+          - Apache Hamilton: tools/orchestration/apache-hamilton.md
+          - Argo Workflows: tools/orchestration/argo-workflows.md
+          - Dagster: tools/orchestration/dagster.md
+          - Flyte: tools/orchestration/flyte.md
+          - Kestra: tools/orchestration/kestra.md
+          - Prefect: tools/orchestration/prefect.md
           - Temporal: tools/orchestration/temporal.md
+          - ZenML: tools/orchestration/zenml.md
       - Infrastructure:
           - Docker: tools/infrastructure/docker.md
           - Headscale: services/headscale.md


### PR DESCRIPTION
## Summary
- Adds eight substantive orchestration tool pages for Apache Airflow, Apache Hamilton, Argo Workflows, Dagster, Flyte, Kestra, Prefect, and ZenML.
- Updates the orchestration index, tool catalog, MkDocs nav, and 2026-05-06 intake log.

## Validation
- `python3 scripts/check_catalog_consistency.py`
- `python3 scripts/check_docs_contract.py docs/tools/orchestration/apache-airflow.md docs/tools/orchestration/apache-hamilton.md docs/tools/orchestration/argo-workflows.md docs/tools/orchestration/dagster.md docs/tools/orchestration/flyte.md docs/tools/orchestration/kestra.md docs/tools/orchestration/prefect.md docs/tools/orchestration/zenml.md docs/tools/orchestration/index.md docs/new-sources.md docs/new-sources/2026-05-06.md`
- `python3 scripts/validate_new_sources.py`
- `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'`
- `python3 -m json.tool data/all_tools.json >/dev/null`

Closes #468