### PR TITLE
Add agent framework learning map

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -37,6 +37,12 @@
       "doc_path": "docs/knowledge_base/patterns/agentic-workflows.md"
     },
     {
+      "id": "agent-framework-learning-map",
+      "name": "Agent Framework Learning Map",
+      "category": "Knowledge Base",
+      "doc_path": "docs/knowledge_base/agent_framework_learning_map.md"
+    },
+    {
       "id": "agentops",
       "name": "AgentOps",
       "category": "Process & Understanding",

--- a/docs/knowledge_base/agent_framework_learning_map.md
+++ b/docs/knowledge_base/agent_framework_learning_map.md
@@ -1,0 +1,111 @@
+# Agent Framework Learning Map
+
+This page turns a mixed list of agent frameworks, agent products, and specialised agents into a practical learning and adoption map. It is meant to avoid treating every agent project as interchangeable: some are best studied for architecture, some are practical production components, and some are niche tools to compose into a larger stack.
+
+## Quick classification
+
+| Tool | Type | Learn from it | Use in production | Best reason to study or adopt |
+| :--- | :--- | :---: | :---: | :--- |
+| [LangGraph](../tools/frameworks/langgraph.md) | Stateful agent orchestration runtime | Excellent | Excellent | Reliable graph control flow, state, loops, and checkpoints for serious agent engineering. |
+| [OpenAI Agents SDK](../tools/frameworks/openai-agents-sdk.md) | Lightweight agent SDK | Excellent | Strong | Minimal agent abstractions around tools, handoffs, sessions, and tracing. |
+| [CrewAI](../tools/frameworks/crewai.md) | Role-based multi-agent framework | Good | Moderate | Fast prototyping and clear mental model for role-playing collaborative agents. |
+| [AutoGen](../tools/frameworks/autogen.md) | Conversation-driven multi-agent framework | Excellent | Mixed | Influential reference point for agent-to-agent collaboration and research experiments. |
+| [OpenHands](../tools/development_ops/openhands.md) | Coding agent platform | Excellent | Emerging | Full software-engineering agent loop with terminal, editor, browser, and verification. |
+| [OpenClaw](../tools/development_ops/openclaw.md) | Personal agent operating system / orchestrator | Fascinating | Experimental | Persistent personal agents with tools, skills, memory, sessions, and human override. |
+| [Browser Use](../tools/automation_orchestration/browser-use.md) | Browser automation layer for agents | Very useful | Strong | Lets agents operate real websites when APIs are unavailable or incomplete. |
+| [GPT Researcher](../tools/agents/gpt-researcher.md) | Deep research agent | Strong niche | Strong niche | Good reference implementation for planning, browsing, synthesis, and report writing. |
+| [Letta](../tools/agents/letta.md) | Memory-first agent framework | Important ideas | Emerging | Persistent memory architecture for long-lived agents and personal assistants. |
+| [DeerFlow](../tools/agents/deerflow.md) | Multi-agent research and coding harness | Excellent | Emerging | Modern sub-agent, tool-routing, sandbox, and long-horizon workflow patterns. |
+
+## Frameworks
+
+Use this bucket when the goal is to build custom agent workflows in code.
+
+- [LangGraph](../tools/frameworks/langgraph.md) is the best default to study first when reliability matters. Its graph model makes state, loops, and checkpoints explicit enough for production agent engineering.
+- [OpenAI Agents SDK](../tools/frameworks/openai-agents-sdk.md) is the cleanest small surface for teams that want tools, handoffs, sessions, and tracing without adopting a heavy framework.
+- [CrewAI](../tools/frameworks/crewai.md) is useful for learning role-based collaboration quickly, especially for business-process prototypes.
+- [AutoGen](../tools/frameworks/autogen.md) remains important for research and design literacy around conversational multi-agent systems, but production use needs discipline around complexity and observability.
+
+## Agent Products And Operating Environments
+
+Use this bucket when the goal is to run a full agent environment, not just import a library.
+
+- [OpenHands](../tools/development_ops/openhands.md) is the strongest reference for autonomous software engineering loops because it combines planning, editing, command execution, browser use, and verification.
+- [OpenClaw](../tools/development_ops/openclaw.md) is the most relevant experimental operating system for personal agents, especially where messaging channels, skills, memory, and scheduled tasks matter.
+- [DeerFlow](../tools/agents/deerflow.md) is a useful modern harness to study for coordinated research/coding flows with sub-agents and tool routing.
+
+## Specialised Agents And Components
+
+Use this bucket when the tool solves one important slice of a larger workflow.
+
+- [Browser Use](../tools/automation_orchestration/browser-use.md) should be treated as a browser capability layer. Prefer APIs first, then use browser automation for websites that do not expose reliable machine interfaces.
+- [GPT Researcher](../tools/agents/gpt-researcher.md) is strongest as a research and report-generation reference implementation.
+- [Letta](../tools/agents/letta.md) is worth studying when the hard problem is persistent memory, not simply tool calling.
+
+## Recommended Learning Order
+
+### Fundamentals
+
+1. [LangGraph](../tools/frameworks/langgraph.md)
+2. [OpenAI Agents SDK](../tools/frameworks/openai-agents-sdk.md)
+3. [CrewAI](../tools/frameworks/crewai.md)
+4. [AutoGen](../tools/frameworks/autogen.md)
+
+### Coding Agents
+
+1. [OpenHands](../tools/development_ops/openhands.md)
+2. [OpenClaw](../tools/development_ops/openclaw.md)
+
+### Specialised Patterns
+
+1. [Browser Use](../tools/automation_orchestration/browser-use.md)
+2. [GPT Researcher](../tools/agents/gpt-researcher.md)
+3. [Letta](../tools/agents/letta.md)
+4. [DeerFlow](../tools/agents/deerflow.md)
+
+## Narrow Stack For OpenClaw-Style Local Orchestration
+
+For a low-cost, local-model-friendly agent stack with GitHub Actions and personal workflow automation, prioritise:
+
+| Layer | Recommended tool | Why |
+| :--- | :--- | :--- |
+| Personal agent runtime | [OpenClaw](../tools/development_ops/openclaw.md) | Channel adapters, skills, memory, sessions, and scheduled workflows. |
+| Durable agent control flow | [LangGraph](../tools/frameworks/langgraph.md) | Explicit state and graph execution when workflows outgrow prompt chains. |
+| Browser capability | [Browser Use](../tools/automation_orchestration/browser-use.md) | Structured browser control for web tasks without stable APIs. |
+| Research workflow | [GPT Researcher](../tools/agents/gpt-researcher.md) | Planning, browsing, and synthesis pattern to reuse or adapt. |
+| Tool protocol | [Model Context Protocol](agent_protocols.md) | Common connector layer for tools and data access. |
+| Automation shell | [n8n](../services/n8n.md) | Human-visible workflow gates, approvals, retries, and integrations. |
+| Model routing | [LiteLLM](../services/litellm.md) | OpenAI-compatible routing across local and hosted models. |
+
+## Practical Adoption Notes
+
+- Do not choose by popularity alone. Choose by workflow shape: coding, research, browser operation, personal assistant, or production application runtime.
+- Treat "good to study" and "good to run" as different decisions. AutoGen and OpenClaw are valuable to study even when LangGraph or OpenAI Agents SDK is the safer production default.
+- Keep specialised tools composable. Browser Use, GPT Researcher, and Letta are often better as components in a broader system than as the whole architecture.
+- Use [Model Context Protocol](agent_protocols.md) and [LiteLLM](../services/litellm.md) as stabilising layers when combining local models, cloud models, and tool access.
+
+## Related tools / concepts
+
+- [AI Tooling Landscape](ai_tooling_landscape.md)
+- [AI Builder Index](ai_builder_index.md)
+- [Agent Protocols](agent_protocols.md)
+- [Agentic Workflows](patterns/agentic-workflows.md)
+- [OpenClaw Workflow Prompts](patterns/openclaw-workflow-prompts.md)
+
+## Sources / References
+
+- [LangGraph documentation](https://langchain-ai.github.io/langgraph/)
+- [OpenAI Agents SDK documentation](https://openai.github.io/openai-agents-python/)
+- [CrewAI documentation](https://docs.crewai.com/)
+- [AutoGen documentation](https://microsoft.github.io/autogen/)
+- [OpenHands documentation](https://docs.openhands.dev/)
+- [OpenClaw documentation](https://docs.openclaw.ai/)
+- [Browser Use documentation](https://docs.browser-use.ai/)
+- [GPT Researcher GitHub](https://github.com/assafelovic/gpt-researcher)
+- [Letta documentation](https://docs.letta.com/)
+- [DeerFlow GitHub](https://github.com/bytedance/deer-flow)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-05-06
+- Confidence: medium

--- a/docs/knowledge_base/ai_builder_index.md
+++ b/docs/knowledge_base/ai_builder_index.md
@@ -11,6 +11,7 @@ It is inspired by the information-distribution pattern used on [awesomeclaude.ai
 | Build a website or app for free | [Free AI Website Playbook](free_ai_website_playbook.md) | [Vercel](../tools/development_ops/vercel.md), [Cloudflare Pages](../tools/development_ops/cloudflare-pages.md), [GitHub Pages](../tools/development_ops/github-pages.md), [Supabase](../tools/infrastructure/supabase.md) | Founders, consultants, internal builders |
 | Set up an AI-driven company stack | [AI Company Starter Stack](ai_company_starter_stack.md) | [n8n](../services/n8n.md), [Google Workspace CLI](../tools/automation_orchestration/google-workspace-cli.md), [mem0](../tools/agents/mem0.md) | Teams building operating leverage |
 | Build AI products | [AI Tooling Landscape](ai_tooling_landscape.md) | [Context7](../tools/development_ops/context7.md), [Claude Cookbooks](../tools/development_ops/claude-cookbooks.md), [OpenRouter](../tools/ai_knowledge/openrouter.md) | Product builders and engineers |
+| Choose an agent framework or agent stack | [Agent Framework Learning Map](agent_framework_learning_map.md) | [LangGraph](../tools/frameworks/langgraph.md), [OpenAI Agents SDK](../tools/frameworks/openai-agents-sdk.md), [OpenClaw](../tools/development_ops/openclaw.md) | Builders deciding what to study vs what to use |
 | Research markets, leads, or targets | [AI Company Starter Stack](ai_company_starter_stack.md) | [DeerFlow](../tools/agents/deerflow.md), [Tavily](../tools/providers/tavily.md), [Browser Use](../tools/automation_orchestration/browser-use.md) | Agencies, sales, strategy work |
 | Build internal knowledge assistants | [AI Company Starter Stack](ai_company_starter_stack.md) | [AnythingLLM](../tools/ai_knowledge/anythingllm.md), [LocalAI](../tools/infrastructure/localai.md), [Ollama](../services/ollama.md) | Internal enablement and knowledge access |
 | Run local or private AI | [AI Company Starter Stack](ai_company_starter_stack.md) | [LocalAI](../tools/infrastructure/localai.md), [llmfit](../tools/development_ops/llmfit.md), [Ollama](../services/ollama.md) | Privacy-sensitive or cost-conscious teams |
@@ -90,6 +91,7 @@ Use this bucket when the main question is, "What can I launch this week without 
 Use this bucket when the main question is, "How do I build the AI product itself without making architecture mistakes?"
 
 - [AI Tooling Landscape](ai_tooling_landscape.md)
+- [Agent Framework Learning Map](agent_framework_learning_map.md)
 - [Context7](../tools/development_ops/context7.md)
 - [Claude Cookbooks](../tools/development_ops/claude-cookbooks.md)
 - [OpenRouter](../tools/ai_knowledge/openrouter.md)
@@ -153,6 +155,7 @@ flowchart TD
 - [Free AI Website Playbook](free_ai_website_playbook.md)
 - [AI Company Starter Stack](ai_company_starter_stack.md)
 - [AI Tooling Landscape](ai_tooling_landscape.md)
+- [Agent Framework Learning Map](agent_framework_learning_map.md)
 - [Home](../index.md)
 
 ## Sources / References

--- a/docs/new-sources.md
+++ b/docs/new-sources.md
@@ -7,7 +7,7 @@ This index tracks daily source-ingestion files. Each day gets a dedicated log fi
 | Date | Log File | New | Integrated | Notes |
 | :--- | :--- | :---: | :---: | :--- |
 | 2026-05-07 | [2026-05-07](/new-sources/2026-05-07/) | 0 | 6 | Integrated 6 agent frameworks for Batch 2. |
-| 2026-05-06 | [2026-05-06](/new-sources/2026-05-06/) | 0 | 8 | Expanded orchestration category for issue #468. |
+| 2026-05-06 | [2026-05-06](/new-sources/2026-05-06/) | 0 | 9 | Expanded orchestration category for #468 and added agent learning map for #407. |
 | 2026-05-02 | [2026-05-02](/new-sources/2026-05-02/) | 0 | 8 | Integrated 8 calendar & task tools for #422. |
 | 2026-04-27 | [2026-04-27](/new-sources/2026-04-27/) | 0 | 5 | Integrated RAG and Agentic Workflows patterns. |
 | 2026-04-26 | [2026-04-26](/new-sources/2026-04-26/) | 10 | 8 | Decomposed tasks from #360, #299, #296. Integrated 8 items. |

--- a/docs/new-sources/2026-05-06.md
+++ b/docs/new-sources/2026-05-06.md
@@ -7,6 +7,7 @@
 | Dagster | https://dagster.io/ | orchestration | integrated | [Dagster](../tools/orchestration/dagster.md) | Asset-aware data and AI pipeline orchestrator. |
 | Flyte | https://flyte.org/ | orchestration | integrated | [Flyte](../tools/orchestration/flyte.md) | AI and ML workflow orchestration platform. |
 | Apache Hamilton | https://hamilton.dagworks.io/ | orchestration | integrated | [Apache Hamilton](../tools/orchestration/apache-hamilton.md) | Python dataflow framework for function-derived DAGs. |
+| Agent framework learning map | https://github.com/joanmarcriera/Home-office-automations/issues/407 | analysis | integrated | [Agent Framework Learning Map](../knowledge_base/agent_framework_learning_map.md) | Synthesised framework, agent product, and specialised-agent adoption guidance. |
 | Kestra | https://kestra.io/ | orchestration | integrated | [Kestra](../tools/orchestration/kestra.md) | Declarative scheduled and event-driven workflow platform. |
 | Prefect | https://www.prefect.io/ | orchestration | integrated | [Prefect](../tools/orchestration/prefect.md) | Python-native workflow orchestration engine. |
 | ZenML | https://www.zenml.io/ | orchestration | integrated | [ZenML](../tools/orchestration/zenml.md) | MLOps pipeline framework with swappable orchestrators. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -574,6 +574,8 @@ nav:
   - Knowledge Base:
       - Overview: knowledge_base/README.md
       - Agent Protocols: knowledge_base/agent_protocols.md
+      - Agent Framework Learning Map:
+          knowledge_base/agent_framework_learning_map.md
       - AI Economic Impact: knowledge_base/ai_economic_impact.md
       - API Pricing & Free Tiers: knowledge_base/api_pricing_free_tiers.md
       - Family Values: knowledge_base/family-values.md


### PR DESCRIPTION
## Summary
- Adds a knowledge-base synthesis page that classifies agent frameworks, agent products, and specialised agents from #407.
- Distinguishes tools that are best to study from tools that are good production defaults.
- Links the new page from the AI Builder Index, MkDocs nav, catalog, and the 2026-05-06 intake log.

## Validation
- `python3 scripts/check_catalog_consistency.py`
- `python3 scripts/check_docs_contract.py docs/knowledge_base/agent_framework_learning_map.md docs/knowledge_base/ai_builder_index.md docs/new-sources/2026-05-06.md docs/new-sources.md`
- `python3 scripts/validate_new_sources.py`
- `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'`
- `python3 -m json.tool data/all_tools.json >/dev/null`

Closes #407