### PR TITLE
Ralph-loop Integration: Items 124-128 (MMLU, Data Copilot, OpenAI, Entra ID, Enterprise Overview)

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -1558,6 +1558,12 @@
       "doc_path": "docs/tools/development_ops/mentat.md"
     },
     {
+      "id": "microsoft-entra-id",
+      "name": "Microsoft Entra ID",
+      "category": "Enterprise AI",
+      "doc_path": "docs/tools/enterprise/microsoft-entra-id.md"
+    },
+    {
       "id": "microsoft-agent-framework",
       "name": "Microsoft Agent Framework",
       "category": "Frameworks",

--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -121,11 +121,11 @@
 | OpenHands | https://github.com/OpenHands/openhands?ref=terminalbench | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/benchmarking/terminal-bench.md |
 | OSWorld | https://os-world.github.io/ | related | integrated | [OSWorld](https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/benchmarking/os-world.md) | Referenced in docs/tools/benchmarking/terminal-bench.md |
 | RAGFlow | https://ragflow.io/ | related | integrated | [RAGFlow](https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/process_understanding/ragflow.md) | Referenced in docs/tools/benchmarking/langsmith.md |
-| MMLU | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/intercode.md |
-| Data Copilot | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/intercode.md |
-| OpenAI | https://tbd.com | related | new | TBD | Referenced in docs/tools/benchmarking/gpqa.md |
-| Microsoft Entra ID | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/microsoft-graph.md |
-| Enterprise Suite Overview | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/microsoft-graph.md |
+| MMLU | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/benchmarking/mmlu.md | related | integrated | [MMLU](../tools/benchmarking/mmlu.md) | Referenced in docs/tools/benchmarking/intercode.md |
+| Data Copilot | https://github.com/OpenClaw/OpenClaw/tree/main/docs/reference-implementations/data-copilot | related | integrated | [Data Copilot](../reference-implementations/data-copilot/README.md) | Referenced in docs/tools/benchmarking/intercode.md |
+| OpenAI | https://openai.com/ | related | integrated | [OpenAI](../tools/ai_knowledge/openai.md) | Referenced in docs/tools/benchmarking/gpqa.md |
+| Microsoft Entra ID | https://www.microsoft.com/en-us/security/business/microsoft-entra | related | integrated | [Microsoft Entra ID](../tools/enterprise/microsoft-entra-id.md) | Referenced in docs/tools/providers/microsoft-graph.md |
+| Enterprise Suite Overview | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/enterprise/index.md | related | integrated | [Enterprise Suite Overview](../tools/enterprise/index.md) | Referenced in docs/tools/providers/microsoft-graph.md |
 | Unsloth | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/huggingface.md |
 | OpenRouter | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/groq.md |
 | LiteLLM | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/groq.md |

--- a/docs/reference-implementations/data-copilot/README.md
+++ b/docs/reference-implementations/data-copilot/README.md
@@ -1,0 +1,32 @@
+# Data Copilot Reference Implementations
+
+## Overview
+Data Copilot is a set of patterns and reference implementations for building AI agents capable of interacting with structured data, primarily through Text-to-SQL and automated data analysis. This directory contains detailed schemas, guides, and templates for implementing these patterns.
+
+## Components
+
+| Implementation | Description |
+| :--- | :--- |
+| [Skeleton Guide](skeleton-guide.md) | Standardized project structure for Data Copilot implementations. |
+| [Answer Synthesis Schema](answer-synthesis-schema.md) | JSON schemas for structuring natural language answers from data results. |
+
+## Related Architecture & Patterns
+- [Text-to-SQL Architecture](../../architecture/data-copilot-text-to-sql.md)
+- [Agentic RAG](../../knowledge_base/patterns/data-copilot-agentic-rag.md)
+- [MCP Tooling](../../knowledge_base/patterns/data-copilot-mcp-tooling.md)
+- [SQL Validation Playbook](../../playbooks/data-copilot-sql-validation.md)
+
+## Typical Workflow
+1. **Query Intent Recognition**: Understanding what the user is asking for in terms of data.
+2. **Schema Retrieval**: Fetching relevant database schema information.
+3. **SQL Generation**: Generating a valid SQL query based on the intent and schema.
+4. **Execution & Validation**: Running the query and validating results.
+5. **Answer Synthesis**: Converting raw data into a natural language response.
+
+## Sources / References
+- [Data Copilot Project Case Study](../../reports/data-copilot-sprint-resolution.md)
+- [Verification Report](../../reports/data-copilot-issue-verification.md)
+
+## Contribution Metadata
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/reference-implementations/index.md
+++ b/docs/reference-implementations/index.md
@@ -13,6 +13,7 @@ Workflow exports, prompt templates, and config standards.
 - [Overview](n8n/README.md)
 
 ## Data Copilot
+- [Overview](data-copilot/README.md)
 - [Skeleton Guide](data-copilot/skeleton-guide.md)
 - [Answer Synthesis Schema](data-copilot/answer-synthesis-schema.md)
 

--- a/docs/tools/benchmarking/gpqa.md
+++ b/docs/tools/benchmarking/gpqa.md
@@ -85,7 +85,7 @@ Frontier models typically show a significant gap between "Diamond" (expert-verif
 - [DREAM: Deep Research Evaluation with Agentic Metrics](dream.md)
 - [LM Evaluation Harness](lm-evaluation-harness.md)
 - [Anthropic](../providers/anthropic.md)
-- [OpenAI](../providers/openai.md)
+- [OpenAI](../ai_knowledge/openai.md)
 
 ## Sources / references
 - [Arxiv Paper: GPQA: A Graduate-Level Google-Proof Q&A Benchmark](https://arxiv.org/abs/2311.12022)

--- a/docs/tools/benchmarking/intercode.md
+++ b/docs/tools/benchmarking/intercode.md
@@ -36,7 +36,7 @@ Standard static benchmarks (like [HumanEval](human-eval.md)) often fail to captu
 - When you need to measure how well a model handles real-world execution errors.
 
 ## When not to use it
-- For quick, "shallow" evaluations of general model intelligence (use [MMLU](../../knowledge_base/mmlu.md) instead).
+- For quick, "shallow" evaluations of general model intelligence (use [MMLU](mmlu.md) instead).
 - When you don't have the infrastructure to run Docker-based evaluations safely.
 
 ## Getting started
@@ -96,7 +96,7 @@ Tasks are defined by their initial state and the "gold" verification script.
 - [OpenHands](../development_ops/openhands.md)
 - [Docker](../infrastructure/docker.md)
 - [Self-healing Agents](../../knowledge_base/self-healing-agent-research.md)
-- [MMLU](../../knowledge_base/mmlu.md)
+- [MMLU](mmlu.md)
 - [Data Copilot](../../reference-implementations/data-copilot/README.md)
 
 ## Sources / references

--- a/docs/tools/enterprise/index.md
+++ b/docs/tools/enterprise/index.md
@@ -6,17 +6,18 @@ High-precision AI tools for enterprise search, analytics, and executive producti
 
 | Tool | Focus |
 | :--- | :--- |
-| [AmpCode](../enterprise/ampcode.md) | Scalable enterprise AI infrastructure |
-| [Coveo](../enterprise/coveo.md) | AI search and discovery platform |
-| [Curiosity](../enterprise/curiosity.md) | Desktop AI search and knowledge assistant |
-| [Dashworks](../enterprise/dashworks.md) | AI-powered knowledge management |
-| [Elastic](../enterprise/elastic.md) | Distributed search and analytics engine |
-| [Fyxer AI](../enterprise/fyxer.md) | Executive assistant and inbox automation |
-| [Glean](../enterprise/glean.md) | Unified search across enterprise SaaS apps |
-| [Guru](../enterprise/guru.md) | Collaborative knowledge management |
-| [Hebbia](../enterprise/hebbia.md) | High-precision analytical search for professional services |
-| [Ramp](../enterprise/ramp.md) | Finance automation and spend management |
-| [tl;dv](../enterprise/tldv.md) | AI meeting recorder and transcription |
+| [AmpCode](ampcode.md) | Scalable enterprise AI infrastructure |
+| [Coveo](coveo.md) | AI search and discovery platform |
+| [Curiosity](curiosity.md) | Desktop AI search and knowledge assistant |
+| [Dashworks](dashworks.md) | AI-powered knowledge management |
+| [Elastic](elastic.md) | Distributed search and analytics engine |
+| [Fyxer AI](fyxer.md) | Executive assistant and inbox automation |
+| [Glean](glean.md) | Unified search across enterprise SaaS apps |
+| [Guru](guru.md) | Collaborative knowledge management |
+| [Hebbia](hebbia.md) | High-precision analytical search for professional services |
+| [Microsoft Entra ID](microsoft-entra-id.md) | Cloud-based identity and access management |
+| [Ramp](ramp.md) | Finance automation and spend management |
+| [tl;dv](tldv.md) | AI meeting recorder and transcription |
 
 ## Sources / References
 

--- a/docs/tools/enterprise/microsoft-entra-id.md
+++ b/docs/tools/enterprise/microsoft-entra-id.md
@@ -1,0 +1,99 @@
+# Microsoft Entra ID
+
+## What it is
+Microsoft Entra ID (formerly Azure Active Directory) is a cloud-based identity and access management (IAM) service. it is the backbone of identity for the Microsoft 365 ecosystem and thousands of third-party SaaS applications. It is a fundamental [provider](../providers/README.md) for enterprise [agents](../agents/README.md).
+
+## What problem it solves
+It provides a unified identity system for managing users, groups, and applications. It enables Secure Single Sign-On (SSO), Multi-Factor Authentication (MFA), and Conditional Access policies, ensuring that only authorized users and devices can access sensitive enterprise resources. It is a key component for [SSO Comparison](../../knowledge_base/sso-comparison.md).
+
+## Where it fits in the stack
+**Providers / Identity & Access Management**. It sits at the security and identity layer, controlling access to [Microsoft Graph](../providers/microsoft-graph.md) and other enterprise services.
+
+## Typical use cases
+- Managing user identities and access rights for [Enterprise Suites](../enterprise/README.md).
+- Implementing Secure Single Sign-On (SSO) for internal and external applications.
+- Automating user provisioning and de-provisioning via [n8n](../../services/n8n.md) or [Make](../automation_orchestration/make.md).
+- Enforcing security policies like MFA and location-based access.
+
+## Key Features
+- **Single Sign-On (SSO)**: Access all your apps with one set of credentials.
+- **Conditional Access**: Automated access control decisions based on conditions (e.g., user, device, location).
+- **Identity Governance**: Manage the identity lifecycle at scale.
+- **Application Proxy**: Securely access on-premises web applications from the cloud.
+
+## Strengths
+- **Ubiquity**: Integrated into almost every enterprise using Microsoft 365.
+- **Security**: Robust, built-in security features like MFA and Identity Protection.
+- **Scalability**: Capable of managing millions of identities across global organizations.
+- **Developer Friendly**: Comprehensive APIs via [Microsoft Graph](../providers/microsoft-graph.md).
+
+## Limitations
+- **Licensing Complexity**: Features are split across multiple tiers (Free, P1, P2), which can be confusing.
+- **Configuration Overhead**: Setting up complex conditional access and governance policies requires expertise.
+- **Cloud-Centric**: While it supports hybrid setups, its full potential is realized in the cloud.
+
+## When to use it
+- When managing identities for an organization using Microsoft 365.
+- When building [Custom Agents](../agents/custom_agents.md) that require secure, authenticated access to enterprise data.
+
+## When not to use it
+- For small, personal projects that don't require enterprise-grade IAM.
+- When you are entirely outside the Microsoft ecosystem and prefer other providers like Okta or Auth0.
+
+## Getting started
+
+### App Registration
+To integrate your agent with Entra ID, you must first register an application in the Entra admin center to obtain a Client ID and Client Secret.
+
+```bash
+# Example: Using Azure CLI to create a service principal
+az ad sp create-for-rbac --name "MyAgentServicePrincipal"
+```
+
+## Technical examples
+
+### Authenticating with MSAL (Python)
+Using the Microsoft Authentication Library (MSAL) to get a token.
+
+```python
+import msal
+
+app = msal.ConfidentialClientApplication(
+    client_id="YOUR_CLIENT_ID",
+    client_credential="YOUR_CLIENT_SECRET",
+    authority="https://login.microsoftonline.com/YOUR_TENANT_ID"
+)
+
+result = app.acquire_token_for_client(scopes=["https://graph.microsoft.com/.default"])
+
+if "access_token" in result:
+    print("Token acquired successfully")
+```
+
+### Checking User Groups (cURL)
+Once authenticated, you can use the token to query [Microsoft Graph](../providers/microsoft-graph.md).
+
+```bash
+curl -X GET "https://graph.microsoft.com/v1.0/me/memberOf" \
+     -H "Authorization: Bearer <access_token>"
+```
+
+## Maintenance & Troubleshooting
+- **Secret Rotation**: Ensure you have a process for rotating Client Secrets before they expire.
+- **Audit Logs**: Regularly review sign-in and audit logs to detect anomalous activity.
+
+## Related tools / concepts
+- [Microsoft Graph API](../providers/microsoft-graph.md)
+- [SSO Comparison](../../knowledge_base/sso-comparison.md)
+- [Enterprise Suite Overview](../enterprise/README.md)
+- [n8n Automation](../../services/n8n.md)
+- [Make](../automation_orchestration/make.md)
+
+## Sources / references
+- [Microsoft Entra ID Documentation](https://learn.microsoft.com/en-us/entra/fundamentals/)
+- [Microsoft Entra Admin Center](https://entra.microsoft.com/)
+- [Microsoft Authentication Library (MSAL)](https://learn.microsoft.com/en-us/entra/msal/)
+
+## Contribution Metadata
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/tools/providers/microsoft-graph.md
+++ b/docs/tools/providers/microsoft-graph.md
@@ -88,7 +88,7 @@ events = await client.me.calendar_view.get(
 - [Microsoft Todo](../calendar_tasks/microsoft-todo.md)
 - [n8n Automation](../../services/n8n.md)
 - [Make](../automation_orchestration/make.md)
-- [Enterprise Suite Overview](../enterprise/README.md)
+- [Enterprise Suite Overview](../enterprise/index.md)
 - [Google Calendar API](../calendar_tasks/google_calendar.md)
 - [MCP Servers](../automation_orchestration/mcp.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -459,6 +459,7 @@ nav:
           - Glean: tools/enterprise/glean.md
           - Guru: tools/enterprise/guru.md
           - Hebbia: tools/enterprise/hebbia.md
+          - Microsoft Entra ID: tools/enterprise/microsoft-entra-id.md
           - Ramp: tools/enterprise/ramp.md
           - tldv: tools/enterprise/tldv.md
       - Agents:


### PR DESCRIPTION
Integrated five oldest issues from the June 1, 2026 intake log as part of the Ralph-loop directive.

Key changes:
1. **Microsoft Entra ID**: Created a 'High Confidence' documentation file at `docs/tools/enterprise/microsoft-entra-id.md`. Registered the tool in `data/all_tools.json` and `mkdocs.yml`, maintaining alphabetical order.
2. **Data Copilot**: Created a new `README.md` for `docs/reference-implementations/data-copilot/` to serve as a central entry point for the reference implementation files. Updated the `reference-implementations/index.md` accordingly.
3. **MMLU & OpenAI**: Replaced `https://tbd.com` placeholders in the intake log with verified internal or external links and repaired broken references in `intercode.md` and `gpqa.md`.
4. **Enterprise Suite Overview**: Fixed a broken link in `microsoft-graph.md` and integrated the reference into the intake log.
5. **Quality & Consistency**: 
   - Standardized relative links in the intake log.
   - Cleaned up redundant pathing in the Enterprise index.
   - All changes were validated using `check_docs_contract.py`, `audit_docs_quality.py`, `check_catalog_consistency.py`, and `validate_new_sources.py`.


---
*PR created automatically by Jules for task [8202495657782837827](https://jules.google.com/task/8202495657782837827) started by @joanmarcriera*