### PR TITLE
Add Claude plugin starter guidance

### DIFF
--- a/docs/new-sources.md
+++ b/docs/new-sources.md
@@ -7,7 +7,7 @@ This index tracks daily source-ingestion files. Each day gets a dedicated log fi
 | Date | Log File | New | Integrated | Notes |
 | :--- | :--- | :---: | :---: | :--- |
 | 2026-05-07 | [2026-05-07](/new-sources/2026-05-07/) | 0 | 6 | Integrated 6 agent frameworks for Batch 2. |
-| 2026-05-06 | [2026-05-06](/new-sources/2026-05-06/) | 0 | 9 | Expanded orchestration category for #468 and added agent learning map for #407. |
+| 2026-05-06 | [2026-05-06](/new-sources/2026-05-06/) | 0 | 10 | Expanded orchestration category for #468, added agent learning map for #407, and integrated Claude plugin starters for #404. |
 | 2026-05-02 | [2026-05-02](/new-sources/2026-05-02/) | 0 | 8 | Integrated 8 calendar & task tools for #422. |
 | 2026-04-27 | [2026-04-27](/new-sources/2026-04-27/) | 0 | 5 | Integrated RAG and Agentic Workflows patterns. |
 | 2026-04-26 | [2026-04-26](/new-sources/2026-04-26/) | 10 | 8 | Decomposed tasks from #360, #299, #296. Integrated 8 items. |

--- a/docs/new-sources/2026-05-06.md
+++ b/docs/new-sources/2026-05-06.md
@@ -8,6 +8,7 @@
 | Flyte | https://flyte.org/ | orchestration | integrated | [Flyte](../tools/orchestration/flyte.md) | AI and ML workflow orchestration platform. |
 | Apache Hamilton | https://hamilton.dagworks.io/ | orchestration | integrated | [Apache Hamilton](../tools/orchestration/apache-hamilton.md) | Python dataflow framework for function-derived DAGs. |
 | Agent framework learning map | https://github.com/joanmarcriera/Home-office-automations/issues/407 | analysis | integrated | [Agent Framework Learning Map](../knowledge_base/agent_framework_learning_map.md) | Synthesised framework, agent product, and specialised-agent adoption guidance. |
+| Claude Code plugin starters | https://github.com/joanmarcriera/Home-office-automations/issues/404 | development-ops, plugins | integrated | [Claude Plugins](../tools/development_ops/claude-plugins.md) | Added starter plugin list and adoption order. |
 | Kestra | https://kestra.io/ | orchestration | integrated | [Kestra](../tools/orchestration/kestra.md) | Declarative scheduled and event-driven workflow platform. |
 | Prefect | https://www.prefect.io/ | orchestration | integrated | [Prefect](../tools/orchestration/prefect.md) | Python-native workflow orchestration engine. |
 | ZenML | https://www.zenml.io/ | orchestration | integrated | [ZenML](../tools/orchestration/zenml.md) | MLOps pipeline framework with swappable orchestrators. |

--- a/docs/tools/development_ops/claude-plugins.md
+++ b/docs/tools/development_ops/claude-plugins.md
@@ -45,6 +45,30 @@ They make common add-ons easier to install and reuse instead of copying prompts,
 - **Problem it solves**: Standardizes how high-level skills (like documentation writing or code refinement) are discovered and executed.
 - **Typical Use Case**: Enterprise-wide standardization of agent behaviors.
 
+## Recommended Claude Code Plugin Starters
+
+Start with plugins that match the workflow already in use. Do not install every community plugin at once; overlapping repo instructions, hooks, and tool permissions can make agent behaviour harder to reason about.
+
+| Plugin | Primary job | Best fit | Adoption note |
+| :--- | :--- | :--- | :--- |
+| `connect-apps` | Connect Claude Code to GitHub, Slack, Notion, Gmail, and other work apps | Cross-app project and operations workflows | Review OAuth scopes and workspace permissions before enabling broad access. |
+| `agentlint` | Check whether a repo is friendly to AI agents | Repos using `AGENTS.md`, `CLAUDE.md`, tool manifests, or structured docs | Run before adding more automation so missing context is fixed at the repo level. |
+| `code-review` | Run structured PR reviews before shipping | Teams that want a second-pass review from an agent | Treat as a reviewer aid, not a replacement for required human review on risky changes. |
+| `test-writer-fixer` | Generate and repair unit tests across Jest, Vitest, Pytest, and similar frameworks | Codebases with weak regression coverage | Pair with the real test command so generated tests prove behaviour rather than only compile. |
+| `debugger` | Investigate complex bugs, logs, traces, and failing flows | Failures where the first stack trace is not enough | Give it exact reproduction commands and current logs. |
+| `bug-fix` | Analyse stack traces and apply targeted fixes | Narrow failures with clear error output | Keep diffs small and require verification after patching. |
+| `mcp-builder` | Scaffold and iterate on Model Context Protocol servers | Teams exposing internal tools or services to agents | Start with one small read-only tool before granting write capabilities. |
+| `theme-factory` | Generate or adapt UI themes | Frontend projects that need consistent visual tokens | Review output against the app design system before accepting generated styles. |
+
+## Suggested adoption order
+
+1. `agentlint` to improve repository readiness.
+2. `code-review` and `test-writer-fixer` for quality gates.
+3. `debugger` and `bug-fix` for repair loops.
+4. `connect-apps` only after permissions and audit expectations are clear.
+5. `mcp-builder` when the team has a real internal tool to expose.
+6. `theme-factory` when a frontend project needs repeatable theme work.
+
 ## Related tools / concepts
 - [Claude Code](claude-code.md)
 - [Claude Hooks](claude-hooks.md)
@@ -57,6 +81,8 @@ They make common add-ons easier to install and reuse instead of copying prompts,
 - [awesomeclaude.ai](https://awesomeclaude.ai/)
 - [AI Templates](https://www.aitmpl.com/)
 - [Superpowers](https://github.com/obra/superpowers)
+- [Awesome Claude Plugins](https://github.com/ComposioHQ/awesome-claude-plugins)
+- [Issue #404 source discussion](https://github.com/joanmarcriera/Home-office-automations/issues/404)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-11


### PR DESCRIPTION
## Summary
- Adds the issue #404 Claude Code plugin starter list to the canonical Claude Plugins page.
- Includes practical adoption notes and a suggested adoption order.
- Logs the integration in the 2026-05-06 intake file and updates the index count.

## Validation
- `python3 scripts/check_docs_contract.py docs/tools/development_ops/claude-plugins.md docs/new-sources/2026-05-06.md docs/new-sources.md`
- `python3 scripts/validate_new_sources.py`
- `python3 scripts/check_catalog_consistency.py`
- `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'`

Closes #404