### PR TITLE
Ralph-loop: Integrate 5 new sources from June 1st log

### DIFF
--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -12,11 +12,11 @@
 | Python SDK | https://github.com/sgl-project/sglang/tree/main/python/sglang | related | integrated | SGLang Python SDK | Referenced in docs/tools/infrastructure/sglang.md |
 | LM Studio | [LM Studio](../tools/infrastructure/lm-studio.md) | related | integrated | LM Studio | Referenced in docs/tools/infrastructure/localai.md |
 | Model Serving Patterns | [Model Serving Patterns](../knowledge_base/model_routing_guide.md) | related | integrated | Model Routing Guide | Referenced in docs/tools/infrastructure/localai.md |
-| Weights & Biases | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/openpipe.md |
-| Unstructured | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/openpipe.md |
-| LlamaParse | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/openpipe.md |
-| Dify | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/supabase.md |
-| Longhorn | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/k3s.md |
+| Weights & Biases | https://wandb.ai/site/ | related | integrated | [Weights & Biases](../process_understanding/wandb-weave.md) | Referenced in docs/tools/infrastructure/openpipe.md |
+| Unstructured | https://unstructured.io/blog | related | integrated | [Unstructured](../intake_storage/unstructured.md) | Referenced in docs/tools/infrastructure/openpipe.md |
+| LlamaParse | https://www.llamaindex.ai/llamaparse/ | related | integrated | [LlamaParse](../intake_storage/llamaparse.md) | Referenced in docs/tools/infrastructure/openpipe.md |
+| Dify | https://dify.ai/ | related | integrated | [Dify](../ai_knowledge/dify.md) | Referenced in docs/tools/infrastructure/supabase.md |
+| Longhorn | https://longhorn.io/ | related | integrated | Longhorn | Referenced in docs/tools/infrastructure/k3s.md |
 | Llama Factory | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/mlx.md |
 | Model Serving Patterns | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/zse.md |
 | Quantization | https://tbd.com | related | new | TBD | Referenced in docs/tools/infrastructure/exllamav2.md |

--- a/docs/tools/infrastructure/k3s.md
+++ b/docs/tools/infrastructure/k3s.md
@@ -89,7 +89,7 @@ sudo k3s kubectl apply -f whoami.yaml
 - [Home Assistant (via HASS-K8s)](../../services/home-assistant.md)
 - [TrueNAS SCALE (Uses K3s internally)](../../architecture/infrastructure.md)
 - [Talos OS](../../knowledge_base/talos-vs-ubuntu-k3s.md)
-- [Longhorn](../../roadmap.md)
+- [Longhorn](https://longhorn.io/)
 
 ## Sources / References
 - [Official Website](https://k3s.io/)

--- a/docs/tools/infrastructure/openpipe.md
+++ b/docs/tools/infrastructure/openpipe.md
@@ -129,17 +129,17 @@ response = client.chat.completions.create(
 - [vLLM](vllm.md)
 - [OpenRouter](../ai_knowledge/openrouter.md)
 - [LangSmith](../benchmarking/langsmith.md)
-- [Weights & Biases](../benchmarking/wandb.md)
-- [Unstructured](../process_understanding/unstructured.md)
-- [LlamaParse](../process_understanding/llamaparse.md)
+- [Weights & Biases](../process_understanding/wandb-weave.md)
+- [Unstructured](../intake_storage/unstructured.md)
+- [LlamaParse](../intake_storage/llamaparse.md)
 
 ## Sources / References
 - [Official Website](https://openpipe.ai/)
 - [GitHub](https://github.com/openpipe/openpipe)
 - [Docs](https://docs.openpipe.ai/)
-- [Weights & Biases](../process_understanding/wandb-weave.md)
-- [Unstructured](../intake_storage/unstructured.md)
-- [LlamaParse](../intake_storage/llamaparse.md)
+- [Weights & Biases](https://wandb.ai/)
+- [Unstructured](https://unstructured.io/)
+- [LlamaParse](https://www.llamaindex.ai/llamaparse)
 
 ## Contribution Metadata
 - Last reviewed: 2026-06-02

--- a/docs/tools/infrastructure/supabase.md
+++ b/docs/tools/infrastructure/supabase.md
@@ -216,14 +216,14 @@ const channel = supabase
 - [n8n](../../services/n8n.md) — Workflow automation that often uses Supabase for state.
 - [Tavily](../providers/tavily.md) — AI-native search that can feed data into Supabase.
 - [Open WebUI](../../services/open-webui.md) — Self-hosted UI for LLMs that can be backed by Postgres.
-- [Dify](../automation_orchestration/dify.md) — LLM application development platform.
+- [Dify](../ai_knowledge/dify.md) — LLM application development platform.
 
 ## Sources / References
 - [Official Website](https://supabase.com/)
 - [Documentation](https://supabase.com/docs)
 - [GitHub Repository](https://github.com/supabase/supabase)
 - [pgvector on Supabase](https://supabase.com/docs/guides/ai)
-- [Dify Integration](../ai_knowledge/dify.md)
+- [Dify](https://dify.ai/)
 
 ## Contribution Metadata
 - Last reviewed: 2026-06-02


### PR DESCRIPTION
Integrated the next batch of 5 items from the 2026-06-01 intake log. Replaced TBD placeholders with verified official URLs for Weights & Biases, Unstructured, LlamaParse, Dify, and Longhorn. Fixed broken internal relative links in referencing documentation (openpipe.md, supabase.md, and k3s.md) and updated the status of these items to 'integrated'.

---
*PR created automatically by Jules for task [1454146793466648184](https://jules.google.com/task/1454146793466648184) started by @joanmarcriera*