### PR TITLE
Ralph-loop: Deepen Batch 47 Documentation

### DIFF
--- a/docs/reports/ralph-loop-execution-2026-05-14-batch-47.md
+++ b/docs/reports/ralph-loop-execution-2026-05-14-batch-47.md
@@ -1,0 +1,33 @@
+# Ralph-loop Execution Report — 2026-05-14 (Batch 47)
+
+This report documents the resolution of the next 5 oldest "Medium Confidence" documentation issues as part of the Ralph-loop maintenance cycle on May 14, 2026.
+
+## Batch 47 Overview
+- **Objective**: Resolve the 5 oldest documentation items identified by `Last reviewed` date and "Medium Confidence" status (post-Batch 46).
+- **Standards**: Bring all targeted documents to "High Confidence" standards (10 sections, 7+ links, technical examples).
+
+## Issues Processed (Action A)
+
+| File | Status | Notes |
+| :--- | :--- | :--- |
+| `docs/tools/automation_orchestration/servicenow-mcp.md` | **High Confidence** | Added ServiceNow ITSM tool examples and configuration. |
+| `docs/tools/benchmarking/chatbot-arena.md` | **High Confidence** | Added Elo calculation details and human preference nuances. |
+| `docs/tools/benchmarking/gpqa.md` | **High Confidence** | Added expert-verified reasoning patterns and benchmark stats. |
+| `docs/tools/benchmarking/gsm8k.md` | **High Confidence** | Added multi-step reasoning examples and CoT efficacy. |
+| `docs/tools/benchmarking/human-eval.md` | **High Confidence** | Added Pass@k metric details and execution environment setup. |
+
+## Implementation Details
+- **Content Expansion**: Each document now includes all 10 mandatory sections (What it is, What problem it solves, Strengths, Limitations, etc.).
+- **Graph Density**: Expanded "Related tools / concepts" sections to ensure >= 7 relative markdown links per page.
+- **Technical Depth**: Added practical "Getting started" guides and API/CLI/n8n examples for all tools.
+- **Metadata**: Updated `Confidence` to `high` and `Last reviewed` to `2026-05-14`.
+
+## Verification Results
+- `scripts/check_docs_contract.py`: **PASSED** (5/5 files)
+- `scripts/audit_docs_quality.py`: **100% Compliant**
+- `scripts/check_catalog_consistency.py`: **PASSED**
+
+---
+- Confidence: high
+- Date: 2026-05-14
+- Created by: Jules

--- a/docs/reports/ralph-loop-triage.md
+++ b/docs/reports/ralph-loop-triage.md
@@ -1,6 +1,6 @@
-# Ralph-loop Triage Report — 2026-05-13
+# Ralph-loop Triage Report — 2026-05-14
 
-This report documents the triage of open GitHub issues and ongoing maintenance tasks as of May 13, 2026.
+This report documents the triage of open GitHub issues and ongoing maintenance tasks as of May 14, 2026.
 
 ## Issue Status Summary
 
@@ -41,6 +41,10 @@ This report documents the triage of open GitHub issues and ongoing maintenance t
 | **Batch 39** | Knowledge Base Deepening | **Resolved** | Deepened ai_signal_sources, agent_protocols, and ai_tool_access_matrix. |
 | **Batch 40** | Playbook Deepening | **Resolved** | Deepened raspberry-pi-kiosk-automation and scan-to-task. |
 | **Batch 41** | Maintenance Run (Audit Resolution) | **Verified & Closed** | 100% compliance achieved across 486/486 docs (2026-05-12). |
+| **Batch 44** | Maintenance Run (Oldest Backlog) | **Resolved** | Deepened `standards.md`, `logseq.md`, etc. (2026-05-14). |
+| **Batch 45** | Maintenance Run (Oldest Backlog) | **Resolved** | Deepened `llama-cpp.md`, `llm-trust-boundaries.md`, etc. (2026-05-14). |
+| **Batch 46** | Maintenance Run (Medium Confidence) | **Resolved** | Deepened `obsidian.md`, `make.md`, `zapier.md`, etc. (2026-05-14). |
+| **Batch 47** | Maintenance Run (Medium Confidence) | **Resolved** | Deepened `human-eval.md`, `gsm8k.md`, `chatbot-arena.md`, etc. (2026-05-14). |
 
 ## Action Plan for Remaining Work (Action C)
 The following tasks are identified for future Ralph-loop runs to maintain the "High Confidence" standard:

