### PR TITLE
Ralph-loop: Service Documentation Deepening (Batch 92)

### DIFF
--- a/docs/reports/ralph-loop-execution-2026-05-24-batch-92.md
+++ b/docs/reports/ralph-loop-execution-2026-05-24-batch-92.md
@@ -1,0 +1,36 @@
+# Ralph-loop Execution Report — 2026-05-24 (Batch 92)
+
+This report documents the execution of Sub-Batch 92.2 and 92.3 from `docs/reports/task-decomposition-batch-92.md`.
+
+## Execution Summary
+
+| Task | File(s) | Action | Result |
+| :--- | :--- | :--- | :--- |
+| **Sub-Batch 92.2: Networking & Security** | `tailscale.md`, `qbittorrent.md`, `portracker.md` | **Action (a)**: Technical Deepening | **Completed**. Added MagicDNS, Advanced ACLs, Gluetun VPN killswitch, and Alerting webhooks. |
+| **Sub-Batch 92.3: Media & Content Mgmt** | `jellyfin.md`, `plex.md`, `tubearchivist.md`, `kiwix.md`, `linkwarden.md` | **Action (a)**: Technical Deepening | **Completed**. Added Gelli integration, PMM config, Subscriptions, Automated ZIM updates, and Browser extension guide. |
+
+## Detailed Changes
+
+### Networking & Security
+- **Tailscale**: Added MagicDNS configuration steps and a comprehensive JSON example for tag-based ACLs (separating family, admins, and automation).
+- **qBittorrent**: Implemented a "VPN Killswitch" section featuring a Docker Compose example with the Gluetun sidecar.
+- **Portracker**: Added an "Alerting & Webhooks" section with a Python Flask example for receiving port change notifications.
+
+### Media & Content Management
+- **Jellyfin**: Documented Gelli (Android music client) integration.
+- **Plex**: Added Plex Meta Manager (PMM) configuration for automated collection and overlay management.
+- **Tube Archivist**: Explained the "Automated Subscriptions" feature for channel archival.
+- **Kiwix**: Provided a shell script for automated ZIM file library updates using `aria2c`.
+- **Linkwarden**: Added instructions for the official browser extension setup and configuration.
+
+## Verification Results
+- **Quality Audit**: `scripts/audit_docs_quality.py` reported 100% compliance across all 496 docs.
+- **Structural Contract**: `scripts/check_docs_contract.py` passed for all 8 modified files.
+- **Decomposition Update**: `docs/reports/task-decomposition-batch-92.md` successfully updated.
+
+---
+- Status: Sub-Batches 92.2 and 92.3 resolved.
+- Next Step: Continue with Sub-Batch 92.4 (Productivity & Storage) in future runs.
+- Confidence: high
+- Date: 2026-05-24
+- Executed by: Jules

--- a/docs/reports/task-decomposition-batch-92.md
+++ b/docs/reports/task-decomposition-batch-92.md
@@ -12,18 +12,18 @@ Focus on connecting existing services via n8n or specialized APIs.
 ## Sub-Batch 92.2: Networking & Security
 Focus on hardening and infrastructure access.
 - [x] `docs/services/tailscale.md`: Setup Tailscale Exit Node on TrueNAS SCALE.
-- [ ] `docs/services/tailscale.md`: Configure MagicDNS for easy service access.
-- [ ] `docs/services/tailscale.md`: Add an ACL example for separating family devices from automation runners.
-- [ ] `docs/services/qbittorrent.md`: Setup WireGuard VPN killswitch for the qBittorrent container.
-- [ ] `docs/services/portracker.md`: Set up alerts for unexpected port changes.
+- [x] `docs/services/tailscale.md`: Configure MagicDNS for easy service access.
+- [x] `docs/services/tailscale.md`: Add an ACL example for separating family devices from automation runners.
+- [x] `docs/services/qbittorrent.md`: Setup WireGuard VPN killswitch for the qBittorrent container.
+- [x] `docs/services/portracker.md`: Set up alerts for unexpected port changes.
 
 ## Sub-Batch 92.3: Media & Content Management
 Focus on enriching the media stack and archival automation.
