### PR TITLE
Verify and Close Ralph-loop Batches 63-71

### DIFF
--- a/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-63.md
+++ b/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-63.md
@@ -1,0 +1,24 @@
+# Ralph-loop Verification Report — 2026-06-01 (Batch 63)
+
+## Summary
+Verified and closed Batch 63 (5 files reviewed 2026-05-16). All files meet "High Confidence" standards (10+ headers, 7+ internal links, technical examples, full metadata).
+
+## Targeted Files
+- `docs/tools/automation_orchestration/chronos-mcp.md`
+- `docs/tools/automation_orchestration/makefile-mcp.md`
+- `docs/tools/automation_orchestration/vault-mcp.md`
+- `docs/tools/automation_orchestration/vikunja-mcp.md`
+- `docs/tools/development_ops/axiom-guardian.md`
+
+## Actions Taken
+- **Link Deepening**:
+  - Added internal link to `vault-mcp.md` in `chronos-mcp.md`.
+  - Added internal link to `vikunja-mcp.md` in `vault-mcp.md`.
+- **Validation**:
+  - `scripts/check_docs_contract.py`: PASSED
+  - `scripts/audit_docs_quality.py`: PASSED
+  - `scripts/check_catalog_consistency.py`: PASSED
+
+## Contribution Metadata
+- Last reviewed: 2026-06-01
+- Confidence: high

--- a/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-64.md
+++ b/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-64.md
@@ -1,0 +1,22 @@
+# Ralph-loop Verification Report — 2026-06-01 (Batch 64)
+
+## Summary
+Verified and closed Batch 64 (5 files reviewed 2026-05-16). All files meet "High Confidence" standards (10+ headers, 7+ internal links, technical examples, full metadata).
+
+## Targeted Files
+- `docs/tools/ai_knowledge/google-opal.md`
+- `docs/tools/ai_knowledge/project-genie.md`
+- `docs/tools/ai_knowledge/gemini-canvas.md`
+- `docs/tools/ai_knowledge/kimi-cli.md`
+- `docs/tools/ai_knowledge/synthesia.md`
+
+## Actions Taken
+- **Audit**: Verified that all 5 files contain code examples, >= 10 headers, and >= 7 internal relative links.
+- **Validation**:
+  - `scripts/check_docs_contract.py`: PASSED
+  - `scripts/audit_docs_quality.py`: PASSED
+  - `scripts/check_catalog_consistency.py`: PASSED
+
+## Contribution Metadata
+- Last reviewed: 2026-06-01
+- Confidence: high

--- a/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-69.md
+++ b/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-69.md
@@ -1,0 +1,27 @@
+# Ralph-loop Verification Report — 2026-06-01 (Batch 69)
+
+## Summary
+Verified and closed Batch 69 (5 files reviewed 2026-05-17). All files meet "High Confidence" standards (10+ headers, 7+ internal links, technical examples, full metadata).
+
+## Targeted Files
+- `docs/tools/frameworks/langgraph.md`
+- `docs/tools/frameworks/semantic-kernel.md`
+- `docs/tools/frameworks/smolagents.md`
+- `docs/tools/process_understanding/docling-mcp.md`
+- `docs/tools/providers/cohere.md`
+
+## Actions Taken
+- **Link Deepening**:
+  - Added 4 internal links to `langgraph.md`.
+  - Added 2 internal links to `semantic-kernel.md`.
+  - Added 2 internal links to `smolagents.md`.
+  - Added 2 internal links to `docling-mcp.md`.
+  - Added 4 internal links to `cohere.md`.
+- **Validation**:
+  - `scripts/check_docs_contract.py`: PASSED
+  - `scripts/audit_docs_quality.py`: PASSED
+  - `scripts/check_catalog_consistency.py`: PASSED
+
+## Contribution Metadata
+- Last reviewed: 2026-06-01
+- Confidence: high

