### PR TITLE
Ralph-loop: Deepen Media Services (Sub-Batch 35.1)

### DIFF
--- a/docs/reports/ralph-loop-execution-2026-05-12.md
+++ b/docs/reports/ralph-loop-execution-2026-05-12.md
@@ -1,12 +1,21 @@
 # Ralph-loop Execution Report — 2026-05-12
 
 ## Summary
-Deepened the final 15 non-compliant documentation files to "High Confidence" standards, completing the Batch 41 Audit Resolution. The repository documentation is now 100% compliant with the KnowledgeOps contract (10 mandatory sections, 7+ cross-links, technical examples).
+- Deepened the final 15 non-compliant documentation files to "High Confidence" standards, completing the Batch 41 Audit Resolution.
+- Deepened 4 high-priority media services (`linkwarden`, `tubearchivist`, `navidrome`, `jackett`) as part of Sub-Batch 35.1.
+- The repository documentation is now 100% compliant with the KnowledgeOps contract (10 mandatory sections, 7+ cross-links, technical examples).
 
 ## Targeted Issues
 - **Batch 41 Audit Resolution**: Bringing all "Shallow" and "Non-compliant" documents to the repository standard.
+- **Batch 35 (Sub-Batch 35.1)**: Advanced technical deepening of media services.
 
 ## Targeted Files
+### Sub-Batch 35.1: Media & Content Archival
+- `docs/services/linkwarden.md`
+- `docs/services/tubearchivist.md`
+- `docs/services/navidrome.md`
+- `docs/services/jackett.md`
+
 ### Sub-Batch 41.11: Automation & Benchmarking
 - `docs/tools/automation_orchestration/gumloop.md`
 - `docs/tools/automation_orchestration/llmware.md`

--- a/docs/reports/ralph-loop-triage.md
+++ b/docs/reports/ralph-loop-triage.md
@@ -46,7 +46,7 @@ This report documents the triage of open GitHub issues and ongoing maintenance t
 The following tasks are identified for future Ralph-loop runs to maintain the "High Confidence" standard:
 
 - **Access Matrix Freshness**: **Updated (2026-06-01)** (Perplexity Gmail/Calendar updated to 🟢; Aider MCP updated to 🟠).
-- **Batch 35**: Deepen remaining shallow docs from `data/growth-metrics.json` (e.g., `linkwarden.md`, `tubearchivist.md`).
+- **Batch 35**: Deepen remaining shallow docs from `data/growth-metrics.json`. **Sub-Batch 35.1 (Media) completed 2026-05-12**.
 - **Batch 41**: Address remaining 80+ non-compliant docs as decomposed in `docs/reports/task-decomposition-batch-41.md`. **(Completed 2026-05-12)**.
 
 ---

--- a/docs/reports/task-decomposition-batch-35.md
+++ b/docs/reports/task-decomposition-batch-35.md
@@ -7,10 +7,10 @@ This report implements **Action C** for the "Shallow" documents identified in `d
 - **Priority**: Focus on services that act as central hubs or intake points in the homelab stack.
 
 ## Sub-Batch 35.1: Media & Content Archival (High Priority)
-- [ ] `docs/services/linkwarden.md`: Add example of automated tagging via LLM and advanced PDF export management via API.
-- [ ] `docs/services/tubearchivist.md`: Add advanced `yt-dlp` configuration examples for quality control and metadata post-processing.
-- [ ] `docs/services/navidrome.md`: Add examples for subsonic API integration with local agents and automated playlist management.
-- [ ] `docs/services/jackett.md`: Add advanced query filtering examples and integration with automated media intake pipelines.
+- [x] `docs/services/linkwarden.md`: Add example of automated tagging via LLM and advanced PDF export management via API.
+- [x] `docs/services/tubearchivist.md`: Add advanced `yt-dlp` configuration examples for quality control and metadata post-processing.
+- [x] `docs/services/navidrome.md`: Add examples for subsonic API integration with local agents and automated playlist management.
+- [x] `docs/services/jackett.md`: Add advanced query filtering examples and integration with automated media intake pipelines.
 
 ## Sub-Batch 35.2: Communication & Security
 - [ ] `docs/services/element.md`: Add advanced bot integration examples using `matrix-nio` for home automation state reporting.

--- a/docs/services/jackett.md
+++ b/docs/services/jackett.md
@@ -104,6 +104,66 @@ with urllib.request.urlopen(url, timeout=10) as response:
     print(response.read().decode()[:500])
 ```
 
