### PR TITLE
Ralph-loop: Deepen 5 Oldest Documentation Issues (Batch 46)

### DIFF
--- a/docs/reports/ralph-loop-execution-2026-05-14-batch-46.md
+++ b/docs/reports/ralph-loop-execution-2026-05-14-batch-46.md
@@ -1,0 +1,33 @@
+# Ralph-loop Execution Report — 2026-05-14 (Batch 46)
+
+This report documents the resolution of the 5 oldest "Medium Confidence" documentation issues as part of the Ralph-loop maintenance cycle on May 14, 2026.
+
+## Batch 46 Overview
+- **Objective**: Resolve the 5 oldest documentation items identified by `Last reviewed` date and "Medium Confidence" status.
+- **Standards**: Bring all targeted documents to "High Confidence" standards (10 sections, 7+ links, technical examples).
+
+## Issues Processed (Action A)
+
+| File | Status | Notes |
+| :--- | :--- | :--- |
+| `docs/tools/ai_knowledge/obsidian.md` | **High Confidence** | Added URI scheme, Dataview, and indexing examples. |
+| `docs/tools/automation_orchestration/make.md` | **High Confidence** | Added Webhook curl patterns and JSON transform examples. |
+| `docs/tools/automation_orchestration/zapier.md` | **High Confidence** | Added Python/JS code block and Zapier Central details. |
+| `docs/tools/automation_orchestration/clihub.md` | **High Confidence** | Added compilation and n8n integration examples. |
+| `docs/tools/automation_orchestration/mcp-registry.md` | **High Confidence** | Added `server.json` publishing and discovery patterns. |
+
+## Implementation Details
+- **Content Expansion**: Each document now includes all 10 mandatory sections (What it is, What problem it solves, Strengths, Limitations, etc.).
+- **Graph Density**: Expanded "Related tools / concepts" sections to ensure >= 7 relative markdown links per page.
+- **Technical Depth**: Added practical "Getting started" guides and API/CLI/n8n examples for all tools.
+- **Metadata**: Updated `Confidence` to `high` and `Last reviewed` to `2026-05-14`.
+
+## Verification Results
+- `scripts/check_docs_contract.py`: **PASSED** (5/5 files)
+- `scripts/audit_docs_quality.py`: **100% Compliant** (491/491 files)
+- `scripts/check_catalog_consistency.py`: **PASSED**
+
+---
+- Confidence: high
+- Date: 2026-05-14
+- Created by: Jules

--- a/docs/tools/ai_knowledge/obsidian.md
+++ b/docs/tools/ai_knowledge/obsidian.md
@@ -4,46 +4,102 @@
 Obsidian is a powerful knowledge base built on top of a local folder of plain text Markdown files. It is highly extensible through plugins and themes, allowing you to build a personalized second brain.
 
 ## What problem it solves
-Provides a flexible, local-first environment for organizing notes and knowledge using plain Markdown files, with a rich plugin ecosystem for customization.
+Provides a flexible, local-first environment for organizing notes and knowledge using plain Markdown files, with a rich plugin ecosystem for customization. It solves the "data lock-in" problem of cloud-based note-taking apps by keeping all files as standard Markdown on your local disk.
 
 ## Where it fits in the stack
-AI & Knowledge — serves as a personal knowledge management tool that stores data locally as Markdown, fitting the privacy-first philosophy of the stack.
+AI & Knowledge — serves as a personal knowledge management tool that stores data locally as Markdown, fitting the privacy-first philosophy of the stack. It often acts as the primary interface for "thinking in public" and "thinking in private" within the homelab ecosystem.
 
 ## Typical use cases
 - Building a personal knowledge base with bidirectional links and graph view
 - Writing and organizing documentation, research notes, and daily journals
 - Extending functionality with community plugins such as AI-powered note linking
+- Implementing Zettelkasten or other knowledge management methodologies
+- Local-first RAG (Retrieval-Augmented Generation) source for personal agents
 
 ## Strengths
 - Data stored as plain Markdown files, ensuring portability and longevity
