### PR TITLE
Ralph-loop Maintenance: Deepen and Modernize Documentation

### DIFF
--- a/audit_results.txt
+++ b/audit_results.txt
@@ -1,0 +1,308 @@
+============================================================
+  Docs Quality Audit Report
+============================================================
+
+Total docs scanned:  486
+Compliant:           361 (74.3%)
+Legacy-format:       9
+Missing metadata:    0
+
+--- Legacy-format docs (have '## Description') ---
+  docs/services/homebox.md
+  docs/services/it-tools.md
+  docs/services/jackett.md
+  docs/services/navidrome.md
+  docs/services/portracker.md
+  docs/services/rclone-automation.md
+  docs/services/speedtest.md
+  docs/services/storj.md
+  docs/services/tailscale.md
+
+--- Per-category breakdown ---
+  docs/architecture                              0/8  (0%)
+  docs/knowledge_base                            7/35  (20%)
+  docs/knowledge_base/patterns                   8/17  (47%)
+  docs/playbooks                                 1/12  (8%)
+  docs/reference-implementations                 0/1  (0%)
+  docs/reference-implementations/calendar        0/1  (0%)
+  docs/reference-implementations/data-copilot    1/2  (50%)
+  docs/reference-implementations/llm-prompts     0/6  (0%)
+  docs/reference-implementations/manual-assistant  1/1  (100%)
+  docs/reference-implementations/metadata-schemas  0/2  (0%)
+  docs/reference-implementations/paperless       0/2  (0%)
+  docs/services                                  36/52  (69%)
+  docs/tools/agents                              25/25  (100%)
+  docs/tools/ai_knowledge                        60/68  (88%)
+  docs/tools/automation_orchestration            22/28  (79%)
+  docs/tools/benchmarking                        28/31  (90%)
+  docs/tools/calendar_tasks                      20/20  (100%)
+  docs/tools/development_ops                     57/57  (100%)
+  docs/tools/enterprise                          6/11  (55%)
+  docs/tools/frameworks                          18/21  (86%)
+  docs/tools/infrastructure                      17/18  (94%)
+  docs/tools/intake_storage                      8/9  (89%)
+  docs/tools/orchestration                       9/9  (100%)
+  docs/tools/process_understanding               18/30  (60%)
+  docs/tools/providers                           19/20  (95%)
+
+--- Non-compliant doc details ---
+  docs/architecture/automated_contributions.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/architecture/component_map.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/architecture/data-copilot-text-to-sql.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/architecture/flows.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/architecture/infrastructure.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/architecture/multi_agent_knowledgeops.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/architecture/prompt-catalogue.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/architecture/ssh_execution_patterns.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/agent_framework_learning_map.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/knowledge_base/agent_protocols.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/ai_builder_index.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/ai_company_starter_stack.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/ai_economic_impact.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/ai_reading_list.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/ai_signal_sources.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/ai_tool_access_matrix.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/ai_tooling_landscape.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/api_pricing_free_tiers.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/audio-transcription-research.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/energy-anomaly-detection-baseline.md
+    - missing sections: What it is, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/family-values.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/free_ai_website_playbook.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/google_axion.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/google_one_plans_comparison.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/home-admin-agent-architecture.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/invisible_kubernetes.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/landscape-overview.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/model_classes.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/model_comparison_and_evaluation.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/knowledge_base/model_routing_guide.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/patterns/agentic-workflows.md
+    - missing sections: Where it fits in the stack
+  docs/knowledge_base/patterns/data-copilot-agentic-rag.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/knowledge_base/patterns/filesystem-context.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/knowledge_base/patterns/fine-tuning-open-models.md
+    - missing sections: Typical use cases
+  docs/knowledge_base/patterns/n8n-error-handling.md
+    - missing sections: What it is, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/patterns/openclaw-use-case-catalog.md
+    - missing sections: Typical use cases
+  docs/knowledge_base/patterns/prompt_requests.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/patterns/rag-pattern.md
+    - missing sections: Where it fits in the stack
+  docs/knowledge_base/patterns/skills-best-practices.md
+    - missing sections: Typical use cases
+  docs/knowledge_base/real_time_sync_engines.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/self-healing-agent-research.md
+    - missing sections: What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/sso-comparison.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/starred_ai_agent_repos.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/knowledge_base/system_prompts.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/knowledge_base/talos-vs-ubuntu-k3s.md
+    - missing sections: Where it fits in the stack, Typical use cases
+  docs/playbooks/dev-workflow-ai-assisted.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/document-preparation-for-llm-training.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/email-to-calendar.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/family-admin-automation.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/k3s-cluster-setup.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/knowledge-base-health.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/playbooks/nfs-csi-setup.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/raspberry-pi-kiosk-automation.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/scan-to-task.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/school-admin-intake.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/playbooks/tailscale-to-headscale-migration.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/calendar/mapping-rules.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/data-copilot/skeleton-guide.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/hitl-ui-design.md
+    - missing sections: Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/llm-prompts/daily-briefing.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/llm-prompts/date-extraction.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/llm-prompts/extraction-and-classification.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/llm-prompts/family-context.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/llm-prompts/vikunja-task-routing.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/llm-prompts/warranty-extraction.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/metadata-schemas/audio-transcription.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/metadata-schemas/manuals.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/paperless/tag-taxonomy.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/reference-implementations/paperless/webhook-ingestion.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/services/cloudflare-mesh.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, When to use it, When not to use it, Related tools / concepts
+  docs/services/excalidraw.md
+    - missing sections: When to use it, When not to use it
+  docs/services/focalboard.md
+    - missing sections: When to use it, When not to use it
+  docs/services/gitea.md
+    - missing sections: When to use it, When not to use it
+  docs/services/homebox.md
+    - legacy format (## Description)
+  docs/services/inventory.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations, When to use it, When not to use it, Related tools / concepts
+  docs/services/it-tools.md
+    - legacy format (## Description)
+  docs/services/jackett.md
+    - missing sections: When to use it, Related tools / concepts
+    - legacy format (## Description)
+  docs/services/litellm.md
+    - missing sections: Typical use cases
+  docs/services/navidrome.md
+    - missing sections: When to use it, Related tools / concepts
+    - legacy format (## Description)
+  docs/services/portracker.md
+    - legacy format (## Description)
+  docs/services/rclone-automation.md
+    - missing sections: What it is, What problem it solves
+    - legacy format (## Description)
+  docs/services/speedtest.md
+    - missing sections: What it is, What problem it solves
+    - legacy format (## Description)
+  docs/services/storj.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations
+    - legacy format (## Description)
+  docs/services/tailscale.md
+    - missing sections: What it is, What problem it solves, Where it fits in the stack, Typical use cases, Strengths, Limitations
+    - legacy format (## Description)
+  docs/services/vikunja.md
+    - missing sections: Typical use cases, Strengths, Limitations
+  docs/tools/ai_knowledge/deepseek-r1.md
+    - missing sections: When not to use it
+  docs/tools/ai_knowledge/fish-audio.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/ai_knowledge/jules.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/ai_knowledge/kimi-cli.md
+    - missing sections: When not to use it
+  docs/tools/ai_knowledge/kokoclone.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/ai_knowledge/last30days-skill.md
+    - missing sections: Limitations, When to use it, When not to use it
+  docs/tools/ai_knowledge/llamaindex-ts.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/ai_knowledge/nemotron.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/automation_orchestration/airops.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/automation_orchestration/goose.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/automation_orchestration/gumloop.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/automation_orchestration/llmware.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/automation_orchestration/open-interpreter.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/automation_orchestration/stagehand.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/benchmarking/sharp-ai.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/benchmarking/supermetal.md
+    - missing sections: When not to use it
+  docs/tools/benchmarking/vakra.md
+    - missing sections: Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/tools/enterprise/fyxer.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/enterprise/glean.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/enterprise/hebbia.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/enterprise/ramp.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/enterprise/tldv.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/frameworks/firebase-genkit.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/frameworks/google-adk.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/frameworks/instructor.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/infrastructure/ubuntu-ai.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/intake_storage/s3-storage.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/agentops.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/ai-auditing-tools.md
+    - missing sections: When not to use it
+  docs/tools/process_understanding/clickhouse.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/comet-opik.md
+    - missing sections: When not to use it
+  docs/tools/process_understanding/datadog.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/helicone.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/langfuse.md
+    - missing sections: Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/tools/process_understanding/opentelemetry-collector.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/posthog.md
+    - missing sections: Typical use cases, Strengths, Limitations, When to use it, When not to use it
+  docs/tools/process_understanding/snowflake.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/wandb-weave.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/process_understanding/webhook.md
+    - missing sections: When to use it, When not to use it
+  docs/tools/providers/portkey.md
+    - missing sections: When to use it, When not to use it
+
+============================================================
+  Audit complete.
+============================================================

--- a/docs/reports/ralph-loop-execution-2026-07-02.md
+++ b/docs/reports/ralph-loop-execution-2026-07-02.md
@@ -1,0 +1,33 @@
+# Ralph-loop Execution Report — 2026-07-02
+
+## Summary
+Deepened documentation for three "Shallow" pages (`colqwen.md`, `home-admin-tools.md`, `xai-grok.md`) to "High Confidence" standards and modernized two legacy-format service pages (`homebox.md`, `it-tools.md`).
+
+## Targeted Issues
+- **Daily Maintenance**: Doc quality audit and deepening (Automated task when issue queue is low).
+
+## Targeted Files
+- `docs/tools/ai_knowledge/colqwen.md`
+- `docs/tools/agents/home-admin-tools.md`
+- `docs/tools/providers/xai-grok.md`
+- `docs/services/homebox.md`
+- `docs/services/it-tools.md`
+
+## Actions Taken
+- **Content Deepening**:
+    - Filled `<!-- needs-content -->` placeholders in `colqwen.md`, `home-admin-tools.md`, and `xai-grok.md`.
+    - Added mandatory "When to use it" and "When not to use it" sections with grounded technical details.
+    - Expanded "Related tools / concepts" sections to ensure >= 7 relative markdown links per page.
+- **Legacy Modernization**:
+    - Removed legacy `## Description` headers from `homebox.md` and `it-tools.md`.
+    - Consolidated duplicate `## What it is` headers.
+    - Verified all 10 mandatory sections are present and correctly formatted.
+- **Verification**: Confirmed all modified files pass the knowledge contract and catalog consistency checks.
+
+## Verification Results
+- `scripts/check_docs_contract.py`: PASSED
+- `scripts/check_catalog_consistency.py`: PASSED
+- `scripts/validate_new_sources.py`: PASSED
+
+## Next Steps
+- Continue with remaining legacy-format docs identified in audit: `jackett.md`, `navidrome.md`, `portracker.md`, `rclone-automation.md`, `speedtest.md`, `storj.md`, `tailscale.md`.

--- a/docs/services/homebox.md
+++ b/docs/services/homebox.md
@@ -1,8 +1,6 @@
 # Homebox
 
 ## What it is
-
-## What it is
 A lightweight, self-hosted inventory management system written in Go. It uses a single SQLite database for all data, making it easy to host and backup.
 
 ## What problem it solves
@@ -24,9 +22,6 @@ It is a **Standalone Service** in the home automation stack, typically deployed 
 ## Limitations
 - **Simplicity**: Lacks advanced supply chain or POS features found in enterprise ERPs.
 - **Permissions**: Limited multi-user role-based access control.
-
-## Description
-It helps you keep track of your belongings, their locations, warranties, and purchase details. Written in Go, it is extremely lightweight (typically using less than 50MB of RAM) and uses SQLite for portable data management.
 
 ## When to use it
 - When you need a simple, fast inventory system to track household items.

--- a/docs/services/it-tools.md
+++ b/docs/services/it-tools.md
@@ -1,8 +1,6 @@
 # IT-Tools
 
 ## What it is
-
-## What it is
 A comprehensive suite of web-based developer utilities including formatters, generators, and converters. It is designed to run entirely in the client's browser.
 
 ## What problem it solves
@@ -24,9 +22,6 @@ It is a **Client-Side Utility Service**, typically self-hosted via Docker for pr
 ## Limitations
 - **Browser-Bound**: Not suitable for CLI-based automation or bulk processing of massive files.
 - **Client Performance**: Very large files may lag the browser interface.
-
-## Description
-It provides a wide variety of web-based tools, including formatters (JSON, SQL, XML), generators (UUID, Password, QR Code), and converters. It is designed to be fast and runs entirely in the browser.
 
 ## When to use it
 - When you need quick access to common developer utilities (formatters, generators, converters) without leaving the browser.

--- a/docs/tools/agents/home-admin-tools.md
+++ b/docs/tools/agents/home-admin-tools.md
@@ -3,28 +3,36 @@
 This page documents the specialized tools available to the Home Admin Agent (Ralph) for interacting with home services.
 
 ## What it is
-Home Admin Agent Tools are the local service adapters exposed to the Ralph home-admin agent. <!-- needs-content -->
+Home Admin Agent Tools are the local service adapters exposed to the Ralph home-admin agent. They wrap the complex REST APIs of household services into simplified, agent-discoverable tools following the [MCP](../../tools/automation_orchestration/mcp.md) or standard tool-calling patterns.
 
 ## What problem it solves
-They give the agent controlled interfaces for querying and changing household task and smart-home systems. <!-- needs-content -->
+They give the agent controlled, high-level interfaces for querying and changing household task and smart-home systems. This prevents the agent from needing direct database access or unrestricted shell execution, providing a layer of security and predictability to autonomous home operations.
 
 ## Where it fits in the stack
-**Agents / Home administration tool layer**. <!-- needs-content -->
+**Agents / Home administration tool layer**. It sits between the reasoning agent (Ralph) and the household's core services, acting as a translator for intent-to-action.
 
 ## Typical use cases
-Use these tools for task creation, task updates, home-state checks, and scene control. <!-- needs-content -->
+- **Automated Morning Briefing**: Querying Vikunja for today's tasks and Home Assistant for the current weather/house state.
+- **Scene Management**: Triggering "Good Night" or "Away" scenes based on family schedule or manual intent.
+- **Task Delegation**: Automatically creating maintenance tasks in Vikunja when Home Assistant detects a sensor alert (e.g., "Fridge door left open").
 
 ## Strengths
-The tools keep home-admin actions behind explicit API wrappers instead of unrestricted shell or browser access. <!-- needs-content -->
+- **Security**: Actions are limited by the tool's defined schema and API scopes.
+- **Discoverability**: Standard argument definitions allow LLMs to reliably use the tools without retraining.
+- **Portability**: The tools follow patterns that can be easily ported to other agent frameworks (e.g., LangGraph or MCP).
 
 ## Limitations
-The page still needs fuller operational notes on permissions, failure handling, and audit logging. <!-- needs-content -->
+- **Permission Scoping**: The tools operate with the permissions of the configured API tokens. If a token has broad access, the agent inherits that access.
+- **Lack of Transactional Rollback**: Home state changes (e.g., turning on a light) or task creations in Vikunja cannot always be automatically rolled back if a multi-step workflow fails.
+- **Dependency on Local Network**: These tools require stable connectivity to the local instances of Home Assistant and Vikunja.
 
 ## When to use it
-Use these tools when Ralph needs to interact with Vikunja or Home Assistant through defined service APIs. <!-- needs-content -->
+- When an autonomous agent needs to read from or write to the household's task and automation systems.
+- When you want to provide a "Natural Language" interface for complex home operations.
 
 ## When not to use it
-Do not use these tools for services that lack configured credentials, clear ownership, or rollback expectations. <!-- needs-content -->
+- For services that lack configured credentials or clear ownership.
+- When an action is extremely sensitive and requires a human-in-the-loop (HITL) approval that is not yet implemented.
 
 ## Vikunja Tools
 
@@ -96,11 +104,12 @@ These tools require the following environment variables to be set:
 | `HOME_ASSISTANT_TOKEN` | Long-lived access token for HA | (Required) |
 
 ## Related tools / concepts
-
+- [Home Assistant](../../services/home-assistant.md)
+- [Vikunja](../../services/vikunja.md)
+- [n8n](../../services/n8n.md)
+- [LangGraph](../frameworks/langgraph.md)
+- [MCP](../automation_orchestration/mcp.md)
 - [Agency Swarm](agency-swarm.md)
-- [Agency-Agents](agency-agents.md)
-- [Agentic Automation Canvas (AAC)](agentic-automation-canvas.md)
-- [Agno](agno.md)
 - [Anthropic Agent Skills](anthropic-agent-skills.md)
 
 ## Sources / References

--- a/docs/tools/ai_knowledge/colqwen.md
+++ b/docs/tools/ai_knowledge/colqwen.md
@@ -40,18 +40,26 @@ results = RAG.search("How do I reset the filter on the X100 model?")
 - **Specialized Pipeline**: Requires specific libraries or implementations to handle the multi-vector late interaction logic.
 
 ## When to use it
-<!-- needs-content -->
+- When building **Vision-RAG** pipelines that must handle complex document layouts (e.g., multi-column PDFs, forms).
+- When information is primarily contained in **charts, tables, or diagrams** that standard OCR often misrepresents.
+- For high-precision retrieval where the semantic relationship between visual elements and text is critical.
 
 ## When not to use it
-<!-- needs-content -->
+- For **text-only document** archives where standard embedding models (like OpenAI or HuggingFace text-only models) are more storage-efficient.
+- In environments with **high storage constraints**, as multi-vector late interaction embeddings can take 10x-100x more space than single-vector embeddings.
+- When query latency is the absolute priority over retrieval recall in very large-scale datasets.
 
 ## Licensing and cost
 - **Open Weights**: Available on Hugging Face (under Qwen model license).
 
 ## Related tools / concepts
-- [Qwen](../ai_knowledge/qwen.md)
-- [RAG Pattern](../../knowledge_base/rag.md)
+- [Qwen](qwen.md)
+- [RAG Pattern](../../knowledge_base/patterns/rag.md)
 - [Vision Models Research](../../knowledge_base/vision-models-research.md)
+- [LlamaIndex](llamaindex.md)
+- [LangChain](langchain.md)
+- [Ollama](../../services/ollama.md)
+- [Paperless-ngx](../../services/paperless-ngx.md)
 
 ## Sources / References
 - [ColQwen3.5-v2 4.5B Release](https://www.reddit.com/r/MachineLearning/comments/1rsxlg8/p_colqwen35v2_45b_is_out/)

--- a/docs/tools/providers/xai-grok.md
+++ b/docs/tools/providers/xai-grok.md
@@ -56,14 +56,23 @@ print(completion.choices[0].message.content)
 - **Cost**: API pricing is tiered and can be higher for the most capable models.
 
 ## When to use it
-<!-- needs-content -->
+- When you need to synthesize real-time trends, public sentiment, or breaking news from the **X (Twitter)** platform.
+- When you prefer a reasoning model with a more **unfiltered, witty, and conversational** tone compared to standard "assistant" personalities.
+- For tasks requiring a **large context window** that is natively supported by the Grok-2 family.
 
 ## When not to use it
-<!-- needs-content -->
+- In **strictly formal or corporate environments** where the model's distinctive "wit" or "rebellious" personality might be inappropriate.
+- When absolute **social media neutrality** is required, as the model's knowledge base is heavily influenced by X platform discourse.
+- If you have strict data residency or privacy requirements that preclude the use of xAI's infrastructure.
 
 ## Related tools / concepts
-- [OpenAI](../ai_knowledge/openai.md) (Compatible API)
-- [Perplexity](../ai_knowledge/perplexity.md) (Alternative for real-time search)
+- [OpenAI](../ai_knowledge/openai.md)
+- [Perplexity](../ai_knowledge/perplexity.md)
+- [Anthropic](anthropic.md)
+- [Gemini](../ai_knowledge/google-gemini.md)
+- [DeepSeek](deepseek.md)
+- [Mistral](mistral.md)
+- [Cohere](cohere.md)
 
 ## Sources / References
 - [xAI Official Site](https://x.ai/)


### PR DESCRIPTION
This PR performs autonomous maintenance as part of the Ralph-loop. It identifies "Shallow" and "Legacy-format" documentation pages through a quality audit and brings them up to the repository's "High Confidence" standards. This includes adding mandatory sections (When to use, When not to use), expanding relative markdown links, and removing non-standard headers. All changes have been verified using the standard validation script suite.

---
*PR created automatically by Jules for task [6082490898376166592](https://jules.google.com/task/6082490898376166592) started by @joanmarcriera*