### PR TITLE
Deepen 5 tool pages to 'High Confidence' standards (Sub-Batch 41.10)

### DIFF
--- a/docs/reports/task-decomposition-batch-41.md
+++ b/docs/reports/task-decomposition-batch-41.md
@@ -85,11 +85,11 @@ This report implements **Action C** for the remaining "Shallow" and "Non-complia
 
 ## Sub-Batch 41.10: AI Knowledge Deepening
 - [x] `docs/tools/ai_knowledge/kokoclone.md`
-- [ ] `docs/tools/ai_knowledge/last30days-skill.md`
-- [ ] `docs/tools/ai_knowledge/llamaindex-ts.md`
-- [ ] `docs/tools/ai_knowledge/nemotron.md`
-- [ ] `docs/tools/automation_orchestration/airops.md`
-- [ ] `docs/tools/automation_orchestration/goose.md`
+- [x] `docs/tools/ai_knowledge/last30days-skill.md`
+- [x] `docs/tools/ai_knowledge/llamaindex-ts.md`
+- [x] `docs/tools/ai_knowledge/nemotron.md`
+- [x] `docs/tools/automation_orchestration/airops.md`
+- [x] `docs/tools/automation_orchestration/goose.md`
 
 ## Sub-Batch 41.11: Automation & Benchmarking
 - [ ] `docs/tools/automation_orchestration/gumloop.md`

--- a/docs/tools/ai_knowledge/last30days-skill.md
+++ b/docs/tools/ai_knowledge/last30days-skill.md
@@ -21,6 +21,22 @@ Traditional search engines often surface stale editorial content or SEO-spam. In
 - **Intelligent Pre-Research**: The v3 engine resolves relevant handles, subreddits, and hashtags before searching, ensuring high-signal discovery.
 - **Shareable Artifacts**: Can emit self-contained, dark-mode HTML briefs for easy distribution in Slack or Notion.
 
+## Limitations
+- **Recency Bias**: Strictly limited to the last 30 days; cannot be used for historical research beyond that window.
+- **Platform Rate Limits**: Subject to the API quotas of underlying social platforms (especially X and GitHub).
+- **English Language Focus**: Community scoring and entity resolution are currently optimized for English-speaking technical communities.
+- **Noise Sensitivity**: While it uses an "AI Judge," viral but low-quality content can occasionally skew the results.
+
+## When to use it
+- Use when researching rapidly evolving software where documentation lags behind community discourse.
+- Use for competitive intelligence when you need to know how users are *actually* feeling about a product today.
+- Use when preparing for a technical deep dive where recent GitHub issues and PR discussions are vital.
+
+## When not to use it
+- Do not use for general knowledge or encyclopedic queries that don't change month-to-month.
+- Do not use for deep historical research (e.g., "History of LLMs before 2023").
+- Do not use for queries requiring strictly verified, peer-reviewed scientific data where community consensus is irrelevant.
+
 ## Getting started
 
 ### Installation (Claude Code)
@@ -55,6 +71,9 @@ clawhub install last30days-official
 - [Claude Skills Ecosystem](../agents/claude-skills-ecosystem.md) (Community context)
 - [OpenRouter](openrouter.md) (API provider used for web search components)
 - [Exa Search](../automation_orchestration/goose.md) (Similar neural search concept)
