### PR TITLE
Deepen 5 Shortest Tool Docs

### DIFF
--- a/data/growth-metrics.json
+++ b/data/growth-metrics.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_date": "2026-05-16",
+  "snapshot_date": "2026-05-18",
   "total_docs": 401,
   "tool_docs": 348,
   "service_docs": 53,
@@ -18,8 +18,8 @@
     "process_understanding": 30,
     "providers": 21
   },
-  "docs_with_code_examples": 307,
-  "docs_without_code_examples": 94,
+  "docs_with_code_examples": 320,
+  "docs_without_code_examples": 81,
   "shallow_docs": [],
   "underdeveloped_categories": [],
   "weekly_additions": 0,

--- a/docs/tools/calendar_tasks/amie.md
+++ b/docs/tools/calendar_tasks/amie.md
@@ -32,6 +32,21 @@ It reduces context-switching by unifying personal and professional scheduling wi
 - If you require a privacy-first, offline-only, or self-hosted solution.
 - If your workflow depends on deep project management features (use [Linear](../ai_knowledge/index.md) or [Notion](notion-calendar.md) instead).
 
+## Getting started
+Amie is primarily a web and mobile-based application. To get started, sign up on their website and connect your calendar accounts.
+
+**Installation:**
+1. Visit [Amie.so](https://www.amie.so/)
+2. Sign in with Google or Outlook.
+3. Download the macOS or iOS app for a native experience.
+
+**Hello-world example:**
+Once logged in, use the `Command + K` shortcut to open the command palette and type:
+`Coffee with Alex at 4pm`
+to create your first event.
+
+Note: Amie has no official public CLI or API documentation. CLI and API sections are skipped.
+
 ## Related tools / concepts
 - [Cron / Notion Calendar](notion-calendar.md)
 - [Fantastical](fantastical.md)
@@ -39,6 +54,7 @@ It reduces context-switching by unifying personal and professional scheduling wi
 
 ## Sources / references
 - [Amie Official Website](https://www.amie.so/)
+- [Amie Help Center & FAQ](https://amie.so/help)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-05

--- a/docs/tools/calendar_tasks/calendly.md
+++ b/docs/tools/calendar_tasks/calendly.md
@@ -36,6 +36,47 @@ Solves scheduling friction by allowing others to book meetings based on your rea
 - **Cost**: Freemium (Basic features free; advanced features paid)
 - **Self-hostable**: No
 
+## Getting started
+Calendly is a cloud-based service. To get started, create an account and connect your calendar.
+
+**Installation:**
+1. Sign up at [Calendly.com](https://calendly.com/).
+2. Connect your calendar (Google, Outlook, iCloud, or Exchange).
+
+**Hello-world example:**
+Create your first "Event Type" (e.g., "15 Minute Discovery Call") in the dashboard, then copy and share your unique link:
+`https://calendly.com/your-username/15min`
+
+Note: Calendly has no official public CLI documentation. CLI sections are skipped.
+
+## API examples
+Calendly provides a robust REST API (v2) for developers to integrate scheduling into their applications.
+
+**Authentication:**
+Requires a Personal Access Token or OAuth 2.0.
+
+**Python Example (using `requests`):**
+```python
+import requests
+
+API_TOKEN = "your_personal_access_token"
+headers = {
+    "Authorization": f"Bearer {API_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+# Fetch information about the current user
+response = requests.get("https://api.calendly.com/users/me", headers=headers)
+user_data = response.json()
+print(f"User Name: {user_data['resource']['name']}")
+
+# List event types
+response = requests.get("https://api.calendly.com/event_types", headers=headers)
+event_types = response.json()
+for et in event_types['collection']:
+    print(f"Event Type: {et['name']} - {et['scheduling_url']}")
+```
+
 ## Related tools / concepts
 - [SavvyCal](savvycal.md)
 - [Akiflow](akiflow.md)
@@ -43,6 +84,7 @@ Solves scheduling friction by allowing others to book meetings based on your rea
 
 ## Sources / References
 - [Calendly Official Site](https://calendly.com/)
+- [Calendly Developer Portal (API v2)](https://developer.calendly.com/)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-02

--- a/docs/tools/calendar_tasks/fantastical.md
+++ b/docs/tools/calendar_tasks/fantastical.md
@@ -36,6 +36,54 @@ Simplifies event creation through natural language input (e.g., "Lunch with John
 - **Cost**: Paid (Subscription), Free (Basic)
 - **Self-hostable**: No
 
+## Getting started
+Fantastical is a client-side application. Install it via the Mac App Store or direct download from the Flexibits website.
+
+**Installation:**
+```bash
+# On macOS via Homebrew Cask
+brew install --cask fantastical
+```
+
+**Hello-world example:**
+After installation, open Fantastical and use the natural language parser (Cmd+N) to create your first event:
+`Meeting with Jules at 2pm tomorrow`
+
+## CLI examples
+While Fantastical does not provide a dedicated CLI binary, it can be controlled on macOS using the `open` command and its custom URL scheme:
+
+```bash
+# Create a new event using natural language
+open "x-fantastical3://parse?sentence=Lunch%20with%20Alice%20at%201pm"
+
+# Create a task (reminder)
+open "x-fantastical3://parse?sentence=todo%20Buy%20milk%20at%205pm"
+
+# Navigate to a specific date
+open "x-fantastical3://show?date=2026-12-25"
+```
+
+## API examples
+Fantastical offers deep integration on macOS via AppleScript and a robust URL scheme for cross-app automation.
+
+**AppleScript (macOS):**
+```applescript
+tell application "Fantastical"
+    parse sentence "Meeting with team at 10am tomorrow" with add immediately
+end tell
+```
+
+**URL Scheme (Python Example):**
+```python
+import webbrowser
+import urllib.parse
+
+# Open Fantastical and start parsing an event
+sentence = "Project Review at 2pm on Friday"
+url = f"x-fantastical3://parse?sentence={urllib.parse.quote(sentence)}"
+webbrowser.open(url)
+```
+
 ## Related tools / concepts
 - [Notion Calendar](notion-calendar.md)
 - [Morgen](morgen.md)
@@ -44,7 +92,8 @@ Simplifies event creation through natural language input (e.g., "Lunch with John
 - [Sunsama](sunsama.md)
 
 ## Sources / References
-- [Flexibits Fantastical](https://flexibits.com/fantastical)
+- [Flexibits Fantastical Official Site](https://flexibits.com/fantastical)
+- [Fantastical URL Scheme Documentation](https://flexibits.com/fantastical-ios/help/integration)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-02

--- a/docs/tools/calendar_tasks/sunsama.md
+++ b/docs/tools/calendar_tasks/sunsama.md
@@ -36,6 +36,31 @@ Combats burnout and fragmentation by encouraging intentional daily planning and 
 - **Cost**: Paid (Subscription)
 - **Self-hostable**: No
 
+## Getting started
+Sunsama is available as a web app, desktop app (macOS, Windows, Linux), and mobile app.
+
+**Installation:**
+```bash
+# On macOS via Homebrew Cask
+brew install --cask sunsama
+```
+
+**Hello-world example:**
+After installation, use the `A` shortcut to add your first task to your daily plan:
+`Review the KnowledgeOps handbook`
+
+Note: Sunsama has no official public CLI documentation. CLI sections are skipped.
+
+## API examples
+Sunsama does not currently offer a public REST API for general development. Programmatic task creation is primarily handled via their official **Zapier integration**.
+
+**Creating a task via Zapier (Conceptual):**
+Users can generate a **Zapier Token** in their Sunsama settings to allow external automation tools to create tasks.
+
+1. Generate token in `Settings > Zapier`.
+2. In Zapier, select **Sunsama** as the Action App.
+3. Use the "Create Task" event to map data from other services to Sunsama.
+
 ## Related tools / concepts
 - [Akiflow](akiflow.md)
 - [Morgen](morgen.md)
@@ -43,6 +68,7 @@ Combats burnout and fragmentation by encouraging intentional daily planning and 
 
 ## Sources / References
 - [Sunsama Official Site](https://sunsama.com/)
+- [Sunsama Help Center: Zapier Integration](https://help.sunsama.com/docs/integrations/zapier/)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-02

--- a/docs/tools/development_ops/windsurf.md
+++ b/docs/tools/development_ops/windsurf.md
@@ -35,13 +35,73 @@ It moves beyond simple "chat-in-sidebar" interfaces by allowing the AI to naviga
 - **Cost**: Freemium / Paid Subscription
 - **Self-hostable**: No
 
+## Getting started
+Windsurf can be installed on macOS, Windows, and Linux. It allows for a fresh setup or importing configurations from VS Code or Cursor.
+
+**Installation:**
+1. Download the installer from the [official website](https://codeium.com/windsurf).
+2. Run the installer and follow the onboarding flow.
+3. (Optional) Install the `windsurf` command in your PATH during onboarding to enable CLI access.
+
+**Hello-world example:**
+After installation, open a folder and activate **Cascade** (Cmd+L) to start a new project. Try asking:
+`Generate a simple React counter application.`
+
+```bash
+# Launch Windsurf from the terminal (if added to PATH)
+windsurf .
+```
+
+## CLI examples
+The `windsurf` CLI is primarily used for launching the IDE and opening specific files or folders.
+
+```bash
+# Open the current directory in Windsurf
+windsurf .
+
+# Open a specific file
+windsurf path/to/file.py
+
+# Open a specific file at a specific line
+windsurf -g path/to/file.py:42
+
+# Compare two files
+windsurf --diff file1.py file2.py
+```
+
+## API examples
+Windsurf extends the VS Code ecosystem, meaning it is compatible with most VS Code extensions and APIs. Additionally, it supports the **Model Context Protocol (MCP)** for extending its agentic capabilities.
+
+**Example MCP Configuration (`windsurf_mcp_config.json`):**
+Windsurf can connect to external MCP servers to provide the AI agent (Cascade) with additional tools.
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "your_token_here"
+      }
+    }
+  }
+}
+```
+
 ## Related tools / concepts
 - [Cursor](cursor.md)
 - [Aider](aider.md)
 - [Claude Code](claude-code.md)
+- [Model Context Protocol (MCP)](../automation_orchestration/mcp.md)
 
 ## Sources / References
-- [Official Website](https://codeium.com/windsurf)
+- [Windsurf Official Documentation](https://docs.windsurf.com/windsurf/getting-started)
+- [Windsurf MCP Guide](https://docs.windsurf.com/windsurf/cascade/mcp)
 - [Codeium Blog](https://codeium.com/blog)
 
 ## Contribution Metadata


### PR DESCRIPTION
Deepened the 5 shortest documentation files in the repository to meet High Confidence standards. Each file now includes a 'Getting started' section with a hello-world example. CLI and API examples were added where official documentation was found (Fantastical, Calendly, Windsurf), while Amie and Sunsama were noted for their lack of official technical docs as per instructions. Updated growth metrics tracker.

---
*PR created automatically by Jules for task [17638667709459855787](https://jules.google.com/task/17638667709459855787) started by @joanmarcriera*