### PR TITLE
docs: deepen SearXNG and Syncthing (Sprint W3)

### DIFF
--- a/docs/services/searXNG.md
+++ b/docs/services/searXNG.md
@@ -111,11 +111,12 @@ print(results)
 - **Self-hostable**: Yes
 
 ## Related tools / concepts
-- [Perplexity](../tools/ai_knowledge/perplexity.md) (AI-powered search)
-- [DuckDuckGo](https://duckduckgo.com/) (Privacy-focused search)
-- [n8n](../services/n8n.md) (For search automation)
-- [Ollama](../services/ollama.md) (To use SearXNG results with local LLMs)
-- [JSON-LD](https://json-ld.org/) (Metadata standard used in results)
+- [Perplexity](../tools/ai_knowledge/perplexity.md) — AI-powered search engine
+- [n8n](n8n.md) — for automating search workflows
+- [Ollama](ollama.md) — to use search results with local LLMs
+- [Paperless-ngx](paperless-ngx.md) — for archiving and managing documents
+- [IT-Tools](it-tools.md) — comprehensive developer utility suite
+- [Linkwarden](linkwarden.md) — to save and organize search results
 
 ## Sources / References
 - [Official Website](https://searxng.org/)

--- a/docs/services/syncthing.md
+++ b/docs/services/syncthing.md
@@ -1,9 +1,30 @@
 # Syncthing
 
-Syncthing is a continuous file synchronization program.
+## What it is
+Syncthing is a continuous, decentralized file synchronization program. It allows you to synchronize files between two or more computers in real time, safely and securely, without relying on a central server or cloud provider.
 
-## Description
-It synchronizes files between two or more computers in real time, safely and securely.
+## What problem it solves
+Managing files across multiple devices (desktop, laptop, mobile, NAS) usually requires a central cloud service like Dropbox or Google Drive, which can pose privacy risks and incur subscription costs. Syncthing solves this by providing a peer-to-peer synchronization mechanism that keeps data entirely on your own hardware.
+
+## Where it fits in the stack
+**Category**: Services / Data Synchronization. It sits in the **storage and sync** layer of a self-hosted environment, ensuring data consistency across the network.
+
+## Typical use cases
+- Syncing a "Work" folder between a desktop and a laptop.
+- Automatically backing up photos from an Android phone to a home server.
+- Synchronizing a KeepassXC database or Obsidian vault across multiple devices.
+- Distributing configuration files across a fleet of servers.
+
+## Strengths
+- **Private and Secure**: Data never leaves your devices. Transfers are encrypted and authenticated.
+- **Decentralized**: No central server to fail or be compromised.
+- **Efficient**: Uses a block-based synchronization algorithm to only transfer changed parts of files.
+- **Cross-Platform**: Runs on Linux, Windows, macOS, Android, and various BSDs.
+
+## Limitations
+- **Not a Backup Tool**: While it has file versioning, it is primarily for sync. Deleting a file on one device deletes it on all (unless "Send Only" is configured).
+- **Initial Setup**: Connecting devices requires exchanging long Device IDs, which can be cumbersome for non-technical users.
+- **No Native iOS App**: Due to OS limitations, there is no official iOS client (though third-party "Möbius Sync" exists).
 
 ## When to use it
 - When you need to sync files across multiple devices without relying on a central cloud provider.
@@ -76,22 +97,27 @@ curl -X POST -H "X-API-Key: <your_api_key>" \
 - [Official Website](https://syncthing.net/)
 - [Documentation](https://docs.syncthing.net/)
 
+## Licensing and cost
+- **Open Source**: Yes (MPL-2.0)
+- **Cost**: Free
+- **Self-hostable**: Yes
+
 ## Related tools / concepts
-- [Nextcloud](nextcloud.md) (Alternative storage/sync)
-- [Rclone Automation](rclone-automation.md) (For cloud sync)
-- [Tailscale](tailscale.md) (For secure peer-to-peer connection)
-- [Docker](../tools/infrastructure/docker.md) (Common deployment method)
-- [Storj](storj.md) (Decentralized storage alternative)
+- [Nextcloud](nextcloud.md) — for a full suite of cloud services beyond just sync
+- [Rclone Automation](rclone-automation.md) — for syncing data to public cloud providers
+- [Tailscale](tailscale.md) — to connect devices across different networks securely
+- [Docker](../tools/infrastructure/docker.md) — for consistent deployment in a homelab
+- [Storj](storj.md) — for decentralized, encrypted cloud storage
+- [Immich](immich.md) — for self-hosted photo management (often paired with Syncthing)
 
 ## Backlog
 - Configure selective sync for mobile devices.
 
 ## Sources / References
-
+- [Official Website](https://syncthing.net/)
 - [Getting Started Guide](https://docs.syncthing.net/intro/getting-started.html)
 - [REST API Documentation](https://docs.syncthing.net/dev/rest.html)
 
 ## Contribution Metadata
-
 - Last reviewed: 2026-06-12
 - Confidence: high


### PR DESCRIPTION
This PR completes work for Issue #506 (Jules Sprint W3) by deepening the documentation for **SearXNG** and **Syncthing**. 

Key improvements:
- **SearXNG**: Updated the 'Related tools / concepts' section to include 6 unique relative links, ensuring compliance with repository discoverability standards.
- **Syncthing**: Transformed the previous stub into a comprehensive guide by adding 'What it is', 'What problem it solves', 'Where it fits in the stack', 'Typical use cases', 'Strengths', 'Limitations', and 'Licensing and cost' sections.

Additionally, this run verified the status of older open issues (#187, #189, #190), confirming that the requested Data Copilot documentation is already present and integrated.

All changes have been validated against the repository's KnowledgeOps contract and catalog consistency scripts.

---
*PR created automatically by Jules for task [15528106379766013391](https://jules.google.com/task/15528106379766013391) started by @joanmarcriera*