### PR TITLE
Integrate 5 new sources and fix infrastructure doc links

### DIFF
--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -7,11 +7,11 @@
 | GGUF | https://github.com/philpax/ggml/blob/gguf-spec/docs/gguf.md | related | integrated | GGUF | Referenced in docs/tools/infrastructure/aphrodite-engine.md |
 | DRY Sampler | https://github.com/PygmalionAI/aphrodite-engine/blob/main/docs/samplers.md#dry | related | integrated | DRY Sampler | Referenced in docs/tools/infrastructure/aphrodite-engine.md |
 | XTC Sampler | https://github.com/PygmalionAI/aphrodite-engine/blob/main/docs/samplers.md#xtc | related | integrated | XTC Sampler | Referenced in docs/tools/infrastructure/aphrodite-engine.md |
-| Local LLMs (Ollama, MLX, llama.cpp) | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/lm-studio.md |
-| JSON Schema | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/sglang.md |
-| Python SDK | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/sglang.md |
-| LM Studio | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/localai.md |
-| Model Serving Patterns | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/localai.md |
+| Local LLMs (Ollama, MLX, llama.cpp) | [Local LLMs](../tools/ai_knowledge/local_llms.md) | related | integrated | Local LLMs | Referenced in docs/tools/infrastructure/lm-studio.md |
+| JSON Schema | https://json-schema.org/ | related | integrated | JSON Schema | Referenced in docs/tools/infrastructure/sglang.md |
+| Python SDK | https://github.com/sgl-project/sglang/tree/main/python/sglang | related | integrated | SGLang Python SDK | Referenced in docs/tools/infrastructure/sglang.md |
+| LM Studio | [LM Studio](../tools/infrastructure/lm-studio.md) | related | integrated | LM Studio | Referenced in docs/tools/infrastructure/localai.md |
+| Model Serving Patterns | [Model Serving Patterns](../knowledge_base/model_routing_guide.md) | related | integrated | Model Routing Guide | Referenced in docs/tools/infrastructure/localai.md |
 | Weights & Biases | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/openpipe.md |
 | Unstructured | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/openpipe.md |
 | LlamaParse | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/openpipe.md |

--- a/docs/tools/infrastructure/lm-studio.md
+++ b/docs/tools/infrastructure/lm-studio.md
@@ -72,7 +72,7 @@ print(response.choices[0].message.content)
 - **Self-hostable**: Local desktop runtime only
 
 ## Related tools / concepts
-- [Local LLMs (Ollama, MLX, llama.cpp)](local_llms.md)
+- [Local LLMs (Ollama, MLX, llama.cpp)](../ai_knowledge/local_llms.md)
 - [Ollama](../../services/ollama.md)
 - [Jan.ai](jan-ai.md)
 - [Msty](msty.md)
@@ -84,5 +84,5 @@ print(response.choices[0].message.content)
 - [LM Studio CLI Documentation](https://lmstudio.ai/docs/cli)
 
 ## Contribution Metadata
-- Last reviewed: 2026-06-01
+- Last reviewed: 2026-06-03
 - Confidence: high

--- a/docs/tools/infrastructure/localai.md
+++ b/docs/tools/infrastructure/localai.md
@@ -113,7 +113,7 @@ print(response.choices[0].message.content)
 
 ## Related tools / concepts
 - [Ollama](../../services/ollama.md)
-- [LM Studio](../ai_knowledge/lm-studio.md)
+- [LM Studio](lm-studio.md)
 - [llmfit](../development_ops/llmfit.md)
 - [llama.cpp](llama-cpp.md)
 - [vLLM](vllm.md)
@@ -121,15 +121,14 @@ print(response.choices[0].message.content)
 - [Home Assistant](../../services/home-assistant.md)
 - [n8n](../../services/n8n.md)
 - [Open WebUI](../../services/open-webui.md)
-- [Model Serving Patterns](../../knowledge_base/patterns/model_routing_guide.md)
-- [LM Studio](../ai_knowledge/lm-studio.md)
+- [Model Serving Patterns](../../knowledge_base/model_routing_guide.md)
 
 ## Sources / References
 - [LocalAI Documentation](https://localai.io/)
- - [Model Serving Patterns](../../knowledge_base/patterns/model_routing_guide.md)
+ - [Model Serving Patterns](../../knowledge_base/model_routing_guide.md)
 - [LocalAI GitHub Repository](https://github.com/mudler/LocalAI)
 - [Model Gallery](https://localai.io/models/)
 
 ## Contribution Metadata
-- Last reviewed: 2026-06-02
+- Last reviewed: 2026-06-03
 - Confidence: high

--- a/docs/tools/infrastructure/sglang.md
+++ b/docs/tools/infrastructure/sglang.md
@@ -89,8 +89,8 @@ Unlike traditional LRU caching, **RadixAttention** manages the KV cache as a rad
 - [Aphrodite Engine](aphrodite-engine.md)
 - [llama.cpp](llama-cpp.md)
 - [Inference engines](index.md)
-- [JSON Schema](../knowledge_base/json-schema.md)
-- [Python SDK](../development_ops/python-sdk.md)
+- [JSON Schema](https://json-schema.org/)
+- [Python SDK](https://github.com/sgl-project/sglang/tree/main/python/sglang)
 
 ## Sources / References
 - [Official Website](https://sgl-project.github.io/)
@@ -99,5 +99,5 @@ Unlike traditional LRU caching, **RadixAttention** manages the KV cache as a rad
 - [RadixAttention Technical Paper](https://arxiv.org/abs/2312.04515)
 
 ## Contribution Metadata
-- Last reviewed: 2026-06-02
+- Last reviewed: 2026-06-03
 - Confidence: high


### PR DESCRIPTION
I have integrated the first 5 pending items from the 2026-06-01 new-sources log. This involved researching valid external URLs and internal relative links, updating the target documentation files (LM Studio, SGLang, LocalAI) to remove placeholders and fix broken links, and marking the items as integrated in the log file. All changes were verified using the repository's validation scripts.

---
*PR created automatically by Jules for task [12164598308908252663](https://jules.google.com/task/12164598308908252663) started by @joanmarcriera*