--- a/docs/tools/automation_orchestration/servicenow-mcp.md
+++ b/docs/tools/automation_orchestration/servicenow-mcp.md
@@ -1,36 +1,98 @@
 # ServiceNow MCP Server
 
 ## What it is
-ServiceNow MCP Server is a Model Context Protocol server that lets AI agents read and update ServiceNow data through MCP tools.
+ServiceNow MCP Server is a Model Context Protocol server that lets AI agents read and update ServiceNow data through MCP tools. It exposes ServiceNow's IT Service Management (ITSM) capabilities as structured tools that LLMs can invoke.
 
 ## What problem it solves
-It reduces direct API wiring work when you want agents to query incidents, change requests, or scripts in ServiceNow through a standard tool interface.
+It reduces direct API wiring work when you want agents to query incidents, change requests, or scripts in ServiceNow through a standard tool interface. It abstracts the complexity of ServiceNow's Table API into a set of well-defined MCP tools.
 
 ## Where it fits in the stack
-**Automation / Orchestration Tool**. It is a domain-specific MCP server used by MCP-compatible clients.
+**Automation / Orchestration Tool**. It is a domain-specific MCP server used by MCP-compatible clients to bridge the gap between AI reasoning and enterprise IT operations.
 
 ## Typical use cases
 - Agent-assisted incident triage against ServiceNow records
 - Querying and updating tickets from coding agents
 - Script include maintenance workflows in ServiceNow from agent tools
+- Automated status reporting for change requests
 
 ## Strengths
 - MCP-native interface for ServiceNow operations
 - Supports practical record search/update workflows
 - Fits existing MCP client ecosystem without custom adapters
+- Simplifies authentication by centralizing it in the server process
 
 ## Limitations
-- Requires ServiceNow credentials and environment setup
-- Trust boundaries and permissions must be configured carefully
+- Requires ServiceNow credentials (Service Account recommended) and environment setup
+- Trust boundaries and permissions must be configured carefully in ServiceNow (ACLs)
 - Coverage depends on server-supported tool set and ServiceNow API access
 
 ## When to use it
 - When your agent workflows already use MCP and need ServiceNow integration
 - When you want standardized tool-calling for ServiceNow tasks
+- For rapid prototyping of AI-driven IT support agents
 
 ## When not to use it
 - When you need full ServiceNow platform automation beyond exposed MCP tools
 - When governance rules require tightly curated direct API integrations only
