### PR TITLE
Deepen Batch 74 Documentation to High Confidence

### DIFF
--- a/docs/reports/ralph-loop-triage.md
+++ b/docs/reports/ralph-loop-triage.md
@@ -68,7 +68,7 @@ This report documents the triage of open GitHub issues and ongoing maintenance t
 | **Batch 71** | Infrastructure Maintenance | **Resolved** | Deepened `tgi.md`, `sglang.md`, `aphrodite-engine.md`, `exllamav2.md`, `claude-code-router.md` (2026-05-17). |
 | **Batch 72** | Inference Providers & Dev Studio | **Resolved** | Deepened `fireworks.md`, `groq.md`, `mistral.md`, `together.md`, `firebase-studio.md` (2026-05-17). |
 | **Batch 73** | High-Value AI Knowledge & Providers | **Resolved** | Deepened `minimax.md`, `moonshot.md`, `copy-ai.md`, `jasper.md`, `runwayml.md` (2026-05-17). |
-| **Batch 74** | Oldest Backlog Maintenance | **In Progress** | Deepening 5 oldest docs (2026-03-14). `superpowers.md` completed. |
+| **Batch 74** | Oldest Backlog Maintenance | **Verified & Closed** | Deepened `superpowers.md`, `elevenlabs.md`, `claude-cookbooks.md`, `playwright.md`, `replicate.md` (2026-05-18). |
 
 ## Action Plan for Remaining Work (Action C)
 The following tasks are identified for future Ralph-loop runs to maintain the "High Confidence" standard:

--- a/docs/reports/task-decomposition-batch-74.md
+++ b/docs/reports/task-decomposition-batch-74.md
@@ -7,10 +7,10 @@ This batch focuses on deepening the 5 oldest documentation issues by review date
 | Doc Path | Target Standard | Status | Notes |
 | :--- | :--- | :--- | :--- |
 | `docs/tools/agents/superpowers.md` | High Confidence | ✅ Completed | 10+ sections, 10+ links, technical examples (YAML/JSON). |
-| `docs/tools/ai_knowledge/elevenlabs.md` | High Confidence | ⏳ Pending | |
-| `docs/tools/development_ops/claude-cookbooks.md` | High Confidence | ⏳ Pending | |
-| `docs/tools/development_ops/playwright.md` | High Confidence | ⏳ Pending | |
-| `docs/tools/providers/replicate.md` | High Confidence | ⏳ Pending | |
+| `docs/tools/ai_knowledge/elevenlabs.md` | High Confidence | ✅ Completed | 18 sections, 10 links, cloning/streaming examples. |
+| `docs/tools/development_ops/claude-cookbooks.md` | High Confidence | ✅ Completed | 16 sections, 8 links, Python/TS examples. |
+| `docs/tools/development_ops/playwright.md` | High Confidence | ✅ Completed | 18 sections, 10 links, agentic browsing workflow. |
+| `docs/tools/providers/replicate.md` | High Confidence | ✅ Completed | 18 sections, 7 links, Cog/Multi-modal examples. |
 
 ## Requirements Checklist (High Confidence)
 - [ ] 10+ distinct sections (headers).
@@ -21,4 +21,4 @@ This batch focuses on deepening the 5 oldest documentation issues by review date
 
 ## Changelog
 - 2026-05-18: Initial decomposition created. Focus started on `superpowers.md`.
-- 2026-05-18: Deepened `superpowers.md` to High Confidence.
+- 2026-05-18: Deepened `superpowers.md`, `elevenlabs.md`, `claude-cookbooks.md`, `playwright.md`, and `replicate.md` to High Confidence. Batch 74 completed.

--- a/docs/tools/ai_knowledge/elevenlabs.md
+++ b/docs/tools/ai_knowledge/elevenlabs.md
@@ -34,6 +34,11 @@ AI & Knowledge — used for audio content generation and accessibility.
 - When simple, functional TTS (like built-in OS voices) is sufficient
 - When strict offline, local processing is a requirement for privacy or latency
 
+## Selection comments
+- ElevenLabs is the gold standard for high-fidelity, expressive AI voices, making it ideal for creative and marketing applications.
+- API stability and low latency (especially with `turbo` models) make it suitable for production-grade real-time interactions.
+- Consider costs at scale; for high-volume, low-complexity tasks, explore cheaper alternatives like [Google Search](google-search.md) (TTS) or [Whisper](../../services/whisper.md) for related tasks.
+
 ## Getting started
 
 ### Installation