+- [Perplexity](perplexity.md) (Search competitor)
+- [Tavily](../providers/tavily.md) (Search API for LLMs)
+- [Dify](dify.md) (Orchestration platform that can host skills)
 
 ## Sources / references
 - [last30days-skill GitHub Repository](https://github.com/mvanhorn/last30days-skill)

--- a/docs/tools/ai_knowledge/llamaindex-ts.md
+++ b/docs/tools/ai_knowledge/llamaindex-ts.md
@@ -25,6 +25,16 @@ It bridges the gap between Large Language Models (LLMs) and custom data sources 
 - **Browser Constraints**: Direct browser support is limited due to the lack of `AsyncLocalStorage` in many browser environments.
 - **Deprecation Warning**: As of April 30, 2026, the core `LlamaIndexTS` repository is marked as deprecated in favor of unified Python/Cloud-first documentation, though the NPM package remains widely used for JS/TS integrations.
 
+## When to use it
+- Use when building enterprise-grade RAG applications within a TypeScript-first tech stack.
+- Use when deploying AI agents to serverless or edge environments where JavaScript runtimes are preferred.
+- Use when you need seamless integration with frontend frameworks like Next.js or React.
+
+## When not to use it
+- Do not use if your project requires highly specialized data connectors only available in the Python version of LlamaIndex.
+- Do not use for heavy data science or machine learning research where Python's library ecosystem (Pandas, PyTorch) is essential.
+- Avoid using in direct client-side browser code if you require persistent local indexing or complex secret management.
+
 ## Getting started
 
 ### Installation
@@ -51,7 +61,11 @@ main();
 - [LlamaIndex (Python)](../ai_knowledge/llamaindex.md)
 - [LlamaParse](../intake_storage/llamaparse.md)
 - [Vercel AI SDK](../development_ops/vercel-ai-sdk.md)
-- [RAG](../../knowledge_base/patterns/rag.md)
+- [RAG](../../knowledge_base/patterns/rag-pattern.md)
+- [LangChain](langchain.md)
+- [Mastra](../frameworks/mastra.md)
+- [Firebase Genkit](../frameworks/firebase-genkit.md)
+- [OpenRouter](openrouter.md)
 
 ## Sources / references
 - [Official Website](https://ts.llamaindex.ai/)

--- a/docs/tools/ai_knowledge/nemotron.md
+++ b/docs/tools/ai_knowledge/nemotron.md
@@ -63,11 +63,25 @@ For agentic deployments, treat Nemotron-3 Super as the planning/escalation model
 - **Hardware Affinity**: Best performance and efficiency gains require NVIDIA Blackwell (B200) GPUs.
 - **Model Size**: At 120B total parameters, it requires significant VRAM even with its 12B active parameter efficiency.
 
+## When to use it
+- Use when building autonomous multi-agent systems that require long-context reasoning across massive document sets.
+- Use if you have access to NVIDIA hardware (especially Blackwell) and need to minimize inference latency for large models.
+- Use for cybersecurity or software engineering tasks where "associative recall" and multi-step planning are critical.
+
+## When not to use it
+- Do not use for simple, single-turn chat interactions where smaller, faster models (like Nemotron-3 Nano) are sufficient.
+- Avoid using on non-NVIDIA hardware if you require the 4x efficiency gains promised by NVFP4 optimization.
+- Do not use if you are strictly limited by VRAM and cannot support a 120B parameter model footprint.
+
 ## Related tools / concepts
 - [NVIDIA](../providers/nvidia.md)
 - [NVIDIA NeMo Retriever](../agents/nemo-retriever.md)
 - [OpenCode](../development_ops/opencode.md)
 - [Mamba Architecture](../../knowledge_base/model_classes.md)
+- [DeepSeek R1](deepseek-r1.md)
+- [Qwen](qwen.md)
+- [OpenRouter](openrouter.md)
+- [Llama.cpp](../infrastructure/llama-cpp.md)
 
 ## Sources / References
 - [Introducing Nemotron 3 Super (NVIDIA Blog)](https://developer.nvidia.com/blog/introducing-nemotron-3-super-an-open-hybrid-mamba-transformer-moe-for-agentic-reasoning/)

--- a/docs/tools/automation_orchestration/airops.md
+++ b/docs/tools/automation_orchestration/airops.md
@@ -25,6 +25,16 @@ AirOps addresses the difficulty of moving AI from a simple chat interface into a
 - **Commercial Platform**: Primarily a paid service with enterprise focus.
 - **Complexity**: Offers a wide range of features that might take time to master.
 
+## When to use it
+- Use when you need a multi-tenant platform for deploying AI workflows to many users or customers.
+- Use if your team includes non-technical stakeholders who need to collaborate on prompt engineering and workflow design.
+- Use when building AI tools that require deep integration with enterprise data sources like Snowflake, Postgres, or Salesforce.
+
+## When not to use it
+- Do not use for simple personal automation where lightweight tools like Zapier or basic scripts are sufficient.
+- Avoid if you require a fully open-source, self-hosted solution; consider Dify or Langflow instead.
+- Do not use for highly experimental research tasks that don't need the production-grade reliability of a managed platform.
+
 ## Getting started
 1.  Sign up for an account at [AirOps.com](https://www.airops.com/).
 2.  Navigate to the API section in your workspace settings to generate an API Key.
@@ -47,6 +57,10 @@ curl --request POST \
 - [Flowise](../ai_knowledge/flowise.md)
 - [Parea](../process_understanding/parea.md)
 - [Zapier](zapier.md)
+- [n8n](../../services/n8n.md)
+- [Make](make.md)
+- [Langflow](../frameworks/langflow.md)
+- [Glean](../enterprise/glean.md)
 
 ## Sources / references
 - [AirOps Official Website](https://www.airops.com/)

--- a/docs/tools/automation_orchestration/goose.md
+++ b/docs/tools/automation_orchestration/goose.md
@@ -24,6 +24,16 @@ Goose addresses the need for a standardized, extensible way for agents to intera
 - **Newer Project**: Community and ecosystem are still growing compared to older frameworks.
 - **Complexity**: Might require more setup than "zero-config" tools like Open Interpreter.
 
+## When to use it
+- Use when you need a local AI agent that can securely interact with your system CLI and internal scripts.
+- Use if you want to build custom toolkits for an agent using Python or the Model Context Protocol (MCP).
+- Use for engineering workflows where you need the agent to perform actions (like running tests or deploying code) rather than just writing text.
+
+## When not to use it
+- Do not use if you prefer a graphical user interface for agent management; Goose is primarily CLI-driven.
+- Avoid for simple chat tasks where a standard LLM interface like ChatGPT or Claude.ai is more convenient.
+- Do not use if you are looking for a fully autonomous agent to manage complex, multi-repo projects without human oversight; Goose is best as an "assistant" in a session.
+
 ## Getting started
 
 ### Installation
@@ -72,6 +82,9 @@ def my_custom_tool(param: str) -> str:
 - [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md)
 - [Aider](../development_ops/aider.md)
 - [Cline](../agents/cline.md)
+- [Jules](../ai_knowledge/jules.md)
+- [Melty](../development_ops/melty.md)
+- [Devin](../development_ops/devin.md)
 
 ## Sources / references
 - [Goose GitHub Repository](https://github.com/block/goose)


### PR DESCRIPTION
This PR deepens five documentation files in the `docs/tools/` directory to meet the "High Confidence" standard (10 mandatory sections, 7+ relative links). 

Modified files:
- `docs/tools/ai_knowledge/last30days-skill.md`
- `docs/tools/ai_knowledge/llamaindex-ts.md`
- `docs/tools/ai_knowledge/nemotron.md`
- `docs/tools/automation_orchestration/airops.md`
- `docs/tools/automation_orchestration/goose.md`

Changes include:
- Adding missing `## Limitations`, `## When to use it`, and `## When not to use it` sections.
- Expanding the `## Related tools / concepts` section to include at least 7 relative links to other internal documentation.
- Updating `docs/reports/task-decomposition-batch-41.md` to mark these tasks as completed.

All changes have been verified using the repository's audit and contract-checking scripts.

---
*PR created automatically by Jules for task [12294664611657307330](https://jules.google.com/task/12294664611657307330) started by @joanmarcriera*