### PR TITLE
Ralph-loop: Integrate LiveCodeBench and Resolve TBD Links (Batch 104-110)

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -1354,6 +1354,12 @@
       "doc_path": "docs/services/litellm.md"
     },
     {
+      "id": "livecodebench",
+      "name": "LiveCodeBench",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/livecodebench.md"
+    },
+    {
       "id": "llama-cpp",
       "name": "llama.cpp",
       "category": "Process & Understanding",

--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -101,13 +101,13 @@
 | Helm | https://helm.sh/ | related | integrated | Helm | Referenced in docs/tools/development_ops/cloud_code.md |
 | Python | https://docs.python.org/3/?ref=jupyter | related | integrated | [Python](../tools/ai_knowledge/python.md) | Referenced in docs/tools/development_ops/jupyter-kernel-mcp.md |
 | Standards and Conventions | https://github.com/OpenClaw/OpenClaw/blob/main/docs/standards.md | related | integrated | [Standards and Conventions](../../standards.md) | Referenced in docs/tools/development_ops/claude-context-mode.md |
-| Architecture Index | https://tbd.com | related | new | TBD | Referenced in docs/tools/development_ops/claude-context-mode.md |
-| CI/CD Workflows | https://tbd.com | related | new | TBD | Referenced in docs/tools/development_ops/claude-code-container-mcp.md |
+| Architecture Index | https://github.com/OpenClaw/OpenClaw/blob/main/ARCHITECTURE.md | related | integrated | [Architecture Index](../../ARCHITECTURE.md) | Referenced in docs/tools/development_ops/claude-context-mode.md |
+| CI/CD Workflows | https://github.com/OpenClaw/OpenClaw/blob/main/docs/playbooks/dev-workflow-ai-assisted.md | related | integrated | [CI/CD Workflows](../../playbooks/dev-workflow-ai-assisted.md) | Referenced in docs/tools/development_ops/claude-code-container-mcp.md |
 | OpenHands | https://github.com/OpenHands/openhands?ref=dream | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/benchmarking/dream.md |
 | OpenHands | https://github.com/OpenHands/openhands?ref=swebench | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/benchmarking/swe-bench.md |
-| LiveCodeBench | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/bigcodebench.md |
-| Grafana | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/supermetal.md |
-| Data Copilot Synthesis | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/judgegpt.md |
+| LiveCodeBench | https://livecodebench.github.io/ | related | integrated | [LiveCodeBench](../tools/benchmarking/livecodebench.md) | Referenced in docs/tools/benchmarking/bigcodebench.md |
+| Grafana | https://grafana.com/ | related | integrated | [Grafana Cloud](../tools/process_understanding/grafana-cloud.md) | Referenced in docs/tools/benchmarking/supermetal.md |
+| Data Copilot Synthesis | https://github.com/OpenClaw/OpenClaw/blob/main/docs/reference-implementations/data-copilot/answer-synthesis-schema.md | related | integrated | [Data Copilot Synthesis](../../reference-implementations/data-copilot/answer-synthesis-schema.md) | Referenced in docs/tools/benchmarking/judgegpt.md |
 | OpenHands | https://github.com/OpenHands/openhands?ref=longcli | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/benchmarking/longcli-bench.md |
 | OpenHands | https://github.com/OpenHands/openhands?ref=pabench | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/benchmarking/pa-bench.md |
 | GAIA (General AI Assistants) | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/pa-bench.md |

--- a/docs/tools/benchmarking/judgegpt.md
+++ b/docs/tools/benchmarking/judgegpt.md
@@ -7,7 +7,7 @@ JudgeGPT is an open-source benchmarking tool that implements the **LLM-as-a-judg
 It addresses the limitations of traditional, static evaluation metrics (like BLEU or ROUGE) which fail to capture the nuance, creativity, and semantic correctness of modern LLM outputs. JudgeGPT automates the labor-intensive process of human evaluation while providing more consistent and scalable results. It helps in identifying [hallucinations](../../knowledge_base/llm_security_privacy.md) and regressions in complex reasoning tasks.
 
 ## Where it fits in the stack
-**Benchmarking / Evaluation**. It is used in the development and fine-tuning cycle to quantify model performance. It can be integrated into [Data Copilot](../../reference-implementations/data-copilot/README.md) workflows to validate synthesized data quality.
+**Benchmarking / Evaluation**. It is used in the development and fine-tuning cycle to quantify model performance. It can be integrated into [Data Copilot](../../reference-implementations/data-copilot/answer-synthesis-schema.md) workflows to validate synthesized data quality.
 
 ## Typical use cases
 - **Model Comparison**: Automatically scoring two different models on the same set of prompts to determine which performs better.
@@ -95,7 +95,7 @@ Output your evaluation in JSON format.
 - [Fine-tuning Open Models](../../knowledge_base/patterns/fine-tuning-open-models.md)
 - [Claude Skills Best Practices](../../knowledge_base/patterns/skills-best-practices.md)
 - [LLM Security & Privacy](../../knowledge_base/llm_security_privacy.md)
-- [Data Copilot Synthesis](../../reference-implementations/data-copilot/README.md)
+- [Data Copilot Synthesis](../../reference-implementations/data-copilot/answer-synthesis-schema.md)
 
 ## Sources / References
 - [Project JudgeGPT: Open-source LLM-as-judge](https://www.reddit.com/r/MachineLearning/comments/1rsxcl3/project_judgegpt_opensource_llmasjudge/)

--- a/docs/tools/benchmarking/livecodebench.md
+++ b/docs/tools/benchmarking/livecodebench.md
@@ -1,0 +1,89 @@
+# LiveCodeBench
+
+## What it is
+LiveCodeBench is a holistic and contamination-free evaluation benchmark for Large Language Models (LLMs) specialized in code. It continuously collects new problems from periodic contests on platforms like LeetCode, AtCoder, and Codeforces to ensure that models are evaluated on unseen data.
+
+## What problem it solves
+Traditional benchmarks such as HumanEval or MBPP are static and have become heavily contaminated, as their problems are often included in the training sets of newer models. LiveCodeBench addresses this by using release dates to evaluate models only on problems published after their training cutoff, providing a truer measure of generalization.
+
+## Where it fits in the stack
+**Benchmarking / Evaluation**. It provides a dynamic signal for the capabilities of code-generation models and autonomous agents.
+
+## Typical use cases
+- **Contamination Analysis**: Measuring how much a model's performance on older benchmarks is due to memorization vs. generalization.
+- **Holistic Capability Assessment**: Evaluating models not just on code generation, but also on self-repair, code execution, and test output prediction.
+- **Model Comparison**: Ranking models (e.g., Claude 3.5 vs. GPT-4o) on the latest competitive programming challenges.
+
+## Strengths
+- **Contamination-Free**: Annotates problems with release dates, allowing for temporally-scoped evaluations.
+- **Holistic**: Beyond generation, it tests execution, repair, and prediction.
+- **Dynamic**: Continuously updated with new problems from active coding contest platforms.
+- **Diverse**: Covers problems from multiple platforms (LeetCode, AtCoder, Codeforces).
+
+## Limitations
+- **Competitive Programming Focus**: Like many benchmarks, it heavily features algorithmic and data structure problems which may not fully represent general software engineering tasks.
+- **Python Centricity**: While the platforms support many languages, most LLM evaluation focuses on the Python subset.
+
+## When to use it
+- When evaluating the "true" coding intelligence of a new model released after 2023.
+- When you need to understand a model's ability to reason about code execution rather than just writing it.
+
+## When not to use it
+- For base models that have not undergone instruction tuning for coding tasks.
+- If you require evaluation of large-scale repository-level software engineering (consider [SWE-bench](swe-bench.md) instead).
+
+## Getting started
+LiveCodeBench is primarily used as a leaderboard and a dataset for model evaluation. You can interact with it via its official website or by using the evaluation scripts provided in its GitHub repository.
+
+## Technical examples
+
+### Running Evaluation (CLI)
+You can use the LiveCodeBench repository to evaluate a model's generations.
+
+```bash
+# Clone the repository
+git clone https://github.com/LiveCodeBench/LiveCodeBench
+cd LiveCodeBench
+
+# Run evaluation for a specific model's output
+python -m lcb_runner.evaluation.main \
+    --model_name "your-model-id" \
+    --scenario "codegeneration" \
+    --release_date "2024-01-01"
+```
+
+### Data Structure (JSON)
+Each problem in the benchmark includes metadata about its release date and platform.
+
+```json
+{
+    "question_id": "1234",
+    "title": "Example Problem",
+    "platform": "LeetCode",
+    "release_date": "2024-02-15",
+    "difficulty": "Hard",
+    "test_cases": [...]
+}
+```
+
+## Licensing and cost
+- **Open Source**: Yes (MIT License).
+- **Cost**: Free to use (software and dataset).
+
+## Related tools / concepts
+- [HumanEval](human-eval.md)
+- [MBPP](mbpp.md)
+- [EvalPlus](evalplus.md)
+- [BigCodeBench](bigcodebench.md)
+- [SWE-bench](swe-bench.md)
+- [Chatbot Arena](chatbot-arena.md)
+- [Contamination Analysis](../../knowledge_base/model_comparison_and_evaluation.md)
+
+## Sources / references
+- [LiveCodeBench Official Website](https://livecodebench.github.io/)
+- [LiveCodeBench GitHub Repository](https://github.com/LiveCodeBench/LiveCodeBench)
+- [LiveCodeBench: Holistic and Contamination Free Evaluation of Large Language Models for Code (arXiv)](https://arxiv.org/abs/2403.07974)
+
+## Contribution Metadata
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/tools/benchmarking/supermetal.md
+++ b/docs/tools/benchmarking/supermetal.md
@@ -69,7 +69,7 @@ curl "https://your-supermetal-instance/api/v1/connectors"
 - [AirOps](../automation_orchestration/airops.md)
 - [Temporal](../orchestration/temporal.md)
 - [Datadog](../process_understanding/datadog.md)
-- [Grafana](../process_understanding/grafana.md)
+- [Grafana](../process_understanding/grafana-cloud.md)
 - [ClickHouse](../process_understanding/clickhouse.md)
 - [Snowflake](../process_understanding/snowflake.md)
 - [Real-time Sync Engines](../../knowledge_base/real_time_sync_engines.md)

--- a/docs/tools/development_ops/claude-code-container-mcp.md
+++ b/docs/tools/development_ops/claude-code-container-mcp.md
@@ -105,7 +105,7 @@ Move files between the host and the container for initial setup or result extrac
 - [Desktop Commander MCP](desktop-commander-mcp.md)
 - [Model Context Protocol (MCP)](../automation_orchestration/mcp.md)
 - [MCP Registry](../automation_orchestration/mcp-registry.md)
-- [CI/CD Workflows](../../playbooks/dev-workflow.md)
+- [CI/CD Workflows](../../playbooks/dev-workflow-ai-assisted.md)
 - [Fuzzing MCP Server](fuzzing-mcp-server.md)
 - [Jupyter Kernel MCP](jupyter-kernel-mcp.md)
 - [Symbolic MCP](symbolic-mcp.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -284,6 +284,7 @@ nav:
           - LangSmith: tools/benchmarking/langsmith.md
           - LLMperf: tools/benchmarking/llmperf.md
           - Lm Evaluation Harness: tools/benchmarking/lm-evaluation-harness.md
+          - LiveCodeBench: tools/benchmarking/livecodebench.md
           - LongCLI-Bench: tools/benchmarking/longcli-bench.md
           - Mbpp: tools/benchmarking/mbpp.md
           - Ollama Benchmark Cli: tools/benchmarking/ollama-benchmark-cli.md


### PR DESCRIPTION
This PR processes the five oldest 'new' items from the `docs/new-sources/2026-06-01.md` intake log as part of the Ralph-loop directive. 

Key changes:
1. **LiveCodeBench Integration**: Created `docs/tools/benchmarking/livecodebench.md` with technical examples and internal links. Added it to the central tool registry and site navigation.
2. **Link Resolution**: Replaced `https://tbd.com` placeholders in the intake log for Architecture Index, CI/CD Workflows, Grafana, and Data Copilot Synthesis with verified external or internal absolute GitHub URLs.
3. **Broken Link Repair**: 
    - Updated `claude-code-container-mcp.md` to point to the correct `dev-workflow-ai-assisted.md`.
    - Updated `supermetal.md` to point to `grafana-cloud.md`.
    - Updated `judgegpt.md` to point to the `answer-synthesis-schema.md`.
4. **Validation**: All modifications passed `scripts/check_docs_contract.py`, `scripts/audit_docs_quality.py`, `scripts/check_catalog_consistency.py`, and `scripts/validate_new_sources.py`.

---
*PR created automatically by Jules for task [13291110309784165960](https://jules.google.com/task/13291110309784165960) started by @joanmarcriera*