+- For high-volume data migrations (use ServiceNow IntegrationHub or direct API instead)
+
+## Getting started
+
+To use the ServiceNow MCP server with a client like Claude Desktop:
+
+1. Obtain your ServiceNow instance URL, username, and password.
+2. Add the server configuration to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "servicenow": {
+      "command": "npx",
+      "args": ["-y", "@michaelbuckner/servicenow-mcp"],
+      "env": {
+        "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
+        "SERVICENOW_USERNAME": "your-username",
+        "SERVICENOW_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+## Technical examples
+
+### Searching for Incidents
+An agent can use the `search_records` tool to find specific incidents:
+
+```json
+// Tool call from agent
+{
+  "name": "search_records",
+  "arguments": {
+    "table_name": "incident",
+    "query": "active=true^priority=1",
+    "limit": 5
+  }
+}
+```
+
+### Updating a Record
+Closing an incident via tool call:
+
+```json
+// Tool call from agent
+{
+  "name": "update_record",
+  "arguments": {
+    "table_name": "incident",
+    "sys_id": "87920394871023948710239487102394",
+    "data": {
+      "state": "7",
+      "close_notes": "Resolved by AI agent through MCP server."
+    }
+  }
+}
+```
 
 ## Licensing and cost
 - **Open Source**: Yes (project listed with MIT badge in registry listing)
@@ -42,6 +104,10 @@ It reduces direct API wiring work when you want agents to query incidents, chang
 - [Model Context Protocol (MCP)](mcp.md)
 - [Atlassian Jira MCP Implementations](atlassian-jira-mcp.md)
 - [Service Inventory](../../services/inventory.md)
+- [Claude Desktop](../agents/claude-desktop.md)
+- [Goose](../agents/goose.md)
+- [Anthropic](../providers/anthropic.md)
+- [Task Schema](../../reference-implementations/metadata-schemas/task-schema.md)
 
 ## Sources / References
 - [ServiceNow MCP Server listing](https://mcpservers.org/servers/michaelbuckner/servicenow-mcp)
@@ -49,5 +115,5 @@ It reduces direct API wiring work when you want agents to query incidents, chang
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/benchmarking/chatbot-arena.md
+++ b/docs/tools/benchmarking/chatbot-arena.md
@@ -1,49 +1,89 @@
 # Chatbot Arena (LMSYS)
 
 ## What it is
-Chatbot Arena is a crowdsourced open platform for evaluating LLMs through human preference. Developed by LMSYS, it uses an Elo rating system based on pairwise comparisons where humans vote for the better response from two anonymous models. Its key metric is the Elo Rating, representing the relative skill level of a model based on thousands of matches.
+Chatbot Arena is a crowdsourced open platform for evaluating LLMs through human preference. Developed by LMSYS (Large Model Systems Organization), it uses an Elo rating system based on pairwise comparisons where humans vote for the better response from two anonymous models. Its key metric is the Elo Rating, representing the relative skill level of a model based on thousands of matches.
 
 ## What problem it solves
-Provides a human-preference-based ranking of LLMs that captures subjective quality differences not easily measured by automated benchmarks.
+Provides a human-preference-based ranking of LLMs that captures subjective quality differences not easily measured by automated benchmarks. It counters "benchmark contamination" by using blind human testing on unpredictable user prompts.
 
 ## Where it fits in the stack
-**Benchmarking**. Serves as a reference leaderboard for comparing LLM quality based on real human judgments.
+**Benchmarking**. Serves as a reference leaderboard for comparing LLM quality based on real human judgments and "vibe" checks.
 
 ## Typical use cases
 - Comparing the conversational quality of different LLMs before selecting one for deployment
-- Tracking how new model releases rank against established models
-- Validating whether automated benchmark scores align with human preferences
+- Tracking how new model releases rank against established models (e.g., GPT-4 vs. Claude 3.5)
+- Validating whether automated benchmark scores (like MMLU) align with human preferences
 
 ## Strengths
 - Based on real human preferences rather than synthetic metrics
 - Large-scale crowdsourced evaluation provides statistical robustness
 - Covers a wide range of models and is continuously updated
+- Dynamic leaderboards for specific categories (Coding, Hard Prompts, Long Context)
 
 ## Limitations
 - Results depend on the demographics and preferences of the crowd
-- Does not measure specific capabilities like code generation or math in isolation
-- No way to run it locally or privately on your own models
+- Does not measure specific capabilities like code generation or math in isolation (though category slices help)
+- No way to run it locally or privately on your own models for the main leaderboard
+- Potential for "style" bias where models with more verbose or polite formatting score higher
 
 ## When to use it
 - When deciding which hosted LLM to use and human-perceived quality matters most
-- When validating whether a model that scores well on automated benchmarks also feels good to users
+- When validating whether a model that scores well on automated benchmarks also "feels" good to users
+- For tracking state-of-the-art (SOTA) progress in the LLM landscape
 
 ## When not to use it
 - When you need to benchmark local or private models not listed on the platform
-- When you need domain-specific evaluation (e.g., code, math, science)
+- When you need domain-specific evaluation for niche technical tasks
+- For rigorous safety or alignment testing (dedicated benchmarks are better)
+
+## Getting started
+
+Users can participate in the arena by visiting the LMSYS website and entering prompts. For developers, the leaderboard data is often available for analysis.
+
+1. Visit [arena.lmsys.org](https://arena.lmsys.org/).
+2. Enter a prompt in the "Side-by-side" mode.
+3. Compare Model A and Model B responses.
+4. Vote for the better response (or a tie).
+
+## Technical examples
+
+### Elo Rating Calculation
+The platform uses the standard Elo rating system. After a match between Model A (rating $R_A$) and Model B (rating $R_B$), the expected score $E_A$ for Model A is:
+
+$$E_A = \frac{1}{1 + 10^{(R_B - R_A)/400}}$$
+
+Ratings are updated based on the actual outcome vs. the expected outcome.
+
+### Accessing Leaderboard via API
+While the voting is human-based, the leaderboard data can sometimes be queried or downloaded via the Hugging Face dataset:
+
+```python
+from datasets import load_dataset
+
+# Load the Chatbot Arena Conversations dataset
+dataset = load_dataset("lmsys/chatbot_arena_conversations")
+print(dataset['train'][0])
+```
 
 ## Related tools / concepts
-
 - [AlpacaEval](alpaca-eval.md)
 - [MT-Bench](mt-bench.md)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [SWE-bench](swe-bench.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)
+- [MMLU](mmlu.md)
+- [GPQA](gpqa.md)
+- [OpenAI](../providers/openai.md)
+- [Anthropic](../providers/anthropic.md)
+- [Google Gemini](../providers/google.md)
+- [Meta Llama](../providers/meta.md)
+
 ## Sources / references
 - [LMSYS Chatbot Arena](https://arena.lmsys.org/)
 - [LMSYS Leaderboard](https://arena.lmsys.org/leaderboard)
+- [LMSYS Org GitHub](https://github.com/lm-sys)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/benchmarking/gpqa.md
+++ b/docs/tools/benchmarking/gpqa.md
@@ -1,48 +1,97 @@
 # GPQA (Graduate-Level Google-Proof Q&A)
 
 ## What it is
-GPQA is a challenging benchmark for evaluating high-level reasoning and knowledge in LLMs. It consists of 448 multiple-choice questions written by experts (PhD-level) in biology, physics, and chemistry. The questions are designed to be "Google-proof," meaning they are difficult even for non-expert humans to solve with access to the internet. Key metrics include accuracy (percentage of correct answers) and self-consistency (reasoning reliability).
+GPQA is a challenging benchmark for evaluating high-level reasoning and knowledge in LLMs. It consists of 448 multiple-choice questions written by experts (PhD-level) in biology, physics, and chemistry. The questions are designed to be "Google-proof," meaning they are difficult even for non-expert humans to solve with access to the internet. Key metrics include accuracy (percentage of correct answers) and self-consistency.
 
 ## What problem it solves
-Measures whether LLMs possess deep, expert-level scientific knowledge and reasoning that cannot be trivially looked up, providing a more rigorous assessment than general knowledge benchmarks.
+Measures whether LLMs possess deep, expert-level scientific knowledge and reasoning that cannot be trivially looked up, providing a more rigorous assessment than general knowledge benchmarks like MMLU which are increasingly appearing in training sets.
 
 ## Where it fits in the stack
-**Benchmarking**. Used as a reference benchmark for evaluating advanced reasoning in LLMs.
+**Benchmarking**. Used as a reference benchmark for evaluating advanced reasoning and scientific competence in state-of-the-art LLMs.
 
 ## Typical use cases
 - Evaluating LLM performance on graduate-level scientific reasoning
 - Comparing models on tasks that require genuine understanding rather than surface-level retrieval
-- Assessing progress toward expert-level AI capabilities
+- Assessing progress toward expert-level AI capabilities in STEM fields
 
 ## Strengths
 - Questions are expert-written and verified to be genuinely difficult
-- Covers multiple scientific disciplines
-- Resistant to simple retrieval-based strategies
+- Covers multiple scientific disciplines (Biology, Physics, Chemistry)
+- Resistant to simple retrieval-based strategies and internet search
+- High correlation with actual reasoning ability in scientific domains
 
 ## Limitations
-- Limited to 448 questions, which may not cover all scientific domains
-- Focuses on biology, physics, and chemistry only
+- Limited scale (448 questions), which may not cover all scientific sub-domains
+- Focuses on "hard" sciences only; does not cover humanities or social sciences
 - Multiple-choice format may not fully capture open-ended reasoning ability
+- High barrier to entry for human verification (requires PhD-level experts)
 
 ## When to use it
-- When comparing LLMs on their ability to handle difficult, expert-level scientific questions
-- When you need a benchmark that is resistant to memorization and search
+- When comparing frontier LLMs on their ability to handle difficult, expert-level scientific questions
+- When you need a benchmark that is resistant to memorization and search-engine shortcuts
 
 ## When not to use it
-- When evaluating code generation or practical task completion
-- When you need broad general-knowledge evaluation (use MMLU instead)
+- When evaluating code generation or practical task completion (use HumanEval or SWE-bench)
+- When you need broad general-knowledge evaluation for a non-expert audience (use MMLU instead)
+- For testing basic conversational capabilities
+
+## Getting started
+
+GPQA is typically run using evaluation frameworks like the LM Evaluation Harness.
+
+1. Clone the LM Evaluation Harness repository.
+2. Install dependencies.
+3. Run the GPQA task against your model:
+
+```bash
+python main.py \
+    --model hf \
+    --model_args pretrained=your-model-name \
+    --tasks gpqa_main \
+    --device cuda:0
+```
+
+## Technical examples
+
+### Example Question Format
+Questions are structured to test reasoning over multiple steps of scientific logic:
+
+```json
+{
+  "question": "In a certain species of flowering plant, the locus for flower color has two alleles...",
+  "explanation": "To solve this, we must first calculate the allele frequencies using the Hardy-Weinberg equilibrium...",
+  "choice_a": "1/4",
+  "choice_b": "1/2",
+  "choice_c": "3/4",
+  "choice_d": "1",
+  "answer": "choice_c"
+}
+```
+
+### Performance Comparison (Representative)
+Frontier models typically show a significant gap between "Diamond" (expert-verified) and general accuracy:
+
+| Model | GPQA Diamond (Acc) |
+| :--- | :--- |
+| Claude 3.5 Sonnet | ~59.4% |
+| GPT-4o | ~53.6% |
+| Claude 3 Opus | ~50.4% |
+| Human (Non-expert) | ~34% |
 
 ## Related tools / concepts
-
 - [MMLU (Massive Multitask Language Understanding)](mmlu.md)
-- [ARC (AI2 Reasoning Challenge)](https://github.com/allenai/ARC-benchmark)
+- [GSM8K (Grade School Math 8K)](gsm8k.md)
+- [HumanEval](human-eval.md)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
-- [SWE-bench](swe-bench.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)
+- [Anthropic](../providers/anthropic.md)
+- [OpenAI](../providers/openai.md)
+
 ## Sources / references
-- [Arxiv Paper](https://arxiv.org/abs/2311.12022)
+- [Arxiv Paper: GPQA: A Graduate-Level Google-Proof Q&A Benchmark](https://arxiv.org/abs/2311.12022)
+- [GPQA Dataset on Hugging Face](https://huggingface.co/datasets/Idavidrein/gpqa)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/benchmarking/gsm8k.md
+++ b/docs/tools/benchmarking/gsm8k.md
@@ -4,45 +4,90 @@
 GSM8K is a benchmark for evaluating the multi-step mathematical reasoning capabilities of LLMs. It contains 8.5K high-quality grade school math word problems that require 2 to 8 steps of basic arithmetic to solve. The key metric is Exact Match (EM), measuring the accuracy of the final numerical answer.
 
 ## What problem it solves
-Provides a standardized way to measure whether LLMs can perform multi-step arithmetic reasoning, a fundamental capability for practical mathematical tasks.
+Provides a standardized way to measure whether LLMs can perform multi-step arithmetic reasoning, a fundamental capability for practical mathematical tasks and logical planning. It moves beyond simple "calculator" tasks to test the model's ability to decompose a problem into logical steps.
 
 ## Where it fits in the stack
-**Benchmarking**. Serves as a widely used reference for evaluating mathematical reasoning in LLMs.
+**Benchmarking**. Serves as a widely used reference for evaluating mathematical reasoning and Chain-of-Thought (CoT) efficacy in LLMs.
 
 ## Typical use cases
 - Evaluating LLM arithmetic and multi-step reasoning capabilities
-- Measuring the impact of prompting strategies (e.g., Chain-of-Thought) on math performance
+- Measuring the impact of prompting strategies (e.g., Chain-of-Thought, Few-Shot) on math performance
 - Comparing models on fundamental mathematical problem-solving
+- Regression testing for fine-tuned models to ensure math capabilities haven't degraded
 
 ## Strengths
 - Large dataset (8.5K problems) provides statistically meaningful results
 - Problems are well-defined with unambiguous numerical answers
-- Widely adopted, enabling cross-model comparisons
+- Widely adopted, enabling easy cross-model comparisons
+- High correlation with a model's general reasoning and instruction-following ability
 
 ## Limitations
-- Limited to grade-school-level math; does not test advanced mathematics
+- Limited to grade-school-level math; does not test advanced mathematics (calculus, linear algebra)
 - Problems are relatively formulaic compared to real-world math applications
-- Exact Match scoring does not give partial credit for correct reasoning with minor errors
+- Exact Match scoring does not give partial credit for correct reasoning with minor arithmetic errors
+- Increasing evidence of benchmark contamination in newer models
 
 ## When to use it
-- When comparing LLMs on basic mathematical reasoning
-- When evaluating the effect of different prompting techniques on math performance
+- When comparing LLMs on basic mathematical reasoning and logical consistency
+- When evaluating the effect of different prompting techniques (like `Let's think step by step`) on math performance
+- For base-level capability checks during model development
 
 ## When not to use it
-- When you need to evaluate advanced mathematical reasoning (use MATH Benchmark instead)
-- When testing non-mathematical capabilities
+- When you need to evaluate advanced mathematical reasoning (use [MATH Benchmark](math-benchmark.md) instead)
+- When testing non-mathematical or creative writing capabilities
+- For evaluating complex symbolic logic or theorem proving
+
+## Getting started
+
+GSM8K can be evaluated using standard libraries like `lm-eval`.
+
+1. Install the LM Evaluation Harness: `pip install lm-eval`
+2. Run the evaluation:
+
+```bash
+lm_eval --model hf \
+    --model_args pretrained=eleutherai/pythia-70m \
+    --tasks gsm8k \
+    --device cuda:0 \
+    --batch_size 8
+```
+
+## Technical examples
+
+### Example Problem
+A typical GSM8K problem involves multiple steps:
+
+> **Question**: Janet has 30 apples. She gives 10 to her neighbor and then buys 15 more. How many apples does she have now?
+> **Reasoning**:
+> 1. Janet starts with 30.
+> 2. She gives away 10: 30 - 10 = 20.
+> 3. She buys 15 more: 20 + 15 = 35.
+> **Answer**: 35
+
+### Evaluation with Chain-of-Thought
+Prompting models with `Let's think step by step` often significantly improves GSM8K scores:
+
+```text
+Q: [GSM8K Question]
+A: Let's think step by step.
+[Model generates reasoning steps]
+Therefore, the answer is [Number].
+```
 
 ## Related tools / concepts
-
 - [MATH Benchmark](math-benchmark.md)
 - [ASDiv](asdiv.md)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [SWE-bench](swe-bench.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)
+- [GPQA](gpqa.md)
+- [MMLU](mmlu.md)
+
 ## Sources / references
-- [GitHub Repository](https://github.com/openai/grade-school-math)
+- [OpenAI GSM8K GitHub Repository](https://github.com/openai/grade-school-math)
+- [Arxiv: Training Verifiers to Solve Math Word Problems](https://arxiv.org/abs/2110.14168)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high

--- a/docs/tools/benchmarking/human-eval.md
+++ b/docs/tools/benchmarking/human-eval.md
@@ -1,48 +1,88 @@
 # HumanEval
 
 ## What it is
-HumanEval is a benchmark released by OpenAI to evaluate the code generation capabilities of Large Language Models. It consists of 164 handwritten programming problems, each including a function signature, docstring, body, and several unit tests. The problems are designed to be self-contained and assess the model's ability to solve basic algorithmic tasks. The key metric is Pass@k, the probability that at least one of the top k generated code samples passes all unit tests.
+HumanEval is a benchmark released by OpenAI to evaluate the code generation capabilities of Large Language Models. It consists of 164 handwritten programming problems, each including a function signature, docstring, body, and several unit tests. The problems assess the model's ability to solve basic algorithmic tasks. The key metric is **Pass@k**, the probability that at least one of the top k generated code samples passes all unit tests.
 
 ## What problem it solves
-Provides a standardized measure of whether LLMs can generate functionally correct code from natural language descriptions.
+Provides a standardized, non-contaminated measure of whether LLMs can generate functionally correct code from natural language descriptions. Since the problems were handwritten and not scraped from public repositories (at least initially), it provides a cleaner evaluation of zero-shot coding ability.
 
 ## Where it fits in the stack
-**Benchmarking**. Used as a primary reference benchmark for code generation capabilities of LLMs.
+**Benchmarking**. Used as a primary reference benchmark for code generation and algorithmic reasoning capabilities of LLMs.
 
 ## Typical use cases
 - Evaluating LLM code generation accuracy on self-contained programming tasks
 - Comparing models on their ability to produce correct Python code
-- Measuring improvements in code generation across model versions
+- Measuring improvements in code generation across model versions or fine-tuning runs
 
 ## Strengths
 - Well-established and widely cited benchmark
-- Problems are self-contained with clear unit test validation
-- Pass@k metric accounts for sampling variability
+- Problems are self-contained with clear, automated unit test validation
+- Pass@k metric accounts for sampling variability and model creativity
+- Focuses on logical correctness rather than just syntax
 
 ## Limitations
-- Only 164 problems, which may not cover the full range of programming tasks
-- Focuses on Python and basic algorithmic tasks
-- Does not test real-world software engineering skills like debugging or working with existing codebases
+- Small scale (164 problems), which may not cover the full range of programming patterns
+- Focuses primarily on Python and basic algorithmic tasks
+- Does not test real-world software engineering skills like debugging, refactoring, or working with large multi-file codebases
+- High risk of contamination as it is frequently used in training data for newer models
 
 ## When to use it
-- When comparing LLMs on their ability to generate correct code from specifications
-- When evaluating a model for coding assistant use cases
+- When comparing frontier LLMs on their ability to generate correct code from specifications
+- When evaluating a model for "coding assistant" use cases
+- As a fast, automated check for coding regression in model pipelines
 
 ## When not to use it
 - When you need to evaluate real-world software engineering capability (use [SWE-bench](swe-bench.md) instead)
-- When you need multilingual code generation evaluation
+- When you need multilingual code generation evaluation (use MultiPL-E)
+- For evaluating complex system design or library-specific knowledge
+
+## Getting started
+
+You can run HumanEval using the official OpenAI execution environment or through broader harnesses.
+
+1. Clone the repository: `git clone https://github.com/openai/human-eval`
+2. Install the package: `pip install -e human-eval`
+3. Run the evaluation script (warning: this executes model-generated code):
+
+```bash
+python evaluate_functional_correctness.py samples.jsonl
+```
+
+## Technical examples
+
+### Example Problem (HumanEval/0)
+```python
+from typing import List
+
+def has_close_elements(numbers: List[float], threshold: float) -> bool:
+    """ Check if in given list of numbers, any two numbers are closer to each other than
+    given threshold.
+    >>> has_close_elements([1.0, 2.0, 3.0], 0.5)
+    False
+    >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)
+    True
+    """
+```
+
+### Pass@k Metric
+Pass@1 is the most common metric. For a model generating $n$ samples, if $c$ samples pass, the Pass@k is calculated as:
+
+$$Pass@k = 1 - \frac{\binom{n-c}{k}}{\binom{n}{k}}$$
 
 ## Related tools / concepts
-
 - [MBPP (Mostly Basic Python Problems)](mbpp.md)
 - [BigCodeBench](https://github.com/bigcode-project/bigcodebench)
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [SWE-bench](swe-bench.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)
+- [Aider](../development_ops/aider.md)
+- [Cursor](../development_ops/cursor.md)
+
 ## Sources / references
-- [GitHub Repository](https://github.com/openai/human-eval)
+- [OpenAI HumanEval GitHub](https://github.com/openai/human-eval)
+- [Arxiv: Evaluating Large Language Models Trained on Code](https://arxiv.org/abs/2107.03374)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-02-26
-- Confidence: medium
+- Last reviewed: 2026-05-14
+- Confidence: high


### PR DESCRIPTION
I have completed a Ralph-loop iteration (Batch 47) by deepening 5 documentation items from "Medium Confidence" to "High Confidence".

Targeted files:
1. `docs/tools/automation_orchestration/servicenow-mcp.md`: Added ServiceNow ITSM tool examples and configuration.
2. `docs/tools/benchmarking/chatbot-arena.md`: Added Elo calculation details and human preference nuances.
3. `docs/tools/benchmarking/gpqa.md`: Added expert-verified reasoning patterns and benchmark stats.
4. `docs/tools/benchmarking/gsm8k.md`: Added multi-step reasoning examples and CoT efficacy.
5. `docs/tools/benchmarking/human-eval.md`: Added Pass@k metric details and execution environment setup.

Additionally, I:
- Created a new execution report: `docs/reports/ralph-loop-execution-2026-05-14-batch-47.md`.
- Updated the central triage report: `docs/reports/ralph-loop-triage.md`.
- Verified all changes using the repository's audit scripts (`check_docs_contract.py`, `audit_docs_quality.py`, and `check_catalog_consistency.py`), maintaining 100% compliance.

---
*PR created automatically by Jules for task [335343920531566474](https://jules.google.com/task/335343920531566474) started by @joanmarcriera*