+### Advanced: Automated Media Intake (Python)
+This pattern demonstrates how to query multiple Jackett indexers for a specific term and filter results by health (seeds) and size. This is a foundational pattern for custom intake agents.
+
+```python
+import requests
+import xml.etree.ElementTree as ET
+
+# Configuration
+JACKETT_URL = "http://localhost:9117"
+API_KEY = "YOUR_JACKETT_API_KEY"
+
+def search_jackett(query, category=2000): # 2000 is usually Movies
+    # Query 'all' indexers via the Torznab interface
+    url = f"{JACKETT_URL}/api/v2.0/indexers/all/results/torznab/api"
+    params = {
+        "apikey": API_KEY,
+        "t": "search",
+        "q": query,
+        "cat": category
+    }
+
+    response = requests.get(url, params=params)
+    if response.status_code != 200:
+        return []
+
+    # Parse Torznab XML response
+    root = ET.fromstring(response.content)
+    results = []
+
+    for item in root.findall(".//item"):
+        title = item.find("title").text
+        link = item.find("link").text
+
+        # Extract Torznab-specific attributes (size, seeders)
+        size = 0
+        seeders = 0
+        for attr in item.findall("{http://torznab.com/schemas/2015/feed}attr"):
+            name = attr.get("name")
+            if name == "size":
+                size = int(attr.get("value"))
+            elif name == "seeders":
+                seeders = int(attr.get("value"))
+
+        results.append({
+            "title": title,
+            "link": link,
+            "size_gb": round(size / (1024**3), 2),
+            "seeders": seeders
+        })
+
+    return results
+
+# Example: Find a specific Linux ISO with at least 10 seeders
+matches = search_jackett("ubuntu 24.04")
+healthy_matches = [m for m in matches if m["seeders"] > 10]
+
+for m in healthy_matches:
+    print(f"Found: {m['title']} ({m['size_gb']} GB, {m['seeders']} seeds)")
+```
+
 ## Troubleshooting
 - If an indexer test fails, re-check credentials, required cookies, two-factor/session settings, and whether the tracker changed its login flow.
 - If downstream Arr apps return no results, confirm that categories selected in Jackett match the media type requested by the app.

--- a/docs/services/linkwarden.md
+++ b/docs/services/linkwarden.md
@@ -124,6 +124,62 @@ curl -X POST "http://localhost:3000/api/v1/links" \
      -d '{"url": "https://www.wikipedia.org", "collectionId": 1}'
 ```
 
+### Advanced: Automated Tagging via LLM (Python)
+This pattern fetches untagged links and uses a local LLM (via [Ollama](ollama.md)) to suggest and apply tags.
+
+```python
+import requests
+import json
+
+BASE_URL = "http://localhost:3000/api/v1"
+API_KEY = "YOUR_LINKWARDEN_API_KEY"
+OLLAMA_URL = "http://localhost:11434/api/generate"
+
+headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+
+def get_untagged_links():
+    res = requests.get(f"{BASE_URL}/links", headers=headers)
+    return [l for l in res.json()['response'] if not l.get('tags')]
+
+def suggest_tags(title, description):
+    prompt = f"Suggest 3 short tags for a bookmark titled '{title}' with description '{description}'. Return as JSON list of strings."
+    res = requests.post(OLLAMA_URL, json={"model": "llama3", "prompt": prompt, "stream": False, "format": "json"})
+    return json.loads(res.json()['response'])
+
+for link in get_untagged_links():
+    tags = suggest_tags(link['title'], link.get('description', ''))
+    requests.patch(f"{BASE_URL}/links/{link['id']}",
+                  headers=headers,
+                  json={"tags": [{"name": t} for t in tags]})
+    print(f"Tagged '{link['title']}' with {tags}")
+```
+
+### Advanced: Bulk PDF Export Management
+Linkwarden stores archives as IDs. This script identifies links with PDF archives and downloads them for external backup.
+
+```python
+import requests
+
+API_KEY = "YOUR_API_KEY"
+headers = {"Authorization": f"Bearer {API_KEY}"}
+
+def download_pdf(link_id, filename):
+    # Endpoint to get preservation details
+    res = requests.get(f"http://localhost:3000/api/v1/links/{link_id}", headers=headers)
+    link_data = res.json()['response']
+
+    # Check for PDF archive ID
+    pdf_archive = next((a for a in link_data.get('archives', []) if a['format'] == 'pdf'), None)
+    if pdf_archive:
+        # Download the actual file
+        file_res = requests.get(f"http://localhost:3000/api/v1/archives/{pdf_archive['id']}", headers=headers)
+        with open(f"./backups/{filename}.pdf", "wb") as f:
+            f.write(file_res.content)
+
+# Example usage
+download_pdf(123, "my_preserved_page")
+```
+
 ## Related tools / concepts
 
 - [Changedetection.io](changedetection.md) — for monitoring websites for changes after bookmarking them.
@@ -139,7 +195,6 @@ curl -X POST "http://localhost:3000/api/v1/links" \
 
 ## Backlog
 - Browser extension integration.
-- Automated tagging via LLM.
 
 ## Sources / References
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -124,6 +124,58 @@ with urllib.request.urlopen(f"{base_url}/rest/ping.view?{query}", timeout=10) as
     print(response.read().decode())
 ```
 