--- a/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-70.md
+++ b/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-70.md
@@ -1,0 +1,22 @@
+# Ralph-loop Verification Report — 2026-06-01 (Batch 70)
+
+## Summary
+Verified and closed Batch 70 (5 files reviewed 2026-05-17). All files meet "High Confidence" standards (10+ headers, 7+ internal links, technical examples, full metadata).
+
+## Targeted Files
+- `docs/tools/frameworks/autogen.md`
+- `docs/tools/frameworks/crewai.md`
+- `docs/tools/frameworks/dspy.md`
+- `docs/tools/frameworks/haystack.md`
+- `docs/tools/infrastructure/vllm.md`
+
+## Actions Taken
+- **Audit**: Verified that all 5 files contain code examples, >= 10 headers, and >= 7 internal relative links.
+- **Validation**:
+  - `scripts/check_docs_contract.py`: PASSED
+  - `scripts/audit_docs_quality.py`: PASSED
+  - `scripts/check_catalog_consistency.py`: PASSED
+
+## Contribution Metadata
+- Last reviewed: 2026-06-01
+- Confidence: high

--- a/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-71.md
+++ b/docs/reports/ralph-loop-execution-2026-06-01-verification-batch-71.md
@@ -1,0 +1,23 @@
+# Ralph-loop Verification Report — 2026-06-01 (Batch 71)
+
+## Summary
+Verified and closed Batch 71 (5 files reviewed 2026-05-17). All files meet "High Confidence" standards (10+ headers, 7+ internal links, technical examples, full metadata).
+
+## Targeted Files
+- `docs/tools/infrastructure/tgi.md`
+- `docs/tools/infrastructure/sglang.md`
+- `docs/tools/infrastructure/aphrodite-engine.md`
+- `docs/tools/infrastructure/exllamav2.md`
+- `docs/tools/development_ops/claude-code-router.md`
+
+## Actions Taken
+- **Link Deepening**:
+  - Added internal link to `tgi.md` in `exllamav2.md`.
+- **Validation**:
+  - `scripts/check_docs_contract.py`: PASSED
+  - `scripts/audit_docs_quality.py`: PASSED
+  - `scripts/check_catalog_consistency.py`: PASSED
+
+## Contribution Metadata
+- Last reviewed: 2026-06-01
+- Confidence: high

--- a/docs/reports/ralph-loop-triage.md
+++ b/docs/reports/ralph-loop-triage.md
@@ -60,12 +60,12 @@ This report documents the triage of open GitHub issues and ongoing maintenance t
 | **Batch 60** | Maintenance Run (Technical Deepening) | **Verified & Closed** | Deepened `valyu.md`, `crawl4ai.md`, etc. Verified 2026-06-01. |
 | **Batch 61** | Maintenance Run (Production Deepening) | **Verified & Closed** | Deepened `langsmith.md`, `firecrawl.md`, etc. Verified 2026-06-01. |
 | **Batch 62** | Maintenance Run (The "Oldest" Res) | **Verified & Closed** | Deepened `teamout.md`, `claude-code-setup.md`, etc. Verified 2026-06-01. |
-| **Batch 63** | Maintenance Run (The "Oldest" Res) | **Resolved** | Deepened `chronos-mcp.md`, `vault-mcp.md`, etc. (2026-05-16). |
-| **Batch 64** | Maintenance Run (AI Knowledge) | **Resolved** | Deepened `google-opal.md`, `project-genie.md`, etc. (2026-05-16). |
+| **Batch 63** | Maintenance Run (The "Oldest" Res) | **Verified & Closed** | Deepened `chronos-mcp.md`, `vault-mcp.md`, etc. Verified 2026-06-01. |
+| **Batch 64** | Maintenance Run (AI Knowledge) | **Verified & Closed** | Deepened `google-opal.md`, `project-genie.md`, etc. Verified 2026-06-01. |
 | **Batch 65** | MCP Technical Deepening | **Verified & Closed** | Deepened `claude-code-container-mcp.md`, `desktop-commander-mcp.md`, etc. (2026-05-16). |