-- [ ] `docs/services/jellyfin.md`: Integrate with Gelli (Android music client).
-- [ ] `docs/services/plex.md`: Configure Plex Meta Manager for automated collection management.
-- [ ] `docs/services/tubearchivist.md`: Configure automated downloads for subscribed channels.
-- [ ] `docs/services/kiwix.md`: Set up automated downloads for new ZIM files.
-- [ ] `docs/services/linkwarden.md`: Browser extension integration.
+- [x] `docs/services/jellyfin.md`: Integrate with Gelli (Android music client).
+- [x] `docs/services/plex.md`: Configure Plex Meta Manager for automated collection management.
+- [x] `docs/services/tubearchivist.md`: Configure automated downloads for subscribed channels.
+- [x] `docs/services/kiwix.md`: Set up automated downloads for new ZIM files.
+- [x] `docs/services/linkwarden.md`: Browser extension integration.
 
 ## Sub-Batch 92.4: Productivity & Storage
 Focus on utility accessibility and data durability.

--- a/docs/services/jellyfin.md
+++ b/docs/services/jellyfin.md
@@ -142,8 +142,12 @@ curl -H "X-Emby-Token: YOUR_ACCESS_TOKEN" \
 - [Tailscale](tailscale.md) — for secure remote access to your Jellyfin server without port forwarding
 - [Radarr/Sonarr](https://servarr.com/) — for automating the collection management that Jellyfin serves
 
-## Backlog
-- Integrate with Gelli (Android music client).
+### Gelli (Android Music)
+[Gelli](https://github.com/dkanada/gelli) is a native Android music player for Jellyfin. It provides a more music-centric interface compared to the main Jellyfin app, supporting offline downloads and Android Auto.
+
+1. **Install Gelli**: Download the APK from the [GitHub releases](https://github.com/dkanada/gelli/releases) or F-Droid.
+2. **Connect**: Enter your Jellyfin server URL and login credentials.
+3. **Usage**: Browse your music library, create playlists, and download tracks for offline listening.
 
 ## Sources / References
 

--- a/docs/services/kiwix.md
+++ b/docs/services/kiwix.md
@@ -91,6 +91,23 @@ kiwix-manage /data/library.xml add /data/new_content.zim
 kiwix-search /data/wikipedia.zim "Quantum Physics"
 ```
 
+### Automated ZIM Updates
+ZIM files are snapshots. To keep your library relatively fresh, you can use a script to download the latest versions from the Kiwix library.
+
+**Example Update Script (`update_zims.sh`):**
+```bash
+#!/bin/bash
+ZIM_DIR="/path/to/zims"
+# URL for the English Wikipedia 'mini' ZIM
+WIKI_URL="https://download.kiwix.org/zim/wikipedia/wikipedia_en_all_mini_latest.zim"
+
+echo "Checking for Wikipedia updates..."
+aria2c -d "$ZIM_DIR" -N "$WIKI_URL"
+
+# Restart kiwix-serve to pick up the new file
+docker restart kiwix
+```
+
 ## API examples
 `kiwix-serve` provides an OPDS (Open Publication Distribution System) catalog and a basic search API.
 
@@ -123,9 +140,6 @@ if response.status_code == 200:
 - [Home Assistant](home-assistant.md) — for integrating Kiwix status or content into a local dashboard
 - [Nextcloud](nextcloud.md) — for syncing ZIM files across devices for offline use
 - [Internet-in-a-Box](https://internet-in-a-box.org/) — a full hardware/software stack for offline knowledge
-
-## Backlog
-- Set up automated downloads for new ZIM files.
 
 ## Sources / References
 

--- a/docs/services/linkwarden.md
+++ b/docs/services/linkwarden.md
@@ -83,6 +83,13 @@ services:
 5. Wait a few moments for Linkwarden to generate the screenshot and PDF.
 6. Click on the link to view the archived snapshot.
 
+### Browser Extension
+The official Linkwarden browser extension allows you to quickly save links and snapshots while browsing.
+
+1. **Install**: Download the extension for [Chrome/Edge](https://chrome.google.com/webstore/detail/linkwarden/afmionibalcnkdpgolnfnidniikfhnnh) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/linkwarden/).
+2. **Configure**: Click the extension icon and enter your self-hosted instance URL (`http://localhost:3000`) and your API key.
+3. **Save**: Click the "Save to Linkwarden" button on any webpage to automatically capture it into your preferred collection.
+
 ## CLI examples
 While primarily managed via the web, you can use Docker for maintenance:
 
@@ -192,9 +199,6 @@ download_pdf(123, "my_preserved_page")
 - [Home Assistant](home-assistant.md) — For automating notifications about newly archived links.
 - [IT-Tools](it-tools.md) — For processing snippets found in bookmarked pages.
 - [Omni Tools](omni-tools.md) — A similar collection of web-based utilities.
-
-## Backlog
-- Browser extension integration.
 
 ## Sources / References
 

--- a/docs/services/plex.md
+++ b/docs/services/plex.md
@@ -119,15 +119,27 @@ for section in plex.library.sections():
     print(f"Library: {section.title}, Type: {section.type}")
 ```
 
-## Backlog
-- Configure Plex Meta Manager for automated collection management.
-
 ## Related tools / concepts
 - [Jellyfin](jellyfin.md) (Open-source alternative)
 - [Docker](../tools/infrastructure/docker.md)
 - [n8n](n8n.md) (For media automation)
 - [qBittorrent](qbittorrent.md) (For content acquisition)
 - [Search & Discovery](../tools/intake_storage/index.md)
+
+### Plex Meta Manager (PMM)
+[Plex Meta Manager](https://metamanager.wiki/) is an advanced tool for automating metadata and collection management in Plex. It can create dynamic collections based on IMDb lists, Trakt, or custom filters.
+
+**Basic `config.yml` Snippet:**
+```yaml
+libraries:
+  Movies:
+    collection_files:
+      - default: trending
+      - default: top_rated
+    overlay_files:
+      - default: resolution
+      - default: ratings
+```
 
 ## Contribution Metadata
 - Confidence: high

--- a/docs/services/portracker.md
+++ b/docs/services/portracker.md
@@ -96,6 +96,26 @@ curl -X GET "http://localhost:4999/api/v1/status" \
      -H "x-api-key: YOUR_PEER_API_KEY"
 ```
 
+### Alerting & Webhooks
+Portracker can be configured to send alerts to external webhooks (e.g., Discord, Slack, or n8n) when unexpected port changes are detected.
+
+**Simple Python Webhook Listener:**
+```python
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.route('/webhook', methods=['POST'])
+def handle_alert():
+    data = request.json
+    print(f"Alert Received: {data['event_type']}")
+    print(f"Message: {data['message']}")
+    return "OK", 200
+
+if __name__ == '__main__':
+    app.run(port=5000)
+```
+
 ## Links
 - [GitHub Repository](https://github.com/mostafa-wahied/portracker)
 
@@ -108,9 +128,6 @@ curl -X GET "http://localhost:4999/api/v1/status" \
 - [Netdata](https://www.netdata.cloud/)
 - [Uptime Kuma](https://uptime.kuma.pet/)
 - [nmap](https://nmap.org/)
-
-## Backlog
-- Set up alerts for unexpected port changes.
 
 ## Contribution Metadata
 - Confidence: high

--- a/docs/services/qbittorrent.md
+++ b/docs/services/qbittorrent.md
@@ -63,6 +63,41 @@ Access the web interface at `http://localhost:8080`. The default credentials (if
 3. Go to **Tools > Options > BitTorrent** and enable "Add torrents in Paused state" for safety.
 4. Click the **Add Torrent Link** button and paste a legal magnet link (e.g., a Linux ISO) to see the client in action.
 
+### VPN Killswitch (Gluetun)
+To ensure qBittorrent only downloads when connected to a VPN, use [Gluetun](https://github.com/qdm12/gluetun) as a network sidecar.
+
+```yaml
+services:
+  gluetun:
+    image: qmcgaw/gluetun
+    container_name: gluetun
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    environment:
+      - VPN_SERVICE_PROVIDER=your_provider
+      - VPN_TYPE=wireguard
+      - WIREGUARD_PRIVATE_KEY=your_key
+      - WIREGUARD_ADDRESSES=10.0.0.2/32
+    ports:
+      - 8080:8080 # qBittorrent Web UI
+
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    container_name: qbittorrent
+    network_mode: "container:gluetun"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - WEBUI_PORT=8080
+    volumes:
+      - ./config:/config
+      - ./downloads:/downloads
+    restart: unless-stopped
+```
+
 ## CLI examples
 The `qbittorrent-nox` binary can be managed via the Docker container.
 
@@ -124,9 +159,6 @@ curl "http://localhost:8080/api/v2/torrents/info" \
 - [Official Website](https://www.qbittorrent.org/)
 - [Transmission](https://transmissionbt.com/)
 - [Deluge](https://deluge-torrent.org/)
-
-## Backlog
-- Setup WireGuard VPN killswitch for the qBittorrent container.
 
 ## Contribution Metadata
 - Confidence: high

--- a/docs/services/tailscale.md
+++ b/docs/services/tailscale.md
@@ -67,6 +67,14 @@ To use your TrueNAS SCALE server as a Tailscale Exit Node (routing all your traf
     - Click **Edit Route Settings** and check **Exit Node**.
 6.  **Usage**: On your client device (phone/laptop), select your TrueNAS server as the "Exit Node" in the Tailscale menu.
 
+### MagicDNS Configuration
+MagicDNS allows you to access your devices using short, stable hostnames instead of IP addresses.
+
+1.  **Enable MagicDNS**: In the [Tailscale Admin Console](https://login.tailscale.com/admin/dns), toggle **MagicDNS** to ON.
+2.  **Nameservers**: Add global nameservers (e.g., Cloudflare `1.1.1.1` or Google `8.8.8.8`) to ensure public DNS resolution continues to work while connected.
+3.  **Search Domains**: Configure search domains if you want to use custom suffixes for your tailnet devices.
+4.  **Usage**: You can now reach your TrueNAS server at `http://truenas` or `http://truenas.your-tailnet.ts.net` instead of its private IP.
+
 ### Hello World
 1. Install Tailscale on two different devices (e.g., your laptop and your phone).
 2. Run `tailscale status` on your laptop to see your phone listed with its Tailscale IP.
@@ -107,6 +115,32 @@ For automation, prefer service-specific tokens plus Tailscale network reachabili
 - Use ACLs or groups to separate family devices, lab servers, and automation runners.
 - Review `tailscale status` and the admin console before assuming an old device is still trusted.
 - Document which nodes advertise routes or run as exit nodes, because those nodes have higher blast radius.
+
+### Advanced ACLs (Tag-based Access Control)
+Use ACLs to enforce least-privilege access across your tailnet. Prefer tags over individual user emails for automation and server nodes.
+
+```json
+{
+  "groups": {
+    "group:admin": ["alice@example.com"],
+    "group:family": ["bob@example.com", "carol@example.com"]
+  },
+  "tags": {
+    "tag:automation": ["alice@example.com"],
+    "tag:server":     ["alice@example.com"]
+  },
+  "acls": [
+    // Admins can access everything
+    {"action": "accept", "src": ["group:admin"], "dst": ["*:*"]},
+
+    // Family can only access the media server (Jellyfin/Plex)
+    {"action": "accept", "src": ["group:family"], "dst": ["tag:server:8096", "tag:server:32400"]},
+
+    // Automation runners can access specific internal APIs
+    {"action": "accept", "src": ["tag:automation"], "dst": ["tag:server:5678", "tag:server:8080"]}
+  ]
+}
+```
 
 ## API examples
 

--- a/docs/services/tubearchivist.md
+++ b/docs/services/tubearchivist.md
@@ -10,6 +10,13 @@ YouTube videos can be deleted, made private, or censored at any time. Tube Archi
 **Category**: Services / Media Management. It serves as a **content preservation layer**, sitting alongside tools like Plex or Jellyfin but specialized for YouTube content and metadata.
 
 ## Typical use cases
+### Automated Subscriptions
+Tube Archivist can automatically monitor and download new videos from your favorite YouTube channels or playlists.
+
+1. **Add Subscription**: Go to the **Subscriptions** tab and enter the URL of a YouTube channel or playlist.
+2. **Configure**: Set the download frequency (e.g., daily) and the maximum number of videos to keep.
+3. **Automate**: Tube Archivist will periodically poll YouTube and download any new content that matches your criteria.
+
 - Archiving educational channels or tutorials for offline reference.
 - Saving high-quality versions of favorite music videos or documentaries.
 - Building a private "YouTube" experience without ads or tracking.
@@ -171,10 +178,6 @@ curl -X POST -H "Authorization: Token <your_api_token>" \
 - [n8n](n8n.md) — for advanced automation of video ingestion.
 - [Home Assistant](home-assistant.md) — For automating notifications about new downloads.
 - [Tailscale](tailscale.md) — For securely accessing your archive from anywhere.
-
-## Backlog
-- Configure automated downloads for subscribed channels.
-
 
 ## Contribution Metadata
 - Confidence: high


### PR DESCRIPTION
Deepened the technical content of 8 service documentation files based on the backlog items identified in Batch 92. The changes include adding advanced configurations (MagicDNS, ACLs, VPN killswitches, webhooks), integrations (Gelli, Plex Meta Manager), and automation patterns (subscriptions, ZIM updates). Updated the corresponding task decomposition report and created a new execution report to document the work. All files meet 'High Confidence' standards and pass automated quality checks.

---
*PR created automatically by Jules for task [3766726873581212660](https://jules.google.com/task/3766726873581212660) started by @joanmarcriera*