+### Advanced: Automated Playlist Management (Python)
+This script demonstrates how to search for tracks by a specific genre and create/update a playlist. This pattern is useful for local agents that curate music based on external triggers (e.g., weather or time of day).
+
+```python
+import requests
+import hashlib
+import secrets
+
+# Configuration
+BASE_URL = "http://localhost:4533/rest"
+USER = "admin"
+PASS = "password"
+CLIENT_ID = "playlist-bot"
+
+def get_auth_params():
+    salt = secrets.token_hex(6)
+    token = hashlib.md5(f"{PASS}{salt}".encode()).hexdigest()
+    return {"u": USER, "t": token, "s": salt, "v": "1.16.1", "c": CLIENT_ID, "f": "json"}
+
+def search_tracks(query):
+    params = get_auth_params()
+    params["query"] = query
+    res = requests.get(f"{BASE_URL}/search3.view", params=params)
+    return res.json().get("subsonic-response", {}).get("searchResult3", {}).get("song", [])
+
+def update_playlist(playlist_name, song_ids):
+    params = get_auth_params()
+    # 1. Get playlist ID
+    res = requests.get(f"{BASE_URL}/getPlaylists.view", params=params)
+    playlists = res.json().get("subsonic-response", {}).get("playlists", {}).get("playlist", [])
+    playlist = next((p for p in playlists if p["name"] == playlist_name), None)
+
+    if not playlist:
+        # Create if not exists
+        params["name"] = playlist_name
+        params["songId"] = song_ids
+        requests.get(f"{BASE_URL}/createPlaylist.view", params=params)
+    else:
+        # Update existing
+        pid = playlist["id"]
+        params["playlistId"] = pid
+        params["songIdToAdd"] = song_ids
+        requests.get(f"{BASE_URL}/updatePlaylist.view", params=params)
+
+# Example: Create a "Jazz Morning" playlist from recent additions
+songs = search_tracks("genre:Jazz")
+ids = [s["id"] for s in songs[:10]]
+if ids:
+    update_playlist("Jazz Morning", ids)
+    print(f"Updated 'Jazz Morning' with {len(ids)} tracks.")
+```
+
 ## Troubleshooting
 - If the UI starts but no albums appear, verify Linux permissions with `ls -n ./music` and make the Compose `user` match the folder owner.
 - If remote clients cannot connect, confirm port `4533` is reachable through the firewall, VPN, or reverse proxy.

--- a/docs/services/tubearchivist.md
+++ b/docs/services/tubearchivist.md
@@ -101,6 +101,42 @@ docker exec tubearchivist pip install -U yt-dlp
 docker exec tubearchivist python manage.py check_worker
 ```
 
+### Advanced: `yt-dlp` Quality Control
+In the **Settings > Application > Download Format** section, you can fine-tune how videos are selected and sorted.
+
+**Priority for AV1 (Higher efficiency):**
+Pass this to **Format Sort**:
+```text
+codec:av1,res,fps,br
+```
+
+**Limit resolution to 1080p and avoid premium/experimental formats:**
+Pass this to **Format**:
+```text
+bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[height<=1080]/best
+```
+
+### Advanced: Metadata Verification
+If you enable **Embed Metadata**, Tube Archivist writes a JSON object into the media file's metadata tags. You can verify this using standard tools.
+
+**Using `ffprobe` (to see the `ta` tag):**
+```bash
+ffprobe -v quiet -show_entries format_tags -of json my_video.mp4 \
+  | jq -r '.format.tags.ta'
+```
+
+**Using Python (`mutagen`):**
+```python
+import json
+from mutagen.mp4 import MP4
+
+video = MP4("video.mp4")
+# Tube Archivist metadata is stored in a custom atom
+metadata = json.loads(video.tags["----:com.tubearchivist:ta"][0].decode())
+print(f"Title: {metadata['title']}")
+print(f"Channel: {metadata['channel_name']}")
+```
+
 ## API examples
 
 ### Python (Get all videos)


### PR DESCRIPTION
Performed Action A of the Ralph-loop by deepening four high-priority media services as part of Batch 35. Added advanced technical content (scripts/examples) for Linkwarden (LLM tagging), Tube Archivist (yt-dlp control), Navidrome (playlist API), and Jackett (Torznab intake). All changes verified via the repository audit suite.

---
*PR created automatically by Jules for task [16416193554913409789](https://jules.google.com/task/16416193554913409789) started by @joanmarcriera*