### PR TITLE
Integrate GAIA, AssistantBench, and OSWorld Benchmarks

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -198,6 +198,12 @@
       "doc_path": "docs/tools/benchmarking/asdiv.md"
     },
     {
+      "id": "assistant-bench",
+      "name": "AssistantBench",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/assistant-bench.md"
+    },
+    {
       "id": "atlassian-jira-mcp-implementations",
       "name": "Atlassian Jira MCP Implementations",
       "category": "Automation & Orchestration",
@@ -861,6 +867,12 @@
       "name": "Fyxer AI",
       "category": "Enterprise AI",
       "doc_path": "docs/tools/enterprise/fyxer.md"
+    },
+    {
+      "id": "gaia",
+      "name": "GAIA (General AI Assistants)",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/gaia.md"
     },
     {
       "id": "gemini",
@@ -1751,6 +1763,12 @@
       "name": "Ollama Benchmark CLI",
       "category": "Benchmarking",
       "doc_path": "docs/tools/benchmarking/ollama-benchmark-cli.md"
+    },
+    {
+      "id": "os-world",
+      "name": "OSWorld",
+      "category": "Benchmarking",
+      "doc_path": "docs/tools/benchmarking/os-world.md"
     },
     {
       "id": "omni-tools",

--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -110,11 +110,11 @@
 | Data Copilot Synthesis | https://github.com/OpenClaw/OpenClaw/blob/main/docs/reference-implementations/data-copilot/answer-synthesis-schema.md | related | integrated | [Data Copilot Synthesis](../../reference-implementations/data-copilot/answer-synthesis-schema.md) | Referenced in docs/tools/benchmarking/judgegpt.md |
 | OpenHands | https://github.com/OpenHands/openhands?ref=longcli | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/benchmarking/longcli-bench.md |
 | OpenHands | https://github.com/OpenHands/openhands?ref=pabench | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/benchmarking/pa-bench.md |
-| GAIA (General AI Assistants) | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/pa-bench.md |
-| AssistantBench | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/pa-bench.md |
-| OSWorld | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/pa-bench.md |
-| OpenAI | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/chatbot-arena.md |
-| Google Gemini | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/chatbot-arena.md |
+| GAIA (General AI Assistants) | https://gaia-benchmark.github.io/ | related | integrated | [GAIA](https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/benchmarking/gaia.md) | Referenced in docs/tools/benchmarking/pa-bench.md |
+| AssistantBench | https://assistantbench.github.io/ | related | integrated | [AssistantBench](https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/benchmarking/assistant-bench.md) | Referenced in docs/tools/benchmarking/pa-bench.md |
+| OSWorld | https://os-world.github.io/ | related | integrated | [OSWorld](https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/benchmarking/os-world.md) | Referenced in docs/tools/benchmarking/pa-bench.md |
+| OpenAI | https://openai.com/ | related | integrated | [OpenAI](https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/ai_knowledge/openai.md) | Referenced in docs/tools/benchmarking/chatbot-arena.md |
+| Google Gemini | https://gemini.google.com/?ref=chatbotarena | related | integrated | [Google Gemini](https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/ai_knowledge/google-gemini.md) | Referenced in docs/tools/benchmarking/chatbot-arena.md |
 | Meta Llama | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/chatbot-arena.md |
 | Giskard | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/sharp-ai.md |
 | Lakera Guard | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/sharp-ai.md |

--- a/docs/tools/benchmarking/assistant-bench.md
+++ b/docs/tools/benchmarking/assistant-bench.md
@@ -1,0 +1,67 @@
+# AssistantBench
+
+## What it is
+AssistantBench is a benchmark designed to evaluate whether web agents can solve realistic, time-consuming, and multi-step tasks on the open web.
+
+## What problem it solves
+It addresses the limitation of benchmarks that focus on atomic actions or single-site interactions. AssistantBench provides 214 tasks that require agents to navigate multiple websites, retrieve information, and reason over it to find answers that a human would typically find "time-consuming."
+
+## Where it fits in the stack
+**Eval**. It serves as a rigorous testing ground for web-connected agents and browser-based automation systems.
+
+## Typical use cases
+- **Web Agent Evaluation**: Testing the reliability of agents like OpenHands, Multi-On, or custom Playwright-based agents.
+- **Information Retrieval**: Measuring the ability to synthesize data from diverse web sources (e.g., real estate, business listings).
+- **Long-Horizon Planning**: Evaluating how agents handle tasks that take 10+ minutes for a human.
+
+## Strengths
+- **Realistic Tasks**: Based on actual queries humans perform on the web.
+- **Multi-domain**: Covers real estate, travel, business, and more.
+- **Execution-based**: Evaluation is grounded in the final answer found on the live web.
+
+## Limitations
+- **Web Volatility**: Since it uses the live web, changes in site structure can affect reproducibility.
+- **Latency**: Running full trajectories on the open web is slower than synthetic environments.
+
+## When to use it
+- When building agents intended for public web navigation.
+- When you need to measure success on complex, multi-site "information seeking" missions.
+
+## When not to use it
+- For testing basic UI interaction (use a UI-specific benchmark like OSWorld).
+- For evaluating models in a sandbox without internet access.
+
+## Getting started
+AssistantBench is supported by the `inspect-ai` framework.
+
+### 1. Installation
+```bash
+pip install inspect-evals
+```
+
+### 2. Running AssistantBench
+```bash
+inspect eval inspect_evals/assistant_bench_web_browser --model openai/gpt-4o
+```
+
+## Related tools / concepts
+- [PA-bench](./pa-bench.md)
+- [GAIA](./gaia.md)
+- [OSWorld](./os-world.md)
+- [WebArena](https://webarena.dev/)
+- [OpenHands](../development_ops/openhands.md)
+- [Stagehand](../automation_orchestration/stagehand.md)
+
+## Licensing and cost
+- **Open Source**: Yes
+- **Cost**: Free (benchmark), but requires internet access and LLM API credits.
+
+## Sources / References
+- [AssistantBench: Can Web Agents Solve Realistic and Time-Consuming Tasks? (ArXiv)](https://arxiv.org/abs/2407.15711)
+- [AssistantBench Project Website](https://assistantbench.github.io/)
+- [AssistantBench GitHub](https://github.com/assistantbench/assistantbench)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/tools/benchmarking/chatbot-arena.md
+++ b/docs/tools/benchmarking/chatbot-arena.md
@@ -73,10 +73,10 @@ print(dataset['train'][0])
 - [LM Evaluation Harness](lm-evaluation-harness.md)
 - [MMLU](mmlu.md)
 - [GPQA](gpqa.md)
-- [OpenAI](../providers/openai.md)
+- [OpenAI](../ai_knowledge/openai.md)
 - [Anthropic](../providers/anthropic.md)
-- [Google Gemini](../providers/google.md)
-- [Meta Llama](../providers/meta.md)
+- [Google Gemini](../ai_knowledge/google-gemini.md)
+- [Meta Llama](https://llama.meta.com/)
 
 ## Sources / references
 - [LMSYS Chatbot Arena](https://arena.lmsys.org/)

--- a/docs/tools/benchmarking/gaia.md
+++ b/docs/tools/benchmarking/gaia.md
@@ -1,0 +1,68 @@
+# GAIA (General AI Assistants)
+
+## What it is
+GAIA (General AI Assistants) is a benchmark proposed to evaluate General AI Assistants. It consists of 450 non-trivial questions that are conceptually simple for humans but challenging for most advanced AI systems.
+
+## What problem it solves
+Existing benchmarks often focus on narrow tasks or synthetic reasoning. GAIA targets real-world tasks that require fundamental abilities such as reasoning, multi-modality handling, web browsing, and tool-use proficiency. It aims to measure how well an agent can function as a general-purpose assistant.
+
+## Where it fits in the stack
+**Eval**. It provides a high-signal benchmark for testing autonomous agents and LLMs on multi-step, real-world tasks.
+
+## Typical use cases
+- **Agent Benchmarking**: Comparing the performance of different agent architectures on realistic assistant tasks.
+- **Tool-Use Proficiency**: Measuring an agent's ability to select and use external tools (browsers, interpreters) correctly.
+- **Reasoning Evaluation**: Testing long-horizon reasoning and planning in open-ended environments.
+
+## Strengths
+- **Non-synthetic**: Questions are grounded in real-world scenarios.
+- **Ease for Humans**: Tasks are generally easy for a human to complete in a few minutes, making the performance gap with AIs very clear.
+- **Multi-modal**: Requires handling text, images, and other file formats.
+- **Robustness**: Designed to be hard to solve via pure memorization or "cheating" through data contamination.
+
+## Limitations
+- **Evaluation Difficulty**: Requires execution-based evaluation or human-in-the-loop for complex open-ended responses.
+- **Environment Dependency**: Web-based tasks are subject to site changes.
+
+## When to use it
+- When you want to evaluate the "generalist" capability of an AI agent.
+- When you need a benchmark that goes beyond simple RAG or coding.
+
+## When not to use it
+- For testing very specific domain expertise (e.g., medical, legal) unless it falls under general assistant tasks.
+- For lightweight testing where a simpler benchmark (like MMLU) suffices.
+
+## Getting started
+GAIA evaluations are often run using frameworks like `inspect-ai`.
+
+### 1. Installation
+```bash
+pip install inspect-evals[gaia]
+```
+
+### 2. Running GAIA with Inspect
+```bash
+inspect eval inspect_evals/gaia --model openai/gpt-4o
+```
+
+## Related tools / concepts
+- [PA-bench](./pa-bench.md)
+- [AssistantBench](./assistant-bench.md)
+- [OSWorld](./os-world.md)
+- [MMLU](./mmlu.md)
+- [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md)
+- [Tool Calling](../../knowledge_base/patterns/tool-calling-and-mcp.md)
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0 / CC-BY-SA 4.0)
+- **Cost**: Free to use the benchmark, but requires LLM API credits.
+
+## Sources / References
+- [GAIA: A Benchmark for General AI Assistants (ArXiv)](https://arxiv.org/abs/2311.12983)
+- [GAIA Project Website](https://gaia-benchmark.github.io/)
+- [GAIA Leaderboard (Hugging Face)](https://huggingface.co/spaces/gaia-benchmark/leaderboard)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/tools/benchmarking/os-world.md
+++ b/docs/tools/benchmarking/os-world.md
@@ -1,0 +1,67 @@
+# OSWorld
+
+## What it is
+OSWorld is a scalable, real computer environment for benchmarking multimodal agents. It supports task setup, execution-based evaluation, and interactive learning across operating systems like Ubuntu, Windows, and macOS.
+
+## What problem it solves
+Most agent benchmarks are limited to the web or specific applications. OSWorld provides a unified environment for assessing open-ended computer tasks that involve arbitrary desktop applications, file I/O, and workflows spanning multiple apps.
+
+## Where it fits in the stack
+**Eval / Environment**. It provides both the benchmarking tasks and the interactive "OS-in-a-box" infrastructure for agent testing.
+
+## Typical use cases
+- **Desktop Agent Evaluation**: Testing agents that interact with native OS elements (menus, file explorers, desktop apps).
+- **Multi-app Workflows**: Evaluating tasks that require moving data between a spreadsheet, a browser, and a local text editor.
+- **VLM Grounding**: Benchmarking the visual grounding capabilities of Vision-Language Models (VLMs) on complex GUIs.
+
+## Strengths
+- **Real OS Environments**: Uses VMware, VirtualBox, or Docker to host actual operating systems.
+- **Diverse Tasks**: 369 tasks derived from real-world computer use cases.
+- **Execution-based Evaluation**: Uses custom scripts to verify the final state of the OS (e.g., "is the file saved in the correct directory?").
+- **Multi-OS**: Not limited to just Linux; includes Windows and macOS support.
+
+## Limitations
+- **Heavy Infrastructure**: Requires virtualization software and significant local/cloud resources to run VM instances.
+- **Setup Complexity**: Initial environment configuration can be challenging.
+
+## When to use it
+- When developing "Computer Use" agents (like Claude Computer Use or Open Operator).
+- When you need to test an agent's ability to handle OS-level interactions and native apps.
+
+## When not to use it
+- For lightweight testing of pure web agents (use WebArena or AssistantBench).
+- If you lack the hardware resources to run virtual machines.
+
+## Getting started
+OSWorld is typically run by cloning the repository and setting up a virtual machine environment.
+
+### 1. Installation
+```bash
+git clone https://github.com/xlang-ai/OSWorld
+cd OSWorld
+pip install -r requirements.txt
+```
+
+### 2. Environment Setup
+OSWorld supports VMware, VirtualBox, and Docker. Refer to the [official documentation](https://os-world.github.io/) for OS image setup.
+
+## Related tools / concepts
+- [PA-bench](./pa-bench.md)
+- [GAIA](./gaia.md)
+- [AssistantBench](./assistant-bench.md)
+- [Claude Code](../development_ops/claude-code.md)
+- [OpenHands](../development_ops/openhands.md)
+
+## Licensing and cost
+- **Open Source**: Yes (Apache 2.0)
+- **Cost**: Free, but requires significant compute/storage for VMs.
+
+## Sources / References
+- [OSWorld: Benchmarking Multimodal Agents for Open-Ended Tasks (ArXiv)](https://arxiv.org/abs/2404.07972)
+- [OSWorld Project Website](https://os-world.github.io/)
+- [OSWorld GitHub Repository](https://github.com/xlang-ai/OSWorld)
+
+## Contribution Metadata
+
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/tools/benchmarking/pa-bench.md
+++ b/docs/tools/benchmarking/pa-bench.md
@@ -87,9 +87,9 @@ sim_manager.shutdown()
 - [OpenHands](../development_ops/openhands.md)
 - [SWE-bench](./swe-bench.md)
 - [Terminal-bench](./terminal-bench.md)
-- [GAIA (General AI Assistants)](./gaia.md)
-- [AssistantBench](./assistant-bench.md)
-- [OSWorld](./os-world.md)
+- [GAIA (General AI Assistants)](gaia.md)
+- [AssistantBench](assistant-bench.md)
+- [OSWorld](os-world.md)
 - [WebArena](https://webarena.dev/)
 
 ## Licensing and cost

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -270,38 +270,41 @@ nav:
           - Zapier: tools/automation_orchestration/zapier.md
       - Benchmarking:
           - Overview: tools/benchmarking/index.md
+          - AlpacaEval: tools/benchmarking/alpaca-eval.md
+          - ARC (AI2 Reasoning Challenge): tools/benchmarking/arc.md
+          - ASDiv: tools/benchmarking/asdiv.md
+          - AssistantBench: tools/benchmarking/assistant-bench.md
+          - BigCodeBench: tools/benchmarking/bigcodebench.md
           - Chatbot Arena: tools/benchmarking/chatbot-arena.md
           - DREAM Benchmark: tools/benchmarking/dream.md
+          - EvalPlus: tools/benchmarking/evalplus.md
+          - GAIA (General AI Assistants): tools/benchmarking/gaia.md
           - Gpqa: tools/benchmarking/gpqa.md
           - Gsm8K: tools/benchmarking/gsm8k.md
+          - HELM: tools/benchmarking/helm.md
           - Human Eval: tools/benchmarking/human-eval.md
           - Humanitys Last Exam: tools/benchmarking/humanitys-last-exam.md
           - InterCode: tools/benchmarking/intercode.md
           - JudgeGPT: tools/benchmarking/judgegpt.md
-          - OpenCompass: tools/benchmarking/opencompass.md
-          - HELM: tools/benchmarking/helm.md
-          - EvalPlus: tools/benchmarking/evalplus.md
           - LangSmith: tools/benchmarking/langsmith.md
+          - LiveCodeBench: tools/benchmarking/livecodebench.md
           - LLMperf: tools/benchmarking/llmperf.md
           - Lm Evaluation Harness: tools/benchmarking/lm-evaluation-harness.md
-          - LiveCodeBench: tools/benchmarking/livecodebench.md
           - LongCLI-Bench: tools/benchmarking/longcli-bench.md
+          - MATH Benchmark: tools/benchmarking/math-benchmark.md
           - Mbpp: tools/benchmarking/mbpp.md
+          - MMLU: tools/benchmarking/mmlu.md
+          - MT-Bench: tools/benchmarking/mt-bench.md
           - Ollama Benchmark Cli: tools/benchmarking/ollama-benchmark-cli.md
+          - OpenCompass: tools/benchmarking/opencompass.md
+          - OSWorld: tools/benchmarking/os-world.md
           - Pa Bench: tools/benchmarking/pa-bench.md
           - Promptfoo: tools/benchmarking/promptfoo.md
-          - Swe Bench: tools/benchmarking/swe-bench.md
-          - Supermetal Benchmark: tools/benchmarking/supermetal.md
-          - VAKRA Benchmark: tools/benchmarking/vakra.md
-          - Terminal Bench: tools/benchmarking/terminal-bench.md
-          - MMLU: tools/benchmarking/mmlu.md
-          - ARC (AI2 Reasoning Challenge): tools/benchmarking/arc.md
-          - ASDiv: tools/benchmarking/asdiv.md
-          - BigCodeBench: tools/benchmarking/bigcodebench.md
-          - AlpacaEval: tools/benchmarking/alpaca-eval.md
-          - MT-Bench: tools/benchmarking/mt-bench.md
-          - MATH Benchmark: tools/benchmarking/math-benchmark.md
           - SharpAI Security Benchmark: tools/benchmarking/sharp-ai.md
+          - Supermetal Benchmark: tools/benchmarking/supermetal.md
+          - Swe Bench: tools/benchmarking/swe-bench.md
+          - Terminal Bench: tools/benchmarking/terminal-bench.md
+          - VAKRA Benchmark: tools/benchmarking/vakra.md
       - Calendar & Tasks:
           - Overview: tools/calendar_tasks/index.md
           - Akiflow: tools/calendar_tasks/akiflow.md


### PR DESCRIPTION
This PR integrates items 113-117 from the 2026-06-01 intake log following the Ralph-loop directive. It replaces TBD placeholders with verified URLs, creates new 'High Confidence' documentation for GAIA, AssistantBench, and OSWorld, and updates the repository registry and navigation. It also repairs broken or suboptimal links in pa-bench.md and chatbot-arena.md.

---
*PR created automatically by Jules for task [13933893724977104231](https://jules.google.com/task/13933893724977104231) started by @joanmarcriera*