-| **Batch 69** | Maintenance Run (Oldest Res) | **Resolved** | Deepened `langgraph.md`, `semantic-kernel.md`, `smolagents.md`, `docling-mcp.md`, `cohere.md` (2026-05-17). |
-| **Batch 70** | Technical Deepening (Frameworks & Infra) | **Resolved** | Deepened `autogen.md`, `crewai.md`, `dspy.md`, `haystack.md`, `vllm.md` (2026-05-17). |
-| **Batch 71** | Infrastructure Maintenance | **Resolved** | Deepened `tgi.md`, `sglang.md`, `aphrodite-engine.md`, `exllamav2.md`, `claude-code-router.md` (2026-05-17). |
+| **Batch 69** | Maintenance Run (Oldest Res) | **Verified & Closed** | Deepened `langgraph.md`, `semantic-kernel.md`, `smolagents.md`, `docling-mcp.md`, `cohere.md`. Verified 2026-06-01. |
+| **Batch 70** | Technical Deepening (Frameworks & Infra) | **Verified & Closed** | Deepened `autogen.md`, `crewai.md`, `dspy.md`, `haystack.md`, `vllm.md`. Verified 2026-06-01. |
+| **Batch 71** | Infrastructure Maintenance | **Verified & Closed** | Deepened `tgi.md`, `sglang.md`, `aphrodite-engine.md`, `exllamav2.md`, `claude-code-router.md`. Verified 2026-06-01. |
 | **Batch 72** | Inference Providers & Dev Studio | **Resolved** | Deepened `fireworks.md`, `groq.md`, `mistral.md`, `together.md`, `firebase-studio.md` (2026-05-17). |
 | **Batch 73** | High-Value AI Knowledge & Providers | **Resolved** | Deepened `minimax.md`, `moonshot.md`, `copy-ai.md`, `jasper.md`, `runwayml.md` (2026-05-17). |
 | **Batch 74** | Oldest Backlog Maintenance | **Verified & Closed** | Deepened `superpowers.md`, `elevenlabs.md`, `claude-cookbooks.md`, `playwright.md`, `replicate.md` (2026-05-18). |

--- a/docs/tools/automation_orchestration/chronos-mcp.md
+++ b/docs/tools/automation_orchestration/chronos-mcp.md
@@ -85,6 +85,7 @@ accounts:
 - [Nextcloud](../../services/nextcloud.md)
 - [Fastmail](../calendar_tasks/fastmail.md)
 - [Vikunja MCP](vikunja-mcp.md)