-- Large and active plugin and theme ecosystem
+- Large and active plugin and theme ecosystem (1000+ community plugins)
 - Strong graph visualization for exploring connections between notes
+- Completely local-first, works offline, and respects privacy
+- Highly customizable interface and workflow
 
 ## Limitations
 - Not open-source (core application is proprietary, though data is open)
 - Real-time collaboration features are limited compared to cloud-based tools
-- Sync across devices requires Obsidian Sync (paid) or third-party solutions
+- Sync across devices requires Obsidian Sync (paid) or third-party solutions (Git, Syncthing)
+- Can become complex to manage with too many plugins or deep customization
 
 ## When to use it
 - When you want a highly customizable, local-first knowledge base with a large plugin ecosystem
-- When plain Markdown portability is important
+- When plain Markdown portability is important for long-term knowledge preservation
+- When you want to leverage local LLMs to query your personal notes
 
 ## When not to use it
-- When you need a fully open-source tool (consider Logseq instead)
+- When you need a fully open-source tool (consider [Logseq](logseq.md) or [SilverBullet](../intake_storage/silverbullet.md) instead)
 - When real-time multi-user collaboration is a core requirement
+- When you prefer a structured database-like approach over free-form Markdown (consider [AnyType](../intake_storage/anytype.md))
+
+## Getting started
+
+### Installation
+Obsidian is available for Windows, macOS, Linux, iOS, and Android.
+Download the installer from the [official website](https://obsidian.md/download).
+
+### Recommended Initial Setup
+1. **Create a Vault**: Choose a local folder where your Markdown files will live.
+2. **Enable Community Plugins**: Go to `Settings` -> `Community plugins` -> `Turn on community plugins`.
+3. **Core Plugins**: Enable `Daily notes`, `Graph view`, and `Backlinks`.
+
+## Technical examples
+
+### Obsidian URI Scheme
+Obsidian provides a custom URI scheme to trigger actions from other apps (e.g., n8n or terminal).
+
+```bash
+# Open a specific vault and file
+open "obsidian://open?vault=my-vault&file=my-note"
+
+# Create a new note with content
+open "obsidian://new?vault=my-vault&name=new-note&content=Hello%20world"
+```
+
+### Dataview Query (Plugin)
+If the Dataview plugin is installed, you can query your notes like a database.
+
+```markdown
+```dataview
+TABLE file.mtime AS "Last Modified"
+FROM "Projects"
+WHERE status = "In Progress"
+SORT file.mtime DESC
+```
+```
+
+### Unified Search Integration
+Using the project's `scripts/unified_search.py`, you can index Obsidian notes into a local vector DB.
+
+```bash
+python3 scripts/obsidian_incremental_indexing.py --vault /path/to/vault --db ./data/chroma_db
+```
 
 ## Related tools / concepts
 
 - [Logseq](logseq.md)
-- [Roam Research](https://roamresearch.com/)
+- [SilverBullet](../intake_storage/silverbullet.md)
+- [AnyType](../intake_storage/anytype.md)
 - [Joplin](joplin.md)
 - [AI Templates](aitmpl.md)
 - [Google Gemini](google-gemini.md)
 - [Google Opal](google-opal.md)
+- [Syncthing](../../services/syncthing.md)
+- [Paperless-ngx](../../services/paperless-ngx.md)
+
 ## Sources / references
 - [Official Website](https://obsidian.md/)
+- [Obsidian Help (Official Documentation)](https://help.obsidian.md/)
+- [Obsidian Community Plugins](https://obsidian.md/plugins)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/automation_orchestration/clihub.md
+++ b/docs/tools/automation_orchestration/clihub.md
@@ -1,53 +1,107 @@
 # CliHub
 
 ## What it is
-CliHub is a generator that connects to an MCP server and produces a compiled CLI binary where each server tool becomes a command.
+CliHub is a generator that connects to a Model Context Protocol (MCP) server and produces a compiled, standalone CLI binary. Each tool exposed by the MCP server is automatically converted into a command within the generated CLI.
 
 ## What problem it solves
-MCP clients are great for interactive agent workflows, but they can add runtime overhead and deployment complexity. CliHub converts MCP tools into portable binaries for scriptable and agent-friendly execution.
+MCP clients (like Claude Desktop) are excellent for interactive agent workflows, but they can add significant runtime overhead and deployment complexity for automated tasks. CliHub solves this by converting MCP tools into portable, fast, and scriptable binaries. It allows "one-command" deployment of entire tool suites for both humans and agents.
 
 ## Where it fits in the stack
-**Automation / Orchestration Tool**. It bridges MCP tool ecosystems into standalone command-line interfaces.
+**Automation / Orchestration Tool**. It bridges the gap between the emerging MCP ecosystem and traditional shell-native workflows. It effectively allows you to "compile" your agentic tools into standard DevOps-friendly binaries.
 
 ## Typical use cases
-- Packaging MCP tools into static binaries for CI jobs
-- Running MCP-backed workflows in shell scripts without full MCP client stacks
-- Shipping deterministic tool interfaces to agent runtimes
+- Packaging complex MCP tool suites (like Jira or GitHub) into static binaries for CI/CD pipelines.
+- Running MCP-backed workflows in shell scripts without needing a full MCP client stack.
+- Shipping deterministic, versioned tool interfaces to autonomous agent runtimes.
+- Reducing latency for tool invocation in high-frequency automation loops.
+- Debugging MCP servers directly from the terminal with standard CLI arguments.
 
 ## Strengths
-- One-command codegen flow from MCP endpoint to CLI
-- Supports HTTP and stdio MCP servers
-- Can generate binaries for multiple target platforms
+- **Simplicity**: One-command codegen flow from MCP endpoint to ready-to-use CLI.
+- **Portability**: Generates binaries for multiple target platforms (Linux, macOS, Windows).
+- **Efficiency**: Eliminates the overhead of maintaining an active MCP transport session for simple, one-off tool calls.
+- **Interoperability**: Supports both HTTP and stdio MCP transport protocols.
+- **Agent-Friendly**: Standard CLI interfaces are easily understood by older agent models or simpler automation scripts.
 
 ## Limitations
-- Generated CLI capability is limited to exposed MCP tools
-- Authentication setup still needs secure secret management
-- Requires regeneration when server tool schemas change
+- **Static Schema**: The generated CLI reflects the MCP server schema at the time of generation; it requires regeneration if the server tools change.
+- **Auth Management**: Authentication setup (API tokens, environment variables) must still be handled securely outside of the binary.
+- **No Stateful Sessions**: Unlike a live MCP client, each CLI call is independent, which may not be suitable for servers that rely on multi-call state.
 
 ## When to use it
-- When you want MCP capabilities in a lightweight CLI distribution model
-- When building agent workflows that prefer shell-native tools
+- When you want to distribute MCP capabilities in a lightweight, zero-dependency model.
+- When building automated DevOps pipelines that need to leverage agent-designed tools.
+- When you want to use MCP tools as part of a larger bash or python automation script.
+- When debugging a new MCP server and you want a standard CLI interface to test each tool.
 
 ## When not to use it
-- When a long-running MCP session is required for advanced agent interactions
-- When dynamic server-tool discovery at runtime is mandatory
+- When a long-running, stateful MCP session is required for advanced multi-step reasoning.
+- When dynamic, runtime discovery of new tools is a core part of the workflow.
+- When the overhead of an MCP client (like the `mcp-cli` or `claude-code`) is already acceptable.
 
-## Licensing and cost
-- **Open Source**: Yes
-- **Cost**: Free software
-- **Self-hostable**: Yes
+## Getting started
+
+### Installation
+You can install the CliHub generator via Go or by downloading a pre-compiled binary.
+
+```bash
+# Install via Go
+go install github.com/thellimist/clihub@latest
+```
+
+### Basic Usage
+Generate a CLI from a local MCP server (stdio):
+
+```bash
+# Generate a CLI named 'my-tool' from a Node-based MCP server
+clihub generate --name my-tool --command "npx -y @anthropic-ai/mcp-server-atlassian"
+```
+
+Generate a CLI from a remote MCP server (SSE/HTTP):
+
+```bash
+clihub generate --name remote-tool --url "https://mcp.example.com/sse"
+```
+
+## Technical / CLI examples
+
+### Invoking a Generated Command
+Once generated, you can use the binary like any other CLI tool. If you generated a Jira CLI:
+
+```bash
+# List issues using the generated CLI
+./jira-cli get_issue --key PROJ-123
+
+# Commands are derived from tool names
+./jira-cli search_issues --jql "project = PROJ AND status = Open"
+```
+
+### Multi-Platform Build
+CliHub can leverage Go's cross-compilation to build for different environments:
+
+```bash
+GOOS=linux GOARCH=amd64 clihub generate --name jira-linux --command "..."
+```
+
+### Integration with n8n
+Instead of configuring complex MCP nodes in n8n, you can use the "Execute Command" node to call a CliHub-generated binary for simple tool execution.
 
 ## Related tools / concepts
+- [Model Context Protocol (MCP)](mcp.md)
 - [MCP Registry](mcp-registry.md)
 - [ServiceNow MCP Server](servicenow-mcp.md)
+- [Atlassian Jira MCP Implementations](atlassian-jira-mcp.md)
+- [Playwright MCP Server](playwright-mcp.md)
 - [Agent Protocols](../../knowledge_base/agent_protocols.md)
+- [Claude Code](../development_ops/claude-code.md)
+- [n8n](../../services/n8n.md)
 
 ## Sources / References
-- [CliHub repository](https://github.com/thellimist/clihub)
-- [CliHub install namespace](https://github.com/clihub/clihub)
+- [CliHub Repository](https://github.com/thellimist/clihub)
 - [I Made MCP 94% Cheaper (And It Only Took One Command)](https://kanyilmaz.me/2026/02/23/cli-vs-mcp.html)
+- [MCP Official Documentation](https://modelcontextprotocol.io/)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/automation_orchestration/make.md
+++ b/docs/tools/automation_orchestration/make.md
@@ -1,48 +1,86 @@
 # Make (formerly Integromat)
 
 ## What it is
-Make is a visual automation platform that allows you to design, build, and automate anything from tasks and workflows to apps and systems.
+Make is a visual automation platform that allows you to design, build, and automate anything from tasks and workflows to apps and systems. It uses a "no-code" approach to connect hundreds of different web services through a drag-and-drop scenario builder.
 
 ## What problem it solves
-Enables non-developers to create complex multi-step automations connecting different apps and services through a visual drag-and-drop interface.
+Enables non-developers to create complex multi-step automations connecting different apps and services through a visual interface. It handles authentication, data mapping, and scheduling, significantly reducing the engineering effort required to build integrations between SaaS products.
 
 ## Where it fits in the stack
-**Orchestration**. Serves as a cloud-based automation platform, an alternative to self-hosted n8n.
+**Automation & Orchestration**. Serves as a cloud-based automation platform, an alternative to self-hosted tools like n8n. It is ideal for workflows that primarily involve third-party cloud services (SaaS) where an official API integration is preferred over custom scripts.
 
 ## Typical use cases
-- Building multi-step workflows connecting cloud services
-- Automating data transformations and transfers between applications
-- Creating integrations for services that lack native connections
+- Building multi-step workflows connecting cloud services (e.g., Typeform to Slack to Google Sheets)
+- Automating data transformations and transfers between applications using built-in functions
+- Creating integrations for services that lack native connections via its "HTTP Request" module
+- Processing incoming webhooks from external services to trigger internal actions
 
 ## Strengths
-- Visual scenario builder makes complex workflows accessible
-- Large library of pre-built integrations
-- Supports branching, error handling, and iterators natively
+- **Visual Scenario Builder**: Highly intuitive drag-and-drop interface with real-time execution tracking.
+- **Large Integration Library**: Supports 1000+ pre-built connectors for popular SaaS tools.
+- **Advanced Logic**: Supports branching, filtering, error handling, and iterators/aggregators natively.
+- **Data Mapping**: Extremely flexible system for transforming data between different formats without code.
 
 ## Limitations
-- Cloud-hosted only; no self-hosting option for privacy-first setups
-- Pricing is based on operations, which can become expensive at scale
-- Less flexible than code-based solutions for advanced logic
+- **Cloud-hosted only**: No self-hosting option for privacy-first or local-only homelab setups.
+- **Operational Cost**: Pricing is based on the number of "operations" and data transfer volume, which can scale quickly.
+- **Proprietary**: Workflows are locked into the Make platform and cannot be easily exported to other systems.
 
 ## When to use it
-- When you need a no-code automation platform with a strong visual editor
-- When the required integrations are available and self-hosting is not a requirement
+- When you need a no-code automation platform with a strong visual editor for SaaS-to-SaaS workflows.
+- When the required integrations are already available as official modules.
+- When you need a reliable, managed service that handles OAuth and API maintenance automatically.
 
 ## When not to use it
-- When privacy requires self-hosted automation (use [n8n](../../services/n8n.md) instead)
-- When you need full programmatic control over automation logic
+- When privacy requires self-hosted automation or local data processing (use [n8n](../../services/n8n.md) or [LocalFlow](../frameworks/langflow.md) instead).
+- When the automation involves significant local file system or hardware access.
+- When you need full programmatic control over the execution environment or custom library support.
+
+## Getting started
+
+1. **Sign up**: Create an account at [Make.com](https://www.make.com/).
+2. **Create a Scenario**: Click "Create a new scenario" and choose a trigger (e.g., "Webhooks").
+3. **Add Modules**: Click the plus icon to add actions from other apps.
+4. **Link and Map**: Connect the modules and map the output fields from one module to the input of the next.
+5. **Run and Schedule**: Test the scenario manually, then set the schedule to "On" to automate it.
+
+## API / Technical examples
+
+### Incoming Webhook Pattern
+Make provides a unique URL for every webhook trigger. You can send data to this URL from any device or script.
+
+```bash
+# Sending JSON data to a Make webhook
+curl -X POST https://hook.eu1.make.com/your-unique-id \
+     -H "Content-Type: application/json" \
+     -d '{"event": "door_open", "sensor": "back_gate", "timestamp": "2026-05-14T03:30:00Z"}'
+```
+
+### JSON Transform Function
+Inside a module, you can use Excel-like functions to transform data:
+`{{upper(1.name)}}` converts the name field to uppercase.
+`{{formatDate(now; "YYYY-MM-DD")}}` returns the current date in ISO format.
+
+### Error Handling
+Make allows adding "Error handlers" (like `Ignore`, `Rollback`, `Resume`) to specific modules to handle API failures or timeouts gracefully.
 
 ## Related tools / concepts
 
 - [n8n](../../services/n8n.md)
 - [Zapier](zapier.md)
-- [Browser Use](browser-use.md)
-- [Atlassian Jira MCP Implementations](atlassian-jira-mcp.md)
+- [Pipedream](pipedream.md)
+- [IFTTT](https://ifttt.com/)
 - [Skyvern](skyvern.md)
+- [Browser Use](browser-use.md)
+- [Webhook Ingestion](../../reference-implementations/paperless/webhook-ingestion.md)
+- [Home Assistant](../../services/home-assistant.md)
+
 ## Sources / references
 - [Official Website](https://www.make.com/)
+- [Make Academy (Training)](https://academy.make.com/)
+- [Make API Documentation](https://www.make.com/en/api-documentation)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/automation_orchestration/mcp-registry.md
+++ b/docs/tools/automation_orchestration/mcp-registry.md
@@ -1,47 +1,99 @@
 # MCP Registry
 
 ## What it is
-The official central repository and discovery platform for Model Context Protocol (MCP) servers. It acts as a standardized directory for tools and integrations that follow the MCP specification.
+The MCP Registry is the central discovery platform and directory for Model Context Protocol (MCP) servers. It provides a standardized way for developers to publish and for users to discover tools that extend the capabilities of AI agents (like Claude Desktop, IDEs, or autonomous scripts).
 
 ## What problem it solves
-It addresses the fragmentation in the MCP ecosystem by providing a single, authoritative source for discovering publicly available MCP servers. It standardizes server metadata using the `server.json` format, enabling easier publishing and discovery for developers and users.
+Before the registry, MCP implementations were fragmented across GitHub, NPM, and private blogs. The registry addresses this fragmentation by providing a single, authoritative source for discovering publicly available MCP servers. It standardizes server metadata (via `server.json`), making it easier to find, evaluate, and install tools.
 
 ## Where it fits in the stack
-**Infra / Router**: It provides the infrastructure for tool discovery and acts as a registry for routing agent requests to the correct tools.
+**Automation / Orchestration**. It acts as the "app store" or "package manager" equivalent for the AI tool-calling ecosystem. It provides the metadata infrastructure that allows agents to find the right tool for a specific task.
 
 ## Typical use cases
-- **Extending Agent Capabilities**: Discovering new MCP servers to add features like calendar access, database management, or smart home control to AI agents.
-- **Developer Publishing**: Providing a standardized way for developers to share their custom MCP servers with the community.
-- **Protocol Compliance**: Ensuring that tools follow the official MCP standards for metadata and communication.
+- **Discovering Integrations**: Finding an MCP server that connects Claude to a specific database (e.g., PostgreSQL), service (e.g., Slack), or local tool (e.g., terminal).
+- **Evaluating Maturity**: Checking the popularity, maintenance status, and exposed toolsets of different MCP implementations before integrating them.
+- **Publishing Tools**: Providing a standardized way for developers to share their custom MCP servers with the wider community.
+- **Protocol Compliance**: Verifying that a server follows the official MCP standards for metadata and communication.
 
 ## Strengths
-- **Authoritative Source**: Official central hub for the MCP ecosystem.
-- **Community-Owned**: Managed by the open-source community with backing from major AI industry players.
-- **Standardized Format**: Enforces the use of `server.json` for consistent tool representation.
-- **Unified Discovery**: Creators publish once, and all consumers can reference the same canonical data.
+- **Official Status**: Backed by Anthropic and the core MCP development team as the canonical directory.
+- **Standardized Metadata**: Enforces the use of `server.json` for consistent tool representation across the ecosystem.
+- **Unified Discovery**: Creators publish once, and all consumers (IDEs, desktop apps, CLI tools) can reference the same canonical data.
+- **Searchable Index**: Provides a categorized and searchable interface for finding specific functionalities.
 
 ## Limitations
-- **Early Stage**: Currently in preview, with the ecosystem and server list still actively growing.
-- **Metadata Only**: Does not host the server binaries or code directly, acting instead as a pointer to other registries (NPM, PyPI, Docker Hub).
+- **Discovery Only**: Does not host the actual server code or binaries; it provides links to where they are hosted (GitHub, NPM, Docker Hub).
+- **Early Stage**: The ecosystem is growing rapidly, so quality and documentation of listed servers can vary significantly.
+- **Permissions**: The registry does not handle authentication or credential management for the servers it lists.
 
 ## When to use it
-- When looking for pre-built integrations for MCP-compatible agents (like Claude Desktop).
-- When developing a new MCP server and wanting to ensure it is discoverable by the community.
+- When you want to see what integrations are available to extend your AI agent's capabilities.
+- When you are developing a new MCP server and want it to be discoverable by other users.
+- When you need to find the correct installation command for an official or community-maintained MCP server.
 
 ## When not to use it
-- When requiring private or internal-only tool integrations that should not be public.
-- When using non-MCP compliant tool-calling frameworks.
+- When you are working with private, internal, or proprietary tools that should not be publicly indexed.
+- When using non-MCP-based tool-calling systems (e.g., legacy OpenAI Function Calling).
+
+## Getting started
+
+### Browsing the Registry
+You can browse the registry through the web interface at [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/).
+
+### Using Registry Metadata in Config
+Many MCP clients use the registry metadata to simplify configuration. For example, if a tool is listed on the registry, you can often find the exact `claude_desktop_config.json` snippet required to run it.
+
+```json
+{
+  "mcpServers": {
+    "everything": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-everything"]
+    }
+  }
+}
+```
+
+## Technical examples
+
+### Publishing to the Registry
+To list a server, developers typically create a `mcp-server.json` file in their repository root and submit a PR to the official registry repository.
+
+```json
+{
+  "mcp-server": {
+    "name": "my-custom-server",
+    "description": "Exposes my custom home automation tools",
+    "version": "1.0.0",
+    "repository": "https://github.com/user/my-custom-server",
+    "license": "MIT"
+  }
+}
+```
+
+### Programmatic Discovery
+Advanced clients can fetch the registry index as JSON to provide an "in-app" discovery experience.
+
+```bash
+# Example of fetching registry metadata (hypothetical endpoint)
+curl https://registry.modelcontextprotocol.io/v1/servers/search?q=postgres
+```
 
 ## Related tools / concepts
-- [Model Context Protocol](../../knowledge_base/agent_protocols.md)
-- [Claude Desktop](../development_ops/vscode.md) (as a primary MCP client)
-- [PulseMCP](https://pulsemcp.com/) (community alternative)
+- [Model Context Protocol (MCP)](mcp.md)
+- [CliHub](clihub.md)
+- [ServiceNow MCP Server](servicenow-mcp.md)
+- [Atlassian Jira MCP Implementations](atlassian-jira-mcp.md)
+- [Playwright MCP Server](playwright-mcp.md)
+- [Claude Desktop](../development_ops/vscode.md)
+- [PulseMCP](https://pulsemcp.com/) (Community-driven alternative directory)
 
 ## Sources / references
-- [Official MCP Registry Announcement](https://modelcontextprotocol.info/tools/registry/)
-- [Registry Browser](https://registry.modelcontextprotocol.io/)
+- [Official MCP Registry](https://registry.modelcontextprotocol.io/)
+- [Model Context Protocol Website](https://modelcontextprotocol.io/)
+- [MCP GitHub Organization](https://github.com/modelcontextprotocol)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/automation_orchestration/zapier.md
+++ b/docs/tools/automation_orchestration/zapier.md
@@ -1,48 +1,95 @@
 # Zapier
 
 ## What it is
-Zapier is a popular automation tool that connects your apps and services. It allows you to automate repetitive tasks without coding or relying on developers to build the integration.
+Zapier is a leading cloud-based automation platform that connects thousands of applications through simple "if-this-then-that" workflows called "Zaps". It is designed to be accessible to non-technical users while providing a massive ecosystem of pre-built integrations.
 
 ## What problem it solves
-Eliminates manual repetitive work by connecting disparate apps and services through simple trigger-action workflows ("Zaps"), without requiring programming skills.
+Eliminates manual repetitive work by connecting disparate apps and services through simple trigger-action workflows, without requiring programming skills or API management. It bridges the gap between SaaS tools that don't natively talk to each other.
 
 ## Where it fits in the stack
-**Orchestration**. Serves as a cloud-based automation platform, an alternative to self-hosted n8n.
+**Automation & Orchestration**. Serves as a primary cloud-based automation alternative. While n8n is preferred for self-hosting and privacy, Zapier is used for long-tail SaaS integrations or when a quick, managed solution is required for external service connectivity.
 
 ## Typical use cases
-- Automating simple trigger-action workflows between cloud services
-- Connecting apps that do not have native integrations
-- Setting up notifications and data routing between services
+- Automating simple trigger-action workflows between cloud services (e.g., Save Gmail attachments to Dropbox).
+- Connecting niche SaaS apps that do not have native integrations in other platforms.
+- Setting up automated social media posting and marketing notifications.
+- Routing lead information from web forms to CRM systems.
+- Centralizing notifications from multiple cloud services into a single Slack channel.
 
 ## Strengths
-- Extremely large library of app integrations (thousands of supported apps)
-- Simple, intuitive interface for basic automations
-- Reliable cloud infrastructure with good uptime
+- **Unrivaled Integration Library**: Supports 6,000+ app integrations, the largest in the industry.
+- **Extreme Simplicity**: The "Zap" builder is optimized for speed and ease of use.
+- **Zapier Central**: New AI-native features that allow building "agents" that can use Zaps as tools.
+- **Reliability**: Managed infrastructure with high uptime and handled API updates.
+- **No-Code UI**: Minimal technical knowledge required to get started.
 
 ## Limitations
-- Cloud-hosted only; no self-hosting option
-- Limited complexity for multi-step or branching workflows compared to alternatives
-- Pricing can escalate quickly with high task volumes
+- **Cloud-hosted only**: No self-hosting option; data must pass through Zapier's servers.
+- **Pricing Model**: Cost scales per "task," which can become significantly more expensive than self-hosted n8n at high volumes.
+- **Limited Control**: Less flexibility for complex data manipulation or custom code compared to n8n or Make.
+- **Linear Workflows**: While "Paths" (branching) exists, it is restricted to higher-tier plans.
 
 ## When to use it
-- When you need quick, simple automations for non-self-hostable cloud services
-- When the priority is breadth of integrations over workflow complexity
+- When you need a quick, simple automation for a cloud service not supported by other tools.
+- When the priority is breadth of integrations and speed of setup over cost or privacy.
+- When building simple AI agents via Zapier Central that need to take actions in SaaS apps.
 
 ## When not to use it
-- When privacy requires self-hosted automation (use [n8n](../../services/n8n.md) instead)
-- When you need complex, multi-step workflows with advanced logic (use [Make](make.md) or n8n)
+- When privacy requires self-hosted automation (use [n8n](../../services/n8n.md) instead).
+- When you have high-volume workflows that would be cost-prohibitive on a per-task basis.
+- When you need complex, multi-step workflows with advanced data processing (use [Make](make.md) or n8n).
+
+## Getting started
+
+1. **Sign Up**: Create an account at [Zapier.com](https://zapier.com/).
+2. **Create a Zap**: Click "Create" and choose a Trigger (e.g., "New Email in Gmail").
+3. **Choose an Action**: Select what happens next (e.g., "Send Message in Slack").
+4. **Authorize Apps**: Log in to the respective accounts to grant Zapier access.
+5. **Test and Publish**: Verify the data flow and turn the Zap on.
+
+## Technical / API examples
+
+### Zapier Webhooks
+You can trigger a Zap using a custom webhook, allowing integration with local scripts or Home Assistant.
+
+```bash
+# Triggering a Zap from a shell script
+curl -X POST https://hooks.zapier.com/hooks/catch/123456/abcdef/ \
+     -H "Content-Type: application/json" \
+     -d '{"status": "complete", "project": "homelab-sync", "nodes": 3}'
+```
+
+### Python/JS "Code by Zapier"
+For logic that can't be handled by standard blocks, you can insert small snippets of code (subject to memory and timeout limits).
+
+```javascript
+// Example JavaScript block to parse a custom date format
+const rawDate = inputData.date;
+const cleanDate = new Date(rawDate).toISOString();
+return { formattedDate: cleanDate };
+```
+
+### Zapier Central
+AI agents in Zapier Central can be configured to use your existing Zaps as tools, enabling natural language control over your automated workflows.
 
 ## Related tools / concepts
 
 - [n8n](../../services/n8n.md)
 - [Make](make.md)
+- [Pipedream](pipedream.md)
+- [IFTTT](https://ifttt.com/)
+- [Skyvern](skyvern.md)
 - [Browser Use](browser-use.md)
 - [Atlassian Jira MCP Implementations](atlassian-jira-mcp.md)
-- [Skyvern](skyvern.md)
+- [Home Assistant](../../services/home-assistant.md)
+
 ## Sources / references
 - [Official Website](https://zapier.com/)
+- [Zapier App Directory](https://zapier.com/apps)
+- [Zapier Engineering Blog](https://zapier.com/engineering)
+- [Zapier Central Docs](https://central.zapier.com/)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high


### PR DESCRIPTION
Deepened the 5 oldest "Medium Confidence" documents (obsidian.md, make.md, zapier.md, clihub.md, mcp-registry.md) to "High Confidence" standards. Each file now includes 10 mandatory sections, 7+ relative cross-links, and technical examples (CLI/API/n8n). Verified via standard repository audit suite.

---
*PR created automatically by Jules for task [3968586131442986085](https://jules.google.com/task/3968586131442986085) started by @joanmarcriera*