### PR TITLE
Deepen 5 shortest tool documentation files

### DIFF
--- a/data/growth-metrics.json
+++ b/data/growth-metrics.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_date": "2026-05-24",
+  "snapshot_date": "2026-05-25",
   "total_docs": 406,
   "tool_docs": 353,
   "service_docs": 53,

--- a/docs/tools/automation_orchestration/lightpanda.md
+++ b/docs/tools/automation_orchestration/lightpanda.md
@@ -36,14 +36,89 @@ It provides a lightweight, extremely fast, and low-memory footprint browser for 
 - **Cost**: Free
 - **Self-hostable**: Yes
 
+## Getting started
+
+### Installation
+Lightpanda can be installed via a one-line script or run as a Docker container.
+
+```bash
+# One-line installer (Linux/macOS)
+curl -fsSL https://pkg.lightpanda.io/install.sh | bash
+
+# Running via Docker (exposed on CDP port 9222)
+docker run -d --name lightpanda -p 127.0.0.1:9222:9222 lightpanda/browser:nightly
+```
+
+### Hello World (CLI)
+Fetch a page and dump it as Markdown directly from the terminal:
+
+```bash
+lightpanda fetch --dump markdown https://example.com
+```
+
+## CLI examples
+The Lightpanda CLI is designed for direct machine interaction and scraping.
+
+```bash
+# Dump page as HTML
+lightpanda fetch --dump html https://news.ycombinator.com
+
+# Execute a custom script on a page
+lightpanda fetch --script "document.querySelectorAll('a').forEach(a => console.log(a.href))" https://example.com
+
+# Start a CDP server for external tools (Playwright/Puppeteer)
+lightpanda server --host 127.0.0.1 --port 9222
+```
+
+## API examples
+Lightpanda is compatible with the **Chrome DevTools Protocol (CDP)**, allowing it to be used as a drop-in replacement for Chrome in many automation frameworks.
+
+### Connecting with Playwright (Python)
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    # Connect to a running Lightpanda instance
+    browser = p.chromium.connect_over_cdp("http://localhost:9222")
+    page = browser.new_context().new_page()
+    page.goto("https://lightpanda.io")
+    print(page.title())
+    browser.close()
+```
+
+### Direct CDP Interaction (Node.js)
+```javascript
+const CDP = require('chrome-remote-interface');
+
+async function example() {
+    let client;
+    try {
+        client = await CDP({ port: 9222 });
+        const {Page, Runtime} = client;
+        await Page.enable();
+        await Page.navigate({url: 'https://example.com'});
+        await Page.loadEventFired();
+        const result = await Runtime.evaluate({expression: 'document.title'});
+        console.log(result.result.value);
+    } catch (err) {
+        console.error(err);
+    } finally {
+        if (client) { await client.close(); }
+    }
+}
+example();
+```
+
 ## Related tools / concepts
 - [Browser Use](browser-use.md)
 - [Playwright](https://playwright.dev/)
 - [Puppeteer](https://pptr.dev/)
+- [CDP (Chrome DevTools Protocol)](https://chromedevtools.github.io/devtools-protocol/)
 
 ## Sources / References
 - [Official Website](https://lightpanda.io/)
-- [GitHub](https://github.com/lightpanda-io/browser)
+- [GitHub Repository](https://github.com/lightpanda-io/browser)
+- [Lightpanda Documentation](https://docs.lightpanda.io/)
 
 ## Contribution Metadata
 - Last reviewed: 2026-04-26

--- a/docs/tools/calendar_tasks/apple-calendar.md
+++ b/docs/tools/calendar_tasks/apple-calendar.md
@@ -36,13 +36,70 @@ Provides a seamless, synchronized scheduling experience for users within the App
 - **Cost**: Free (Included with Apple ID)
 - **Self-hostable**: No
 
+## Getting started
+
+### Installation
+Apple Calendar is pre-installed on all Apple devices. For command-line access, `icalBuddy` is the community standard.
+
+```bash
+# Install icalBuddy via Homebrew
+brew install ical-buddy
+```
+
+### Hello World (AppleScript)
+You can create events directly from the terminal using the built-in `osascript` (AppleScript) engine.
+
+```bash
+osascript -e 'tell application "Calendar" to make new event at end of events of calendar "Calendar" with properties {summary:"Hello from CLI", start date:(current date), end date:((current date) + 3600)}'
+```
+
+## CLI examples
+Using `icalBuddy` to query the local calendar database:
+
+```bash
+# List all events for today
+icalBuddy eventsToday
+
+# List all uncompleted tasks/reminders
+icalBuddy uncompletedTasks
+
+# List all available calendars
+icalBuddy calendars
+```
+
+## API examples
+The official way to interact with Apple Calendar programmatically is via the **EventKit** framework (Swift/Objective-C) or **AppleScript**.
+
+### List Calendars (AppleScript)
+```applescript
+tell application "Calendar"
+    set calendarList to name of every calendar
+    return calendarList
+end tell
+```
+
+### Accessing EventKit (Python via PyObjC)
+```python
+from EventKit import EKEventStore, EKEntityType
+
+store = EKEventStore.alloc().init()
+store.requestAccessToEntityType_completion_(EKEntityTypeEvent, lambda granted, error: None)
+
+calendars = store.calendarsForEntityType_(EKEntityTypeEvent)
+for calendar in calendars:
+    print(f"Calendar: {calendar.title()}")
+```
+
 ## Related tools / concepts
 - [Google Calendar](google_calendar.md)
 - [Outlook Calendar](outlook.md)
 - [Proton Calendar](proton_calendar.md)
+- [EventKit Framework](https://developer.apple.com/documentation/eventkit)
 
 ## Sources / References
 - [Apple Calendar Support](https://support.apple.com/calendar)
+- [icalBuddy Homepage](https://hasseg.org/icalBuddy/)
+- [AppleScript Language Guide](https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptLangGuide/introduction/ASL_intro.html)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-02

--- a/docs/tools/calendar_tasks/fastmail.md
+++ b/docs/tools/calendar_tasks/fastmail.md
@@ -36,13 +36,83 @@ Provides a fast, ad-free, and private surface for email, calendar, and contacts 
 - **Cost**: Paid (Subscription)
 - **Self-hostable**: No
 
+## Getting started
+
+### Installation (CLI)
+The community-maintained `fastmail-cli` provides a robust interface for interacting with Fastmail services.
+
+```bash
+# Install via Cargo
+cargo install --git https://github.com/Lutra-Fs/fastmail-CLI
+
+# Run interactive setup (requires an API token from Settings > Security > API Tokens)
+fastmail setup
+```
+
+### Hello World (Masked Email)
+```bash
+# Create a new masked email for a specific site
+fastmail masked create https://example.com --description "Trial Signup"
+```
+
+## CLI examples
+The `fastmail-cli` tool supports mail, contacts, calendars, and masked emails.
+
+```bash
+# List recent emails
+fastmail mail list --limit 10
+
+# List all calendars
+fastmail calendar list
+
+# Create a new contact
+fastmail contacts create "Jane Doe" --email "jane@example.com"
+```
+
+## API examples
+Fastmail is a primary driver of the **JMAP** (JSON Meta Application Protocol) standard.
+
+### Minimal JMAP Session Request (cURL)
+```bash
+curl -X GET \
+  -H "Authorization: Bearer ${FASTMAIL_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  https://api.fastmail.com/jmap/session
+```
+
+### Fetch Mailboxes (Python)
+```python
+import requests
+
+api_token = "your_api_token"
+url = "https://api.fastmail.com/jmap/api/"
+
+headers = {
+    "Authorization": f"Bearer {api_token}",
+    "Content-Type": "application/json"
+}
+
+payload = {
+    "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+    "methodCalls": [
+        ["Mailbox/get", {"accountId": None, "ids": None}, "0"]
+    ]
+}
+
+response = requests.post(url, headers=headers, json=payload)
+print(response.json())
+```
+
 ## Related tools / concepts
 - [Proton Calendar](proton_calendar.md)
 - [Google Calendar](google_calendar.md)
 - [Radicale](../../services/radicale.md)
+- [JMAP Protocol](https://jmap.io/)
 
 ## Sources / References
 - [Fastmail Official Site](https://www.fastmail.com/)
+- [Fastmail Developer Documentation](https://www.fastmail.com/developer/)
+- [Lutra-Fs/fastmail-CLI](https://github.com/Lutra-Fs/fastmail-CLI)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-02

--- a/docs/tools/calendar_tasks/savvycal.md
+++ b/docs/tools/calendar_tasks/savvycal.md
@@ -36,13 +36,94 @@ Reduces the "scheduling dance" by providing a visual way for invitees to compare
 - **Cost**: Paid (Subscription)
 - **Self-hostable**: No
 
+## Getting started
+
+### Installation
+SavvyCal is a web-based service. There is no official CLI, but it provides a robust REST API for automation.
+
+### Hello World (API Check)
+Verify your API key using cURL:
+
+```bash
+curl -i -X GET "https://api.savvycal.com/v1/me" \
+  -H "Authorization: Bearer ${SAVVYCAL_API_KEY}"
+```
+
+## CLI examples
+Since there is no official CLI, you can use `curl` or a custom script to interact with the API.
+
+```bash
+# List all active scheduling links
+curl -X GET "https://api.savvycal.com/v1/links?state=active" \
+  -H "Authorization: Bearer ${SAVVYCAL_API_KEY}"
+
+# List upcoming meetings
+curl -X GET "https://api.savvycal.com/v1/events" \
+  -H "Authorization: Bearer ${SAVVYCAL_API_KEY}"
+
+# Create a new scheduling link via API
+curl -X POST "https://api.savvycal.com/v1/links" \
+  -H "Authorization: Bearer ${SAVVYCAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Quick Sync", "slug": "quick-sync", "durations": [15, 30]}'
+```
+
+## API examples
+
+### Fetching Availability (Python)
+```python
+import requests
+
+api_key = "your_api_key"
+link_id = "link_abc123"
+url = f"https://api.savvycal.com/v1/links/{link_id}/slots"
+
+headers = {
+    "Authorization": f"Bearer {api_key}",
+    "Accept": "application/json"
+}
+
+params = {
+    "from": "2026-06-01",
+    "to": "2026-06-07"
+}
+
+response = requests.get(url, headers=headers, params=params)
+slots = response.json()
+
+for slot in slots:
+    print(f"Available: {slot['starts_at']}")
+```
+
+### Webhook Integration (Node.js)
+SavvyCal can send webhooks for events like `event.created`.
+
+```javascript
+const express = require('express');
+const app = express();
+
+app.post('/webhooks/savvycal', express.json(), (req, res) => {
+  const event = req.body;
+
+  if (event.type === 'event.created') {
+    console.log(`New meeting booked by ${event.data.invitee.email}`);
+  }
+
+  res.status(200).end();
+});
+
+app.listen(3000);
+```
+
 ## Related tools / concepts
 - [Calendly](calendly.md)
 - [Morgen](morgen.md)
 - [Amie](amie.md)
+- [OAuth2 Authentication](https://developers.savvycal.com/api/authentication)
 
 ## Sources / References
 - [SavvyCal Official Site](https://savvycal.com/)
+- [SavvyCal Developer Documentation](https://developers.savvycal.com/)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-02

--- a/docs/tools/calendar_tasks/ticktick.md
+++ b/docs/tools/calendar_tasks/ticktick.md
@@ -36,13 +36,82 @@ Consolidates personal productivity tools into a single app, reducing context swi
 - **Cost**: Freemium (Basic features free; Pro subscription for full features)
 - **Self-hostable**: No
 
+## Getting started
+
+### Installation
+TickTick provides a limited official API (V1) and a more powerful unofficial one (V2). The `ticktick-py` library is the most popular community client.
+
+```bash
+# Install the community Python client
+pip install ticktick-py
+```
+
+### Hello World (Python)
+Authenticate and create a simple task:
+
+```python
+from ticktick.api import TickTickClient
+
+client = TickTickClient('your_email', 'your_password')
+task = client.task.builder('Hello from Python')
+client.task.create(task)
+```
+
+## CLI examples
+There is no official CLI, but you can use `curl` to interact with the Open API (V1) once you have an OAuth token.
+
+```bash
+# Get all projects
+curl -X GET "https://api.ticktick.com/open/v1/project" \
+  -H "Authorization: Bearer ${TICKTICK_ACCESS_TOKEN}"
+
+# Create a task in the Inbox
+curl -X POST "https://api.ticktick.com/open/v1/task" \
+  -H "Authorization: Bearer ${TICKTICK_ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Buy Milk", "content": "Organic if possible"}'
+
+# Get uncompleted tasks for a specific project
+curl -X GET "https://api.ticktick.com/open/v1/project/{projectId}/data" \
+  -H "Authorization: Bearer ${TICKTICK_ACCESS_TOKEN}"
+```
+
+## API examples
+
+### Batch Task Operations (Python)
+Using the unofficial `ticktick-py` for advanced features like batch creation.
+
+```python
+from ticktick.api import TickTickClient
+
+client = TickTickClient('user@example.com', 'password')
+
+# Batch create tasks
+tasks = [
+    client.task.builder('Task 1', priority=3),
+    client.task.builder('Task 2', priority=1)
+]
+client.task.create(tasks)
+
+# Get all uncompleted tasks from the state
+uncompleted = client.state['tasks']
+for task in uncompleted:
+    print(f"[{task['title']}] - ID: {task['id']}")
+```
+
+### Webhook Support
+TickTick does not provide official outgoing webhooks. Automation usually requires polling the API or using a middleman like Zapier/Make.
+
 ## Related tools / concepts
 - [Todoist](todoist.md)
 - [Any.do](any-do.md)
 - [Habitica](../../services/habitica.md)
+- [TickTick Open API (V1)](https://developer.ticktick.com/docs)
 
 ## Sources / References
 - [TickTick Official Site](https://ticktick.com/)
+- [TickTick Developer Portal](https://developer.ticktick.com/)
+- [ticktick-py Documentation](https://pypi.org/project/ticktick-py/)
 
 ## Contribution Metadata
 - Last reviewed: 2026-05-02


### PR DESCRIPTION
This PR deepens the documentation for the 5 shortest tool files in the repository: Fastmail, Apple Calendar, SavvyCal, TickTick, and Lightpanda. 

### Changes:
- **Fastmail**: Added JMAP API and `fastmail-cli` examples.
- **Apple Calendar**: Added `icalBuddy` and AppleScript (`osascript`) examples.
- **SavvyCal**: Added REST API (cURL) and Python examples for scheduling.
- **TickTick**: Added Open API (V1) and `ticktick-py` (unofficial V2) examples.
- **Lightpanda**: Added Zig CLI installation, fetch commands, and Playwright CDP integration.
- **Metrics**: Updated `data/growth-metrics.json` snapshot date.

All files pass `scripts/audit_docs_quality.py` and `scripts/check_docs_contract.py`.

---
*PR created automatically by Jules for task [274000208524900066](https://jules.google.com/task/274000208524900066) started by @joanmarcriera*