### PR TITLE
Deepen KokoClone documentation to High Confidence

### DIFF
--- a/docs/reports/task-decomposition-batch-41.md
+++ b/docs/reports/task-decomposition-batch-41.md
@@ -84,7 +84,7 @@ This report implements **Action C** for the remaining "Shallow" and "Non-complia
 - [x] `docs/tools/ai_knowledge/kimi-cli.md`
 
 ## Sub-Batch 41.10: AI Knowledge Deepening
-- [ ] `docs/tools/ai_knowledge/kokoclone.md`
+- [x] `docs/tools/ai_knowledge/kokoclone.md`
 - [ ] `docs/tools/ai_knowledge/last30days-skill.md`
 - [ ] `docs/tools/ai_knowledge/llamaindex-ts.md`
 - [ ] `docs/tools/ai_knowledge/nemotron.md`

--- a/docs/tools/ai_knowledge/kokoclone.md
+++ b/docs/tools/ai_knowledge/kokoclone.md
@@ -24,6 +24,15 @@ It eliminates the need for expensive, cloud-based voice cloning subscriptions by
 - **Hardware Performance**: While it runs on CPU, the best experience (lowest latency) still requires an NVIDIA GPU with CUDA support.
 - **Sample Quality**: The quality of the clone is highly dependent on the clarity and lack of background noise in the reference audio sample.
 
+## When to use it
+- **Local-First Workflows**: Ideal for users who prioritize privacy and want to run voice cloning entirely on their own hardware without cloud dependencies.
+- **Real-Time Applications**: Best for interactive systems like personal assistants or game NPCs where low-latency synthesis is critical.
+- **Resource-Constrained Environments**: When high-fidelity synthesis is needed but only consumer-grade hardware (e.g., laptop GPU or CPU) is available.
+
+## When not to use it
+- **Studio-Quality Production**: Not suitable for high-end commercial voiceovers requiring extreme emotional range or complex prosody.
+- **Noisy Source Audio**: When the reference audio has significant background noise, as it lacks advanced noise-reduction capabilities during the cloning phase.
+
 ## Getting started
 
 ### Installation
@@ -65,6 +74,8 @@ python app.py
 - [ElevenLabs](elevenlabs.md) (Cloud-based proprietary alternative)
 - [Ollama](../../services/ollama.md) (Local model runner integration)
 - [Msty](../infrastructure/msty.md) (Local AI desktop with audio support)
+- [Gemini Flash TTS](gemini-flash-tts.md) (Fast cloud-based TTS alternative)
+- [Home Assistant](../../services/home-assistant.md) (Primary integration target for local voice assistants)
 
 ## Sources / references
 - [KokoClone GitHub](https://github.com/Ashish-Patnaik/kokoclone)


### PR DESCRIPTION
This change brings `docs/tools/ai_knowledge/kokoclone.md` to High Confidence standards by adding mandatory 'When to use it' and 'When not to use it' sections and expanding the relative cross-links to 7+. It also updates the Batch 41 task decomposition report.

---
*PR created automatically by Jules for task [16366750101083649691](https://jules.google.com/task/16366750101083649691) started by @joanmarcriera*