### PR TITLE
Deepen 5 oldest non-compliant docs to High Confidence (Batch 81)

### DIFF
--- a/data/growth-metrics.json
+++ b/data/growth-metrics.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_date": "2026-05-19",
+  "snapshot_date": "2026-05-20",
   "total_docs": 406,
   "tool_docs": 353,
   "service_docs": 53,
@@ -18,8 +18,8 @@
     "process_understanding": 30,
     "providers": 21
   },
-  "docs_with_code_examples": 333,
-  "docs_without_code_examples": 73,
+  "docs_with_code_examples": 345,
+  "docs_without_code_examples": 61,
   "shallow_docs": [],
   "underdeveloped_categories": [],
   "weekly_additions": 0,

--- a/docs/reports/task-decomposition-batch-81.md
+++ b/docs/reports/task-decomposition-batch-81.md
@@ -1,0 +1,24 @@
+# Task Decomposition — Batch 81 (Technical Deepening: Oldest Non-Compliant Docs)
+
+This batch focuses on deepening the 5 oldest non-compliant documentation files to meet 'High Confidence' standards.
+
+## Progress Tracking
+
+| Doc Path | Target Standard | Status | Notes |
+| :--- | :--- | :--- | :--- |
+| `docs/tools/providers/aws-bedrock.md` | High Confidence | ✅ Completed | Enterprise-grade foundation model API. |
+| `docs/tools/automation_orchestration/pulse-mcp.md` | High Confidence | ✅ Completed | System monitoring and alerting via MCP. |
+| `docs/tools/benchmarking/alpaca-eval.md` | High Confidence | ✅ Completed | Simulator-based LLM evaluation. |
+| `docs/tools/benchmarking/math-benchmark.md` | High Confidence | ✅ Completed | Mathematical reasoning benchmark. |
+| `docs/tools/benchmarking/mt-bench.md` | High Confidence | ✅ Completed | Multi-turn conversation benchmark. |
+
+## Requirements Checklist (High Confidence)
+- [x] 10+ distinct sections (headers).
+- [x] 7+ unique relative markdown links to other project files.
+- [x] Advanced technical examples (CLI, API, or YAML).
+- [x] Validated against `audit_docs_quality.py`.
+- [x] Validated against `check_docs_contract.py`.
+
+## Changelog
+- 2026-05-20: Initial decomposition created for Batch 81.
+- 2026-05-20: All 5 documents deepened to High Confidence. Batch 81 complete.

--- a/docs/tools/automation_orchestration/pulse-mcp.md
+++ b/docs/tools/automation_orchestration/pulse-mcp.md
@@ -1,46 +1,121 @@
 # PulseMCP
 
 ## What it is
-PulseMCP is a community-driven registry and framework for the Model Context Protocol (MCP). It provides a platform for discovering, exploring, and sharing MCP servers and integrations.
+PulseMCP is a community-driven registry and framework for the Model Context Protocol (MCP). It provides a platform for discovering, exploring, and sharing MCP servers and integrations, effectively acting as an "app store" for the MCP ecosystem.
 
 ## What problem it solves
-It simplifies the discovery of MCP-compliant tools and servers, which otherwise might be scattered across various repositories (GitHub, npm, PyPI). It provides a centralized "app store" experience for the MCP ecosystem.
+The MCP ecosystem is rapidly expanding, with hundreds of servers being developed across various platforms (GitHub, npm, PyPI). PulseMCP solves the discovery problem by providing a centralized, searchable repository of MCP-compliant tools, complete with metadata, usage examples, and community ratings.
 
 ## Where it fits in the stack
 **Automation & Orchestration / Tool Discovery**. It acts as a metadata layer and discovery service for LLM-powered agents to find and utilize standardized tools.
 
 ## Typical use cases