+- [Vault MCP](vault-mcp.md)
 - [Google Calendar](../calendar_tasks/google_calendar.md)
 - [Chronos CalDAV library](https://github.com/democratize-technology/chronos-mcp)
 

--- a/docs/tools/automation_orchestration/vault-mcp.md
+++ b/docs/tools/automation_orchestration/vault-mcp.md
@@ -78,6 +78,7 @@ path "secret/data/my-app/*" {
 ## Related tools / concepts
 - [HashiCorp Vault](https://www.vaultproject.io/)
 - [Model Context Protocol](../../knowledge_base/agent_protocols.md)
+- [Vikunja MCP](vikunja-mcp.md)
 - [Authentik](../../services/authentik.md)
 - [Kubernetes](../../architecture/infrastructure.md)
 - [Tailscale](../../services/tailscale.md)

--- a/docs/tools/frameworks/langgraph.md
+++ b/docs/tools/frameworks/langgraph.md
@@ -163,6 +163,10 @@ for event in graph.stream({"messages": [("user", "Search for the current price o
 - [LangChain](../ai_knowledge/langchain.md)
 - [Agent Protocols (MCP)](../../knowledge_base/agent_protocols.md)
 - [CrewAI](../frameworks/crewai.md)
+- [AutoGen](autogen.md)
+- [DSPy](dspy.md)
+- [Haystack](haystack.md)
+- [Smolagents](smolagents.md)
 
 ## Sources / References
 - [Official Documentation](https://langchain-ai.github.io/langgraph/)

--- a/docs/tools/frameworks/semantic-kernel.md
+++ b/docs/tools/frameworks/semantic-kernel.md
@@ -119,6 +119,8 @@ if __name__ == "__main__":
 - [DSPy](dspy.md)
 - [Haystack](haystack.md)
 - [Smolagents](smolagents.md)
+- [AutoGen](autogen.md)
+- [LangGraph](langgraph.md)
 ## Sources / References
 - [GitHub](https://github.com/microsoft/semantic-kernel)
 - [Microsoft Documentation](https://learn.microsoft.com/en-us/semantic-kernel/)

--- a/docs/tools/frameworks/smolagents.md
+++ b/docs/tools/frameworks/smolagents.md
@@ -128,6 +128,8 @@ agent.run("What is the current population of Tokyo?")
 - [AutoGen](autogen.md)
 - [DSPy](dspy.md)
 - [Haystack](haystack.md)
+- [LangGraph](langgraph.md)
+- [Semantic Kernel](semantic-kernel.md)
 ## Sources / References
 - [GitHub](https://github.com/huggingface/smolagents)
 - [Blog Post](https://huggingface.co/blog/smolagents)

--- a/docs/tools/infrastructure/exllamav2.md
+++ b/docs/tools/infrastructure/exllamav2.md
@@ -84,6 +84,7 @@ ExLlamaV2 supports various environment variables to tune performance:
 - [Quantization](../knowledge_base/patterns/quantization.md)
 - [NVIDIA CUDA](../infrastructure/nvidia-cuda.md)
 - [Long Context](../knowledge_base/long-context.md)
+- [Text Generation Inference (TGI)](tgi.md)
 
 ## Sources / References
 - [Official Website](https://github.com/turboderp/exllamav2)

--- a/docs/tools/process_understanding/docling-mcp.md
+++ b/docs/tools/process_understanding/docling-mcp.md
@@ -71,6 +71,8 @@ Unlike simple OCR or text extraction, Docling MCP can reconstruct the logical st
 - [OCRmyPDF](ocrmypdf.md)
 - [Milvus](https://milvus.io/)
 - [RAGFlow](ragflow.md)
+- [LangGraph](../frameworks/langgraph.md)
+- [Smolagents](../frameworks/smolagents.md)
 
 ## Sources / references
 - [GitHub Repository](https://github.com/docling-project/docling-mcp)

--- a/docs/tools/providers/cohere.md
+++ b/docs/tools/providers/cohere.md
@@ -108,6 +108,10 @@ embeddings = co.embed(
 - [OpenAI](../ai_knowledge/openai.md)
 - [Anthropic](anthropic.md)
 - [OpenRouter](../ai_knowledge/openrouter.md)
+- [DeepSeek](deepseek.md)
+- [Mistral](mistral.md)
+- [Google Gemini](../ai_knowledge/gemini.md)
+- [Meta Llama](../ai_knowledge/llama.md)
 
 ## Sources / References
 - [Official Website](https://cohere.com/)


### PR DESCRIPTION
I have verified and closed the five oldest 'Resolved' batches (63, 64, 69, 70, and 71) in the Ralph-loop triage report. 

As part of this verification:
1.  **Audited 25 documentation files** against 'High Confidence' standards (>=10 headers, >=7 internal links, technical examples, metadata).
2.  **Deepened 8 files** with additional internal links to meet the minimum requirement:
    - `chronos-mcp.md`
    - `vault-mcp.md`
    - `langgraph.md`
    - `semantic-kernel.md`
    - `smolagents.md`
    - `docling-mcp.md`
    - `cohere.md`
    - `exllamav2.md`
3.  **Validated all changes** using `scripts/check_docs_contract.py`, `scripts/audit_docs_quality.py`, and `scripts/check_catalog_consistency.py`. All tests passed with 100% compliance.
4.  **Updated `docs/reports/ralph-loop-triage.md`** to reflect the 'Verified & Closed' status for these batches.
5.  **Generated 5 individual verification reports** in `docs/reports/` to document the specific actions and validation results for each batch.

This completes the processing of the five oldest issues as requested.

---
*PR created automatically by Jules for task [12220669845280641974](https://jules.google.com/task/12220669845280641974) started by @joanmarcriera*