@@ -93,6 +98,40 @@ for chunk in audio_generator:
         pass
 ```
 
+## Voice Cloning
+ElevenLabs provides two levels of voice cloning:
+1. **Instant Voice Cloning**: Requires as little as 1 minute of audio. Ideal for quick prototypes.
+2. **Professional Voice Cloning**: Requires 30-180 minutes of high-quality audio. Provides a near-perfect digital twin.
+
+```python
+# Professional Voice Cloning trigger (conceptual)
+voice = client.clone(
+    name="My Professional Voice",
+    files=["sample1.mp3", "sample2.mp3"],
+    description="A professional clone for branding."
+)
+```
+
+## Real-time Streaming
+For low-latency applications (e.g., AI agents), use the WebSocket API or the streaming parameter in the SDK to start playback before the entire file is generated.
+
+```python
+from elevenlabs import stream
+
+audio_stream = client.generate(
+    text="Hello, I am speaking to you in real-time.",
+    stream=True
+)
+
+stream(audio_stream)
+```
+
+## Example workflow
+1. **Scripting**: Generate a script using [Google Gemini](google-gemini.md).
+2. **Audio Generation**: Use ElevenLabs API to generate audio with a specific emotional profile.
+3. **Video Synthesis**: Use the generated audio as input for [Synthesia](synthesia.md) or [Luma Dream Machine](luma-dream-machine.md) to create an AI avatar video.
+4. **Distribution**: Automate the publishing workflow using [Copy.ai](copy-ai.md).
+
 ## Related tools / concepts
 
 - [Synthesia](synthesia.md)
@@ -100,10 +139,14 @@ for chunk in audio_generator:
 - [AI Templates](aitmpl.md)
 - [Google Gemini](google-gemini.md)
 - [Google Opal](google-opal.md)
+- [Luma Dream Machine](luma-dream-machine.md)
+- [RunwayML](runwayml.md)
+- [Sora](sora.md)
+- [Copy.ai](copy-ai.md)
 ## Sources / references
 - [Official Website](https://elevenlabs.io/)
 - [Documentation](https://elevenlabs.io/docs)
 
 ## Contribution Metadata
-- Last reviewed: 2026-03-14
+- Last reviewed: 2026-05-18
 - Confidence: high

--- a/docs/tools/development_ops/claude-cookbooks.md
+++ b/docs/tools/development_ops/claude-cookbooks.md
@@ -33,6 +33,59 @@ It gives teams a practical set of implementation examples so they do not have to
 ## When not to use it
 - When you need a production-ready architecture without further engineering
 
+## Common Patterns
+The cookbooks are organized around several core patterns:
+- **RAG (Retrieval-Augmented Generation)**: Using Claude with vector databases.
+- **Tool Use (Function Calling)**: Defining and executing tools to interact with the real world.
+- **Prompt Engineering**: System prompt design and multi-shot examples.
+- **Output Structuring**: Forcing Claude to return valid JSON or specific schemas.
+
+## Contribution Guide
+Developers can contribute to the community-driven sections by:
+1. Forking the `claude-cookbooks` repository.
+2. Adding a new notebook or Python script in the relevant category.
+3. Submitting a Pull Request with a clear explanation of the new pattern.
+
+## Technical Examples
+
+### Python: Using a Cookbook Pattern for JSON Extraction
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+# Based on 'Structured Output' cookbook pattern
+response = client.messages.create(
+    model="claude-3-5-sonnet-20240620",
+    max_tokens=1024,
+    system="You are a data extractor. Always return JSON.",
+    messages=[{"role": "user", "content": "Extract name and age: John Doe is 30."}]
+)
+print(response.content)
+```
+
+### TypeScript: Async Streaming Implementation
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+
+const anthropic = new Anthropic();
+
+// Based on 'Streaming' cookbook pattern
+async function main() {
+  const stream = await anthropic.messages.create({
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: 'Explain quantum physics.' }],
+    model: 'claude-3-5-sonnet-20240620',
+    stream: true,
+  });
+  for await (const messageStreamEvent of stream) {
+    console.log(messageStreamEvent.type);
+  }
+}
+
+main();
+```
+
 ## Selection comments
 - Claude Cookbooks is first-party implementation guidance, not an architecture substitute.
 - Use it early in the build process, then move to your own patterns once the team knows what works.
@@ -43,10 +96,14 @@ It gives teams a practical set of implementation examples so they do not have to
 - [Claude Skills Ecosystem](../agents/claude-skills-ecosystem.md)
 - [Anthropic](../providers/anthropic.md)
 - [Context7](context7.md)
+- [LangChain](../ai_knowledge/langchain.md)
+- [LlamaIndex](../ai_knowledge/llamaindex.md)
+- [DSPy](../frameworks/dspy.md)
+- [Flowise](../ai_knowledge/flowise.md)
 
 ## Sources / References
 - [GitHub Repository](https://github.com/anthropics/claude-cookbooks)
 
 ## Contribution Metadata
-- Last reviewed: 2026-03-14
+- Last reviewed: 2026-05-18
 - Confidence: high

--- a/docs/tools/development_ops/playwright.md
+++ b/docs/tools/development_ops/playwright.md
@@ -31,6 +31,65 @@ It gives teams a reliable way to automate browsers for testing, scraping, and UI
 - When an API integration is available and sufficient
 - When the maintenance cost of browser flows outweighs the value
 
+## Selection comments
+- Playwright is the preferred tool for high-reliability browser automation due to its "auto-wait" features and robust selector engine.
+- For AI agent integration, use the [Playwright MCP](https://github.com/microsoft/playwright-mcp) to give agents direct "eyes" on a web page.
+- Combine with [Superpowers](../agents/superpowers.md) for verifiable UI testing and automation cycles.
+
+## CLI examples
+
+```bash
+# Install Playwright and browsers
+npm init playwright@latest
+
+# Generate code by recording your actions
+npx playwright codegen https://example.com
+
+# Run tests in headed mode
+npx playwright test --headed
+
+# Debugging with Playwright Inspector
+PWDEBUG=1 npx playwright test
+```
+
+## API examples
+
+### Basic Page Interaction (TypeScript)
+```typescript
+import { chromium } from 'playwright';
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('https://news.ycombinator.com');
+
+  // Extract data from the page
+  const titles = await page.$$eval('.titleline > a', links =>
+    links.map(link => link.textContent)
+  );
+
+  console.log(titles);
+  await browser.close();
+})();
+```
+
+### Visual Regression Testing
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('homepage visual check', async ({ page }) => {
+  await page.goto('https://example.com');
+  await expect(page).toHaveScreenshot('homepage.png');
+});
+```
+
+## Example workflow: Agentic Browsing
+1. **Trigger**: An agent receives a request to find the price of a specific product on a site without an API.
+2. **Execution**: The agent uses the [Playwright MCP](https://github.com/microsoft/playwright-mcp) to launch a Chromium instance.
+3. **Navigation**: The agent instructs Playwright to `page.goto()`, `page.fill()` (search bar), and `page.click()`.
+4. **Extraction**: The agent parses the DOM for price elements using CSS selectors or text matching.
+5. **Verification**: Playwright takes a screenshot of the results to provide visual proof to the user.
+
 ## Licensing and cost
 - **Open Source**: Yes
 - **Cost**: Free
@@ -40,6 +99,12 @@ It gives teams a reliable way to automate browsers for testing, scraping, and UI
 - [Browser Use](../automation_orchestration/browser-use.md)
 - [Claude Hooks](claude-hooks.md)
 - [n8n](../../services/n8n.md)
+- [GitHub Copilot](github_copilot.md)
+- [VS Code](vscode.md)
+- [Aider](aider.md)
+- [Cursor](cursor.md)
+- [Superpowers](../agents/superpowers.md)
+- [Claude Skills Ecosystem](../agents/claude-skills-ecosystem.md)
 
 ## Sources / References
 - [Official Website](https://playwright.dev/)
@@ -47,5 +112,5 @@ It gives teams a reliable way to automate browsers for testing, scraping, and UI
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp)
 
 ## Contribution Metadata
-- Last reviewed: 2026-03-14
+- Last reviewed: 2026-05-18
 - Confidence: high

--- a/docs/tools/providers/replicate.md
+++ b/docs/tools/providers/replicate.md
@@ -15,12 +15,14 @@ Eliminates the significant complexity of managing GPU infrastructure, Docker con
 - **Scaling Custom Models**: Moving from a local experiment to a production-ready API instantly using their Cog tool.
 
 ## Getting started
+
+### Installation
 Install the SDK:
 ```bash
 pip install replicate
 ```
 
-Basic API call (Llama 3):
+### Basic API call (Llama 3)
 ```python
 import replicate
 
@@ -31,6 +33,46 @@ output = replicate.run(
 for item in output:
     print(item, end="")
 ```
+
+## CLI examples
+
+```bash
+# Run a model from the CLI
+replicate run \
+  -e REPLICATE_API_TOKEN=$REPLICATE_API_TOKEN \
+  meta/llama-2-70b-chat:02e509c789964a7ea473f0d4580c14dec5cb44d32623e20b3296c68a9f34595e \
+  -input "prompt=Who is the CEO of Replicate?"
+
+# Deploy your own model with Cog
+cog predict -i prompt="a futuristic city"
+```
+
+## API examples
+
+### Multi-modal Generation (Image to Video)
+```python
+import replicate
+
+# 1. Generate an image first
+image_url = replicate.run(
+    "stability-ai/sdxl:7762fd0e182511030058e3540099083bc9f5a4813359d9857a878184d34d7c43",
+    input={"prompt": "A serene mountain lake at sunset"}
+)
+
+# 2. Animate the image using Stable Video Diffusion
+video = replicate.run(
+    "stability-ai/stable-video-diffusion:3f04571484b857470f394129e710ea5575773958ef4ac2958cf5d6f5f40177e2",
+    input={"input_image": image_url}
+)
+print(video)
+```
+
+## Example workflow
+1. **Model Discovery**: Use the [Model Explorer](https://replicate.com/explore) to find a model that fits your task (e.g., background removal).
+2. **Integration**: Add the `replicate` SDK to your app and use a few-shot prompt or specific input parameters.
+3. **Packaging**: If you have a custom model, package it using **Cog** (defining `cog.yaml` and `predict.py`).
+4. **Deployment**: Run `replicate deploy` to create a production-ready endpoint for your custom model.
+5. **Orchestration**: Link your Replicate endpoints with [n8n](../../services/n8n.md) or [Flowise](../ai_knowledge/flowise.md) for automated media pipelines.
 
 ## Strengths
 - **Unrivaled Variety**: Hosts thousands of models for text, image, video, audio, and specialized ML tasks.
@@ -51,6 +93,12 @@ for item in output:
 - For high-volume, low-latency LLM-only applications where serverless providers like Groq excel.
 - If you need the extreme proprietary reasoning of models like GPT-4o.
 
+## Selection comments
+- Replicate is the gold standard for multi-modal "Swiss Army Knife" access, particularly for image, video, and audio generation.
+- The **Cog** ecosystem makes it the best choice for developers who want to move from a local PyTorch/TensorFlow environment to a cloud API with zero infrastructure management.
+- For high-volume LLM-only workloads, consider [Groq](groq.md) or [Together AI](together.md) for lower latency and cost.
+- It complements [Tavily](tavily.md) and [Supabase](../infrastructure/supabase.md) well in stacks that need retrieval plus generated media assets.
+
 ## Practical notes
 - Replicate is especially strong when one workflow mixes multiple modalities, for example image generation, speech, and video transforms in the same pipeline.
 - It is often simpler to prototype on Replicate first and only later migrate hot paths to a more specialized provider.
@@ -68,6 +116,8 @@ for item in output:
 - [OpenRouter](../ai_knowledge/openrouter.md)
 - [Tavily](tavily.md)
 - [Supabase](../infrastructure/supabase.md)
+- [Groq](groq.md)
+- [Fireworks](fireworks.md)
 
 ## Sources / References
 - [Official Website](https://replicate.com/)
@@ -75,5 +125,5 @@ for item in output:
 - [Model Explorer](https://replicate.com/explore)
 
 ## Contribution Metadata
-- Last reviewed: 2026-03-14
+- Last reviewed: 2026-05-18
 - Confidence: high


### PR DESCRIPTION
Deepened 5 oldest documentation issues (Batch 74) to High Confidence standards. This included adding technical examples, increasing section counts, and ensuring robust internal linking for `elevenlabs.md`, `claude-cookbooks.md`, `playwright.md`, and `replicate.md`. Tracking reports were updated to reflect completion.

---
*PR created automatically by Jules for task [16349751225393846518](https://jules.google.com/task/16349751225393846518) started by @joanmarcriera*