### PR TITLE
docs: jules sprint W2 Immich backup workflow

### DIFF
--- a/docs/services/immich.md
+++ b/docs/services/immich.md
@@ -23,6 +23,7 @@ It provides a private, high-speed way to backup and organize media from mobile d
 ## Limitations
 - **Setup Complexity**: Requires multiple containers (database, redis, machine learning node).
 - **Resource Intensive**: Machine learning tasks (especially initial library indexing) require significant CPU/GPU.
+- **Not a Backup by Itself**: Mobile upload into Immich is only one copy. Keep an independent backup of the library and database.
 
 ## When to use it
 - If you want a self-hosted alternative to Google Photos or iCloud Photos.
@@ -59,18 +60,32 @@ Immich supports various models for:
 - **CLIP**: Enables semantic search (searching by description).
 - **Facial Recognition**: Automatically detects and groups faces.
 
+## Backup and retention workflow
+
+Treat Immich as the media application layer, not the only preservation layer:
+
+1. Back up the upload/library storage and the PostgreSQL database together.
+2. Keep a second copy outside the Immich host, such as NAS snapshots, object storage, or offline disk rotation.
+3. Test restore by bringing up a temporary stack and confirming albums, people, and search indexes rebuild correctly.
+4. For phone uploads, keep the mobile app's delete-after-upload behavior conservative until the independent backup has run.
+5. Document retention rules for screenshots, duplicates, shared albums, and original camera files separately.
+
+For home-office automation, the useful split is: Immich for browsing and AI search, file-level backup for disaster recovery, and [Paperless-ngx](paperless-ngx.md) or [Homebox](homebox.md) for receipts, warranties, and inventory evidence that should not live only in a photo timeline.
+
 ## Related tools / concepts
 - [Photoprism](https://www.photoprism.app/) (Alternative)
 - [Nextcloud Photos](nextcloud.md) (Alternative)
 
 ## Backlog
 - Configure machine learning node for advanced image classification.
+- Add a tested backup/restore runbook for the Immich database and upload library.
 
 ## Sources / References
 - [Official Website](https://immich.app/)
 - [GitHub Repository](https://github.com/immich-app/immich)
+- [Immich Backup and Restore Documentation](https://immich.app/docs/administration/backup-and-restore/)
 - [Photoprism Official Website](https://www.photoprism.app/)
 
 ## Contribution Metadata
-- Last reviewed: 2026-03-08
+- Last reviewed: 2026-05-07
 - Confidence: high


### PR DESCRIPTION
## What changed

- Deepens `docs/services/immich.md` with backup, retention, and restore-test guidance.
- Adds the official Immich backup/restore documentation as a source.
- Clarifies that Immich is the media application layer, not the only preservation layer.

## Why

Supports sprint issue #505 by improving the Services I-P lane with practical self-hosted media operations guidance.

Fixes #505

## Checks

- `python3 scripts/validate_new_sources.py`
- `python3 scripts/check_catalog_consistency.py`
- `python3 scripts/check_docs_contract.py docs/services/immich.md`
- `ruby -ryaml -e 'YAML.load_file("mkdocs.yml"); puts "mkdocs.yml OK"'`