-- Discovering new MCP servers for specific tasks (e.g., web scraping, analytics).
-- Browsing community-contributed integrations for popular AI clients.
-- Publishing and sharing custom MCP servers with the wider community.
+- **Tool Discovery**: Finding specific MCP servers for tasks like web scraping, database interaction, or API management.
+- **Integration Research**: Exploring how different MCP servers can be combined to form complex agentic workflows.
+- **Community Contribution**: Publishing and sharing custom-built MCP servers with other developers.
+
+## Getting started
+
+### 1. Exploration
+Browse the [PulseMCP website](https://pulsemcp.com/) to find servers categorized by function (e.g., Development, Data, Search).
+
+### 2. Implementation (Node.js example)
+Many Pulse-listed servers can be installed via `npm` and run directly.
+
+```bash
+# Example: Installing a search MCP server listed on Pulse
+npm install -g @modelcontextprotocol/server-google-search
+```
+
+### 3. Configuration in Claude Desktop
+To use a Pulse-discovered server in Claude Desktop, add it to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "google-search": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-google-search"
+      ],
+      "env": {
+        "GOOGLE_API_KEY": "your_api_key",
+        "GOOGLE_SEARCH_ENGINE_ID": "your_engine_id"
+      }
+    }
+  }
+}
+```
+
+## Technical Architecture
+PulseMCP serves as a registry that indexes MCP servers based on their capabilities, transport methods (stdio, SSE), and required environment variables.
+- **Capability Discovery**: Indexes servers that support specific MCP primitives like `tools`, `resources`, and `prompts`.
+- **Validation Layer**: (In development) Automated checks to ensure listed servers adhere to the MCP specification.
+- **Search API**: Allows programmatic discovery of tools by AI agents.
+
+## Server Configuration Example (YAML)
+For tools like `mcp-cli` or custom orchestrators, you might define Pulse servers in a YAML format:
+
+```yaml
+mcp_servers:
+  postgres-tool:
+    command: "docker"
+    args: ["run", "-i", "--rm", "mcp/postgres-server"]
+    env:
+      DATABASE_URL: "postgresql://user:pass@localhost:5432/db"
+
+  weather-tool:
+    command: "npx"
+    args: ["-y", "@pulsemcp/weather-server"]
+    env:
+      OPENWEATHER_API_KEY: "secret_key"
+```
+
+## Community Features
+- **Starring & Rating**: Users can star servers to indicate quality and reliability.
+- **Categorization**: Servers are tagged by domain (e.g., `devops`, `ai-research`, `productivity`).
+- **Standardized Readmes**: Encourages developers to provide clear installation and usage instructions.
 
 ## Strengths
-- **Community-Driven**: Leverages collective contributions to expand the MCP ecosystem.
-- **Discovery**: Provides a structured way to find tools that follow the MCP standard.
-- **Open Source**: The framework and many listed servers are open source.
+- **Centralized Discovery**: Significantly reduces the time to find and implement new agent capabilities.
+- **Community Ecosystem**: Leverages the "wisdom of the crowd" to identify high-quality tools.
+- **Standardized Metadata**: Makes it easier for automated agents to understand tool requirements.
 
 ## Limitations
-- **Ecosystem Maturity**: As a community registry, the quality and reliability of listed servers can vary.
-- **Official vs. Community**: Users must distinguish between officially maintained servers and community-contributed ones.
+- **Varying Quality**: As a community registry, the reliability of individual servers can vary significantly.
+- **Maintenance**: Some listed servers may become stale or broken if not actively maintained by their authors.
+- **Security**: Users must exercise caution when running community-contributed code in their local environments.
 
 ## When to use it
 - When looking for pre-built MCP servers to extend the capabilities of an AI agent or client.
 - When wanting to explore the variety of tools available in the MCP ecosystem.
+- When you have built a useful MCP server and want to share it with the community.
 
 ## When not to use it
 - If you require strictly vetted, enterprise-grade tools with guaranteed support (until specific servers are verified).
-- If the official MCP registry (from Anthropic or others) already covers your specific needs.
+- For highly sensitive tasks where only officially maintained or internally audited servers should be used.
+
+## Licensing and cost
+- **Open Source**: Yes (Registry framework)
+- **Cost**: Free to browse and list; individual servers follow their own licensing.
+- **Self-hostable**: Yes (Framework)
 
 ## Related tools / concepts
-- [MCP Registry](mcp-registry.md)
-- [Model Context Protocol (MCP)](../../knowledge_base/patterns/tool-calling-and-mcp.md)
-- [Anthropic Claude](../../tools/providers/anthropic.md)
+- [MCP Registry](mcp-registry.md) - The official or semi-official directory of MCP servers.
+- [Model Context Protocol (MCP)](../../knowledge_base/patterns/tool-calling-and-mcp.md) - The underlying protocol.
+- [Claude Desktop](../../tools/development_ops/claude-context-mode.md) - A primary client for MCP servers.
+- [Playwright MCP Server](../automation_orchestration/playwright-mcp.md) - A high-value server often featured in registries.
+- [HashiCorp Vault MCP](../automation_orchestration/hashicorp-vault.md) - Example of a security-focused MCP server.
+- [Aider](../../tools/development_ops/aider.md) - An AI coding tool that can utilize MCP servers.
+- [Cline](../../tools/agents/cline.md) - Agent that supports MCP integration.
 
 ## Sources / references
 - [PulseMCP Official Website](https://pulsemcp.com/)
 - [PulseMCP GitHub](https://github.com/pulsemcp)
 - [MCP Market - Pulse Servers](https://mcpmarket.com/server/pulse-servers)
+- [Anthropic MCP Documentation](https://modelcontextprotocol.io/)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-08
+- Last reviewed: 2026-05-20
 - Confidence: high

--- a/docs/tools/benchmarking/alpaca-eval.md
+++ b/docs/tools/benchmarking/alpaca-eval.md
@@ -4,7 +4,7 @@
 AlpacaEval is an automatic evaluator for instruction-following language models. It is designed to be fast, cheap, and highly correlated with human preferences. It measures the win rate of a model's outputs against a reference model (typically GPT-4 or GPT-4 Turbo) using an LLM-based automatic annotator.
 
 ## What problem it solves
-Evaluation of instruction-following models typically requires human interaction, which is time-consuming, expensive, and difficult to replicate. AlpacaEval provides a replicable, automated proxy that allows developers to iterate quickly on model development.
+Evaluation of instruction-following models typically requires human interaction, which is time-consuming, expensive, and difficult to replicate. AlpacaEval provides a replicable, automated proxy that allows developers to iterate quickly on model development by simulating human preference judgments.
 
 ## Where it fits in the stack
 **Benchmarking**. It serves as a middle-ground evaluation tool between static, objective benchmarks (like MMLU) and slow, expensive human evaluations (like Chatbot Arena).
@@ -14,10 +14,64 @@ Evaluation of instruction-following models typically requires human interaction,
 - **Comparative Analysis**: Measuring how a new model performs against established baselines like GPT-4.
 - **Prompt Engineering**: Testing the impact of different system prompts on model performance.
 
+## Getting started
+
+### 1. Installation
+```bash
+pip install alpaca_eval
+```
+
+### 2. Configuration
+Set your API key for the evaluator model (e.g., OpenAI API for GPT-4).
+
+```bash
+export OPENAI_API_KEY="your_api_key"
+```
+
+### 3. Running an Evaluation
+AlpacaEval requires a JSON or JSONL file containing the model's outputs for the evaluation set.
+
+```bash
+# Evaluate your model outputs
+alpaca_eval --model_outputs 'path/to/your_model_outputs.json'
+```
+
+## Technical Methodology
+AlpacaEval 2.0 uses a length-controlled win rate to address the "verbosity bias" where LLMs (and humans) tend to prefer longer, more detailed responses regardless of quality.
+- **Reference Outputs**: Uses a gold standard set of responses from a strong model (GPT-4 Turbo).
+- **Annotator**: A powerful LLM (the "judge") is given the prompt and two anonymized responses, then asked to pick the better one.
+- **LC Win Rate**: Applies a statistical correction to ensure models aren't rewarded just for being wordy.
+
+## Leaderboard Integration
+Results are typically compared against the [official AlpacaEval leaderboard](https://tatsu-lab.github.io/alpaca_eval/), which ranks both open-source and proprietary models.
+- **Verified vs. Unverified**: Official rankings are verified by the Tatsu Lab team, but users can run local "unverified" evals for internal benchmarking.
+
+## CLI Reference
+Commonly used arguments for the `alpaca_eval` command:
+- `--model_outputs`: Path to the JSON file with model responses.
+- `--reference_outputs`: (Optional) Path to custom reference responses.
+- `--annotator_config`: Configuration for the judge model (defaults to `weighted_alpaca_eval_gpt4_turbo`).
+- `--output_path`: Where to save the evaluation summary and individual judgments.
+
+## Evaluation Data Format
+Input file should be a list of dictionaries:
+```json
+[
+  {
+    "instruction": "Explain quantum entanglement to a 5-year-old.",
+    "output": "Imagine you have two magic socks..."
+  },
+  {
+    "instruction": "Write a Python function to sort a list.",
+    "output": "def sort_list(my_list):\n    return sorted(my_list)"
+  }
+]
+```
+
 ## Strengths
 - **Speed and Cost**: Can run in less than 5 minutes for under $10.
-- **Human Correlation**: AlpacaEval 2.0 (with length-controlled win rates) has a 0.98 Spearman correlation with Chatbot Arena.
-- **Length Normalization**: Includes a "Length-Controlled" win rate to mitigate the common LLM bias of preferring longer outputs.
+- **Human Correlation**: AlpacaEval 2.0 has a 0.98 Spearman correlation with Chatbot Arena.
+- **Length Normalization**: Effectively mitigates the bias toward longer outputs.
 - **Reproducibility**: Uses fixed evaluation sets and cached annotations.
 
 ## Limitations
@@ -34,10 +88,13 @@ Evaluation of instruction-following models typically requires human interaction,
 - When you need to evaluate specific technical domains (e.g., medical, legal) that require expert verification.
 
 ## Related tools / concepts
-- [Chatbot Arena](chatbot-arena.md)
-- [MT-Bench](mt-bench.md)
-- [GPQA](gpqa.md)
-- [MMLU](mmlu.md)
+- [Chatbot Arena](chatbot-arena.md) - The "ground truth" human preference leaderboard.
+- [MT-Bench](mt-bench.md) - Multi-turn conversation benchmark.
+- [MMLU](mmlu.md) - Knowledge-based benchmark.
+- [GPQA](gpqa.md) - Expert-level reasoning benchmark.
+- [LM Evaluation Harness](lm-evaluation-harness.md) - Framework for running many benchmarks, including objective ones.
+- [OpenCompass](opencompass.md) - Comprehensive evaluation platform that integrates AlpacaEval.
+- [HELM](helm.md) - Holistic evaluation framework.
 
 ## Sources / references
 - [GitHub Repository](https://github.com/tatsu-lab/alpaca_eval)
@@ -45,5 +102,5 @@ Evaluation of instruction-following models typically requires human interaction,
 - [AlpacaFarm Project](https://github.com/tatsu-lab/alpaca_farm)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-08
+- Last reviewed: 2026-05-20
 - Confidence: high

--- a/docs/tools/benchmarking/math-benchmark.md
+++ b/docs/tools/benchmarking/math-benchmark.md
@@ -1,7 +1,7 @@
 # MATH Benchmark
 
 ## What it is
-The MATH benchmark is a dataset of 12,500 challenging competition mathematics problems. Each problem has a step-by-step solution and a final answer formatted in LaTeX. The problems range from introductory algebra to calculus and are drawn from various high school math competitions.
+The MATH benchmark is a dataset of 12,500 challenging competition mathematics problems. Each problem has a step-by-step solution and a final answer formatted in LaTeX. The problems range from introductory algebra to calculus and are drawn from various high school math competitions (AMC 10, AMC 12, AIME, etc.).
 
 ## What problem it solves
 Traditional math benchmarks (like GSM8K) often focus on elementary arithmetic and simple word problems. The MATH benchmark provides a much higher "ceiling" for evaluation, testing a model's ability to perform complex symbolic reasoning, multi-step proofs, and advanced problem-solving across diverse mathematical fields.
@@ -14,6 +14,49 @@ Traditional math benchmarks (like GSM8K) often focus on elementary arithmetic an
 - **Prompt Engineering for Logic**: Evaluating the effectiveness of Chain-of-Thought (CoT) or program-aided reasoning on difficult tasks.
 - **Model Specialized Training**: Using the MATH dataset (or the associated AMPS pretraining dataset) to fine-tune models for mathematical proficiency.
 
+## Getting started
+
+### 1. Accessing the Data
+The dataset is available on Hugging Face and can be loaded easily using the `datasets` library.
+
+```python
+from datasets import load_dataset
+
+# Load the competition math dataset
+dataset = load_dataset("competition_math")
+print(dataset['test'][0])
+```
+
+### 2. Evaluating with LM Evaluation Harness
+The easiest way to run the MATH benchmark is using the [LM Evaluation Harness](lm-evaluation-harness.md).
+
+```bash
+# Evaluate a model on the MATH benchmark
+python main.py \
+    --model hf \
+    --model_args pretrained=meta-llama/Llama-3-8B \
+    --tasks math \
+    --device cuda:0 \
+    --batch_size 8
+```
+
+### 3. Manual Verification (Example Problem)
+```text
+Problem: Let f(x) = x^2 + 2x + 1. Find f(3).
+Answer: \boxed{16}
+Solution: Substituting x = 3 into the expression, we get 3^2 + 2(3) + 1 = 9 + 6 + 1 = 16.
+```
+
+## Technical Methodology
+- **Subject Categorization**: Problems are divided into 7 subjects: Prealgebra, Algebra, Intermediate Algebra, Counting & Probability, Geometry, Number Theory, and Precalculus.
+- **Difficulty Levels**: Problems are ranked from Level 1 (easiest) to Level 5 (hardest).
+- **Evaluation Metric**: Typically use **Exact Match (EM)**. A model's output is parsed for the `\boxed{...}` content and compared to the ground truth.
+
+## Challenges in Math Evaluation
+- **Parsing**: LLMs often provide the correct logic but fail to format the final answer in the exact LaTeX string expected by the evaluator.
+- **Symbolic Equivalence**: Identifying that `$1/2$` and `$0.5$` are equivalent requires specialized math-aware parsing logic (often using `SymPy`).
+- **Chain of Thought (CoT)**: Performance on MATH is significantly higher when models are allowed to "think" or use a scratchpad before providing the final answer.
+
 ## Strengths
 - **High Difficulty**: Challenges even the most capable models, providing a clear differentiation in reasoning ability.
 - **Diverse Subjects**: Includes Algebra, Counting & Probability, Geometry, Number Theory, Prealgebra, Precalculus, and Intermediate Algebra.
@@ -22,21 +65,24 @@ Traditional math benchmarks (like GSM8K) often focus on elementary arithmetic an
 ## Limitations
 - **Format Sensitivity**: Models often struggle with the LaTeX formatting required for answers.
 - **Data Contamination**: As a widely used public dataset, there is a high risk that problems and solutions have leaked into the training data of newer models.
-- **Rigid Scoring**: Typically uses Exact Match (EM) for the final LaTeX string, which can penalize models for mathematically correct but differently formatted answers.
+- **Rigid Scoring**: Standard EM scoring can penalize models for mathematically correct but differently formatted answers.
 
 ## When to use it
 - When comparing the reasoning capabilities of "frontier" models.
-- When evaluating models specifically for scientific or mathematical applications.
+- When evaluating models specifically for scientific, engineering, or mathematical applications.
 
 ## When not to use it
 - For evaluating general conversational quality or creative writing.
 - When testing basic arithmetic (use [GSM8K](gsm8k.md) instead).
 
 ## Related tools / concepts
-- [GSM8K](gsm8k.md)
-- [ASDiv](asdiv.md)
-- [GPQA](gpqa.md)
-- [HumanEval](human-eval.md)
+- [GSM8K](gsm8k.md) - Grade school math word problems.
+- [ASDiv](asdiv.md) - Academic solver for diverse math word problems.
+- [GPQA](gpqa.md) - Expert-level reasoning across science and math.
+- [HumanEval](human-eval.md) - Coding benchmark (often correlates with math ability).
+- [BigCodeBench](bigcodebench.md) - Complex coding tasks.
+- [LM Evaluation Harness](lm-evaluation-harness.md) - The standard runner for this benchmark.
+- [OpenCompass](opencompass.md) - Includes MATH in its reasoning evaluation suite.
 
 ## Sources / references
 - [GitHub Repository](https://github.com/hendrycks/math)
@@ -44,5 +90,5 @@ Traditional math benchmarks (like GSM8K) often focus on elementary arithmetic an
 - [Hugging Face Dataset](https://huggingface.co/datasets/competition_math)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-08
+- Last reviewed: 2026-05-20
 - Confidence: high

--- a/docs/tools/benchmarking/mt-bench.md
+++ b/docs/tools/benchmarking/mt-bench.md
@@ -4,7 +4,7 @@
 MT-Bench is a benchmark designed to evaluate the multi-turn conversational capabilities of Large Language Models (LLMs). It consists of 80 high-quality, multi-turn questions across eight categories: writing, roleplay, extraction, reasoning, math, coding, knowledge I (STEM), and knowledge II (humanities/social science).
 
 ## What problem it solves
-Many traditional benchmarks only evaluate single-turn responses, failing to capture a model's ability to maintain context, follow instructions across multiple exchanges, and handle the dynamic nature of real-world conversations.
+Many traditional benchmarks only evaluate single-turn responses, failing to capture a model's ability to maintain context, follow instructions across multiple exchanges, and handle the dynamic nature of real-world conversations. MT-Bench specifically tests the "follow-up" capability of models.
 
 ## Where it fits in the stack
 **Benchmarking**. It is a core component of the LMSYS FastChat evaluation framework, providing a more rigorous test of conversational flow than single-turn evaluations.
@@ -14,6 +14,53 @@ Many traditional benchmarks only evaluate single-turn responses, failing to capt
 - **Model Comparison**: Ranking chat-tuned models based on their ability to handle complex, multi-step instructions.
 - **LLM-as-a-Judge Validation**: MT-Bench is often used with GPT-4 as a judge to provide automated, scalable scoring that correlates with human judgment.
 
+## Getting started
+
+### 1. Installation
+MT-Bench is part of the `fastchat` repository.
+
+```bash
+git clone https://github.com/lm-sys/FastChat.git
+cd FastChat
+pip install -e ".[model_worker,llm_judge]"
+```
+
+### 2. Generating Model Answers
+Generate answers for the 80 questions in MT-Bench using your local model or API.
+
+```bash
+python fastchat/llm_judge/gen_model_answer.py \
+    --model-path lmsys/vicuna-7b-v1.5 \
+    --model-id vicuna-7b-v1.5
+```
+
+### 3. Grading with LLM-as-a-Judge
+Use a strong model (like GPT-4) to grade the responses.
+
+```bash
+export OPENAI_API_KEY="your_api_key"
+python fastchat/llm_judge/gen_judgment.py \
+    --model-list vicuna-7b-v1.5 \
+    --parallel 2
+```
+
+### 4. Viewing Results
+```bash
+python fastchat/llm_judge/show_result.py
+```
+
+## Technical Methodology
+- **Two-Turn Structure**: Each question consists of an initial prompt and a pre-defined follow-up question that depends on the model's first answer.
+- **Categories**: 10 questions per category (Writing, Roleplay, Extraction, Reasoning, Math, Coding, STEM, Humanities).
+- **Scoring**: The judge model (GPT-4) assigns a score from 1 to 10 for each turn.
+- **Reference Models**: Scores are often compared against "anchor" models like GPT-3.5 and GPT-4.
+
+## Technical Architecture
+MT-Bench uses the **LLM-as-a-Judge** paradigm.
+- **Judge Model**: Usually GPT-4, which has been shown to have high agreement with human experts.
+- **Prompt Templates**: The judge is given specific templates for "pairwise comparison" (comparing two models) or "single answer grading" (scoring one model).
+- **Control for Biases**: Techniques like swapping the order of models in pairwise comparisons are used to mitigate "position bias."
+
 ## Strengths
 - **Multi-turn Focus**: Specifically designed to test conversation depth.
 - **Diverse Categories**: Covers a wide range of tasks from coding to roleplay.
@@ -22,8 +69,8 @@ Many traditional benchmarks only evaluate single-turn responses, failing to capt
 
 ## Limitations
 - **Judge Bias**: If using an LLM as a judge, it may inherit the biases of that judge (e.g., preference for certain styles or lengths).
-- **Scale**: With 80 questions, it is smaller than some "massive" benchmarks, though the multi-turn nature adds complexity.
-- **Static Nature**: Like all fixed benchmarks, it risks data contamination over time.
+- **Small Sample Size**: With only 80 questions, the results can have higher variance than larger benchmarks.
+- **Static Nature**: Like all fixed benchmarks, it risks data contamination as it is widely included in training sets.
 
 ## When to use it
 - When evaluating chat-tuned models where multi-turn interaction is a primary use case.
@@ -34,10 +81,13 @@ Many traditional benchmarks only evaluate single-turn responses, failing to capt
 - When you only need to measure narrow technical capabilities like raw code execution or mathematical proof (use specialized benchmarks instead).
 
 ## Related tools / concepts
-- [Chatbot Arena](chatbot-arena.md)
-- [AlpacaEval](alpaca-eval.md)
-- [GSM8K](gsm8k.md)
-- [HumanEval](human-eval.md)
+- [Chatbot Arena](chatbot-arena.md) - The primary leaderboard for human preferences.
+- [AlpacaEval](alpaca-eval.md) - Simulator-based evaluator for instruction following.
+- [GSM8K](gsm8k.md) - Basic math reasoning.
+- [MATH Benchmark](math-benchmark.md) - Advanced mathematical competition problems.
+- [HumanEval](human-eval.md) - Core coding benchmark.
+- [LM Evaluation Harness](lm-evaluation-harness.md) - Standard framework for single-turn benchmarks.
+- [OpenCompass](opencompass.md) - Comprehensive evaluation platform that supports MT-Bench.
 
 ## Sources / references
 - [FastChat GitHub (LLM Judge)](https://github.com/lm-sys/FastChat/tree/main/fastchat/llm_judge)
@@ -45,5 +95,5 @@ Many traditional benchmarks only evaluate single-turn responses, failing to capt
 - [LMSYS Leaderboard](https://arena.lmsys.org/leaderboard)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-08
+- Last reviewed: 2026-05-20
 - Confidence: high

--- a/docs/tools/providers/aws-bedrock.md
+++ b/docs/tools/providers/aws-bedrock.md
@@ -15,6 +15,94 @@ It simplifies the process of building and scaling generative AI applications by 
 - **Agentic Workflows**: Deploying autonomous agents that can execute multi-step tasks using AWS resources.
 - **Model Fine-tuning**: Customizing foundation models with private data.
 
+## Getting started
+
+### 1. Prerequisites
+- An AWS account with Bedrock access enabled for the desired models (e.g., Anthropic Claude).
+- AWS CLI configured with appropriate credentials.
+- Python 3.8+ for SDK usage.
+
+### 2. Installation
+```bash
+pip install boto3
+```
+
+### 3. Hello-world task (Python)
+```python
+import boto3
+import json
+
+bedrock = boto3.client(service_name='bedrock-runtime', region_name='us-east-1')
+
+prompt = "Explain the benefit of AWS Bedrock in one sentence."
+body = json.dumps({
+    "anthropic_version": "bedrock-2023-05-31",
+    "max_tokens": 100,
+    "messages": [{"role": "user", "content": prompt}]
+})
+
+response = bedrock.invoke_model(
+    body=body,
+    modelId='anthropic.claude-3-sonnet-20240229-v1:0'
+)
+
+response_body = json.loads(response.get('body').read())
+print(response_body['content'][0]['text'])
+```
+
+## Technical Architecture
+AWS Bedrock operates as a serverless orchestrator between the user and the hosted models.
+- **Bedrock Runtime**: The data plane API for model invocation and streaming.
+- **Bedrock Control Plane**: The API for managing model access, custom models, and provisioning throughput.
+- **Provisioned Throughput**: Allows for dedicated capacity for specific models to ensure consistent latency.
+- **Knowledge Bases**: Integrates with vector databases (like Amazon OpenSearch or Aurora) for managed RAG.
+
+## SDK Example: Streaming Response
+For low-latency applications, streaming allows the UI to display tokens as they are generated.
+
+```python
+import boto3
+import json
+
+client = boto3.client(service_name='bedrock-runtime')
+
+def stream_claude(prompt):
+    body = json.dumps({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 512,
+        "messages": [{"role": "user", "content": prompt}]
+    })
+
+    response = client.invoke_model_with_response_stream(
+        modelId='anthropic.claude-3-5-sonnet-20240620-v1:0',
+        body=body
+    )
+
+    for event in response.get('body'):
+        chunk = json.loads(event.get('chunk').get('bytes'))
+        if chunk['type'] == 'content_block_delta':
+            print(chunk['delta']['text'], end='', flush=True)
+
+stream_claude("Write a short poem about cloud computing.")
+```
+
+## CLI Reference
+Commonly used commands for inspecting model availability and performing quick tests.
+
+```bash
+# List available foundation models
+aws bedrock list-foundation-models --region us-east-1
+
+# Get details for a specific model
+aws bedrock get-foundation-model --model-identifier anthropic.claude-3-5-sonnet-20240620-v1:0
+
+# Invoke a model via CLI
+aws bedrock-runtime invoke-model \
+  --model-id anthropic.claude-3-sonnet-20240229-v1:0 \
+  --body '{"anthropic_version": "bedrock-2023-05-31", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello!"}]}' \
+  output.txt
+```
+
 ## Strengths
 - **Enterprise-Grade Security**: Strong data privacy and compliance features (HIPAA, GDPR, etc.). Data is not used to train the underlying foundation models.
 - **Model Variety**: Access to a broad range of models (Claude, Llama, Mistral, Titan) through a single API.
@@ -41,11 +129,15 @@ It simplifies the process of building and scaling generative AI applications by 
 - [Mistral AI](mistral.md)
 - [Claude Code Container MCP](../development_ops/claude-code-container-mcp.md)
 - [Docker](../infrastructure/docker.md)
+- [LiteLLM](../../services/litellm.md) - Can proxy AWS Bedrock to provide an OpenAI-compatible API.
+- [vLLM](../infrastructure/vllm.md) - Open-source alternative for hosting models yourself.
+- [OpenCompass](../benchmarking/opencompass.md) - Can be used to evaluate models hosted on Bedrock.
 
 ## Sources / References
 - [Official AWS Bedrock Page](https://aws.amazon.com/bedrock/)
 - [Amazon Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [Boto3 Bedrock Runtime Documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime.html)
 
 ## Contribution Metadata
-- Last reviewed: 2026-04-06
+- Last reviewed: 2026-05-20
 - Confidence: high


### PR DESCRIPTION
Deepened aws-bedrock.md, pulse-mcp.md, alpaca-eval.md, math-benchmark.md, and mt-bench.md with technical examples, improved cross-linking, and expanded content. All 5 docs now meet the High Confidence standard (10+ headers, 7+ unique relative links, 1500+ chars). Updated Batch 81 report and growth metrics.

---
*PR created automatically by Jules for task [15446674044368526290](https://jules.google.com/task/15446674044368526290) started by @joanmarcriera*