### PR TITLE
Ralph-loop: Process items 129-133 and repair documentation links

### DIFF
--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -12,10 +12,10 @@
 | Python SDK | https://github.com/sgl-project/sglang/tree/main/python/sglang | related | integrated | SGLang Python SDK | Referenced in docs/tools/infrastructure/sglang.md |
 | LM Studio | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/infrastructure/lm-studio.md | related | integrated | LM Studio | Referenced in docs/tools/infrastructure/localai.md |
 | Model Serving Patterns | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/model_routing_guide.md | related | integrated | Model Routing Guide | Referenced in docs/tools/infrastructure/localai.md |
-| Weights & Biases | https://wandb.ai/site/ | related | integrated | [Weights & Biases](../process_understanding/wandb-weave.md) | Referenced in docs/tools/infrastructure/openpipe.md |
-| Unstructured | https://unstructured.io/blog | related | integrated | [Unstructured](../intake_storage/unstructured.md) | Referenced in docs/tools/infrastructure/openpipe.md |
-| LlamaParse | https://www.llamaindex.ai/llamaparse/ | related | integrated | [LlamaParse](../intake_storage/llamaparse.md) | Referenced in docs/tools/infrastructure/openpipe.md |
-| Dify | https://dify.ai/ | related | integrated | [Dify](../ai_knowledge/dify.md) | Referenced in docs/tools/infrastructure/supabase.md |
+| Weights & Biases | https://wandb.ai/site/ | related | integrated | [Weights & Biases](../tools/process_understanding/wandb-weave.md) | Referenced in docs/tools/infrastructure/openpipe.md |
+| Unstructured | https://unstructured.io/blog | related | integrated | [Unstructured](../tools/intake_storage/unstructured.md) | Referenced in docs/tools/infrastructure/openpipe.md |
+| LlamaParse | https://www.llamaindex.ai/llamaparse/ | related | integrated | [LlamaParse](../tools/intake_storage/llamaparse.md) | Referenced in docs/tools/infrastructure/openpipe.md |
+| Dify | https://dify.ai/ | related | integrated | [Dify](../tools/ai_knowledge/dify.md) | Referenced in docs/tools/infrastructure/supabase.md |
 | Longhorn | https://longhorn.io/ | related | integrated | Longhorn | Referenced in docs/tools/infrastructure/k3s.md |
 | Llama Factory | https://github.com/hiyouga/LLaMA-Factory | related | integrated | [Llama Factory](../tools/frameworks/llama-factory.md) | Referenced in docs/tools/infrastructure/mlx.md |
 | Model Serving Patterns | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/model_routing_guide.md | related | integrated | [Model Routing Guide](../knowledge_base/model_routing_guide.md) | Referenced in docs/tools/infrastructure/zse.md |
@@ -74,15 +74,15 @@
 | KnowledgeOps | https://github.com/OpenClaw/OpenClaw/blob/main/docs/architecture/multi_agent_knowledgeops.md | related | integrated | [Multi-Agent KnowledgeOps](../../architecture/multi_agent_knowledgeops.md) | Referenced in docs/tools/agents/documentation-writer.md |
 | LangGraph | https://www.langchain.com/langgraph | related | integrated | [LangGraph](../tools/frameworks/langgraph.md) | Referenced in docs/tools/agents/deerflow.md |
 | RAGFlow | https://ragflow.io/ | related | integrated | [RAGFlow](../tools/process_understanding/ragflow.md) | Referenced in docs/tools/process_understanding/firecrawl.md |
-| Unstructured | https://unstructured.io/?ref=ragflow | related | integrated | [Unstructured](../intake_storage/unstructured.md) | Referenced in docs/tools/process_understanding/ragflow.md |
-| LlamaParse | https://www.llamaindex.ai/llamaparse?ref=ragflow | related | integrated | [LlamaParse](../intake_storage/llamaparse.md) | Referenced in docs/tools/process_understanding/ragflow.md |
-| RAGFlow | https://ragflow.io/?ref=crawl4ai | related | integrated | [RAGFlow](../process_understanding/ragflow.md) | Referenced in docs/tools/process_understanding/crawl4ai.md |
-| OpenRouter | https://openrouter.ai/?ref=posthog | related | integrated | [OpenRouter](../ai_knowledge/openrouter.md) | Referenced in docs/tools/process_understanding/posthog.md |
+| Unstructured | https://unstructured.io/?ref=ragflow | related | integrated | [Unstructured](../tools/intake_storage/unstructured.md) | Referenced in docs/tools/process_understanding/ragflow.md |
+| LlamaParse | https://www.llamaindex.ai/llamaparse?ref=ragflow | related | integrated | [LlamaParse](../tools/intake_storage/llamaparse.md) | Referenced in docs/tools/process_understanding/ragflow.md |
+| RAGFlow | https://ragflow.io/?ref=crawl4ai | related | integrated | [RAGFlow](../tools/process_understanding/ragflow.md) | Referenced in docs/tools/process_understanding/crawl4ai.md |
+| OpenRouter | https://openrouter.ai/?ref=posthog | related | integrated | [OpenRouter](../tools/ai_knowledge/openrouter.md) | Referenced in docs/tools/process_understanding/posthog.md |
 | REST API | https://github.com/OpenClaw/OpenClaw/blob/main/docs/standards.md?ref=webhook | related | integrated | [REST API](../../standards.md) | Referenced in docs/tools/process_understanding/webhook.md |
 | Claude Code | https://code.claude.com/?ref=rivet | related | integrated | [Claude Code](../development_ops/claude-code.md) | Referenced in docs/tools/frameworks/rivet.md |
 | Extraction and Classification | https://github.com/OpenClaw/OpenClaw/blob/main/docs/reports/task-decomposition-patterns-extraction.md#PATTERN-EXT-01 | related | integrated | [Extraction and Classification](../../knowledge_base/patterns/extraction-and-classification.md) | Referenced in docs/tools/frameworks/instructor.md |
 | Date Extraction | https://github.com/OpenClaw/OpenClaw/blob/main/docs/reports/task-decomposition-patterns-extraction.md#PATTERN-EXT-02 | related | integrated | [Date Extraction](../../knowledge_base/patterns/date-extraction.md) | Referenced in docs/tools/frameworks/instructor.md |
-| Dify | https://dify.ai/?ref=genkit | related | integrated | [Dify](../ai_knowledge/dify.md) | Referenced in docs/tools/frameworks/firebase-genkit.md |
+| Dify | https://dify.ai/?ref=genkit | related | integrated | [Dify](../tools/ai_knowledge/dify.md) | Referenced in docs/tools/frameworks/firebase-genkit.md |
 | MCP | https://modelcontextprotocol.io/?ref=superinterface | related | integrated | [MCP](../../knowledge_base/patterns/tool-calling-and-mcp.md) | Referenced in docs/tools/frameworks/superinterface.md |
 | Agentic Workflows | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/patterns/agentic-workflows.md | related | integrated | [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md) | Referenced in docs/tools/frameworks/mycelium.md |
 | System Prompts | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/system_prompts.md | related | integrated | [System Prompts](../../knowledge_base/system_prompts.md) | Referenced in docs/tools/frameworks/mycelium.md |
@@ -90,14 +90,14 @@
 | Home Admin Agent Architecture | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/home-admin-agent-architecture.md | related | integrated | [Home Admin Agent Architecture](../../knowledge_base/home-admin-agent-architecture.md) | Referenced in docs/tools/frameworks/mycelium.md |
 | Free AI Website Playbook (Docs Version) | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/free_ai_website_playbook.md | related | integrated | [Free AI Website Playbook](../../knowledge_base/free_ai_website_playbook.md) | Referenced in docs/tools/development_ops/vercel-oss.md |
 | Fallback Patterns | https://github.com/OpenClaw/OpenClaw/blob/main/docs/reports/task-decomposition-fallback-patterns.md | related | integrated | [Task Decomposition](../../reports/task-decomposition-fallback-patterns.md) | Referenced in docs/tools/development_ops/claude-code-router.md |
-| Claude | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/ai_knowledge/claude.md | related | integrated | [Claude](../ai_knowledge/claude.md) | Referenced in docs/tools/development_ops/google-stitch.md |
+| Claude | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/ai_knowledge/claude.md | related | integrated | [Claude](../tools/ai_knowledge/claude.md) | Referenced in docs/tools/development_ops/google-stitch.md |
 | Python | https://docs.python.org/3/ | related | integrated | [Python](../tools/ai_knowledge/python.md) | Referenced in docs/tools/development_ops/symbolic-mcp.md |
 | Free AI Website Playbook (Docs Version) | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/free_ai_website_playbook.md | related | integrated | [Free AI Website Playbook](../../knowledge_base/free_ai_website_playbook.md) | Referenced in docs/tools/development_ops/cloudflare-pages.md |
 | Python | https://docs.python.org/3/?ref=fuzzing | related | integrated | [Python](../tools/ai_knowledge/python.md) | Referenced in docs/tools/development_ops/fuzzing-mcp-server.md |
 | OpenHands | https://github.com/OpenHands/openhands | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/development_ops/anti_gravity.md |
 | Cline | https://cline.bot | related | integrated | Cline | Referenced in docs/tools/development_ops/anti_gravity.md |
 | Agentic Workflows | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/patterns/agentic-workflows.md | related | integrated | [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md) | Referenced in docs/tools/development_ops/devin.md |
-| Docker | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/infrastructure/docker.md | related | integrated | [Docker](../../tools/infrastructure/docker.md) | Referenced in docs/tools/development_ops/cloud_code.md |
+| Docker | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/infrastructure/docker.md | related | integrated | [Docker](../tools/infrastructure/docker.md) | Referenced in docs/tools/development_ops/cloud_code.md |
 | Helm | https://helm.sh/ | related | integrated | Helm | Referenced in docs/tools/development_ops/cloud_code.md |
 | Python | https://docs.python.org/3/?ref=jupyter | related | integrated | [Python](../tools/ai_knowledge/python.md) | Referenced in docs/tools/development_ops/jupyter-kernel-mcp.md |
 | Standards and Conventions | https://github.com/OpenClaw/OpenClaw/blob/main/docs/standards.md | related | integrated | [Standards and Conventions](../../standards.md) | Referenced in docs/tools/development_ops/claude-context-mode.md |
@@ -126,11 +126,11 @@
 | OpenAI | https://openai.com/ | related | integrated | [OpenAI](../tools/ai_knowledge/openai.md) | Referenced in docs/tools/benchmarking/gpqa.md |
 | Microsoft Entra ID | https://www.microsoft.com/en-us/security/business/microsoft-entra | related | integrated | [Microsoft Entra ID](../tools/enterprise/microsoft-entra-id.md) | Referenced in docs/tools/providers/microsoft-graph.md |
 | Enterprise Suite Overview | https://github.com/OpenClaw/OpenClaw/blob/main/docs/tools/enterprise/index.md | related | integrated | [Enterprise Suite Overview](../tools/enterprise/index.md) | Referenced in docs/tools/providers/microsoft-graph.md |
-| Unsloth | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/huggingface.md |
-| OpenRouter | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/groq.md |
-| LiteLLM | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/groq.md |
-| Roo Code | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/deepseek.md |
-| Cline | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/deepseek.md |
+| Unsloth | https://unsloth.ai/ | related | integrated | [Unsloth](../tools/infrastructure/unsloth.md) | Referenced in docs/tools/providers/huggingface.md |
+| OpenRouter | https://openrouter.ai/ | related | integrated | [OpenRouter](../tools/ai_knowledge/openrouter.md) | Referenced in docs/tools/providers/groq.md |
+| LiteLLM | https://docs.litellm.ai/ | related | integrated | [LiteLLM](../../services/litellm.md) | Referenced in docs/tools/providers/groq.md |
+| Roo Code | https://github.com/RooCodeInc/Roo-Code | related | integrated | [Roo Code](../tools/agents/roo-code.md) | Referenced in docs/tools/providers/deepseek.md |
+| Cline | https://cline.bot/ | related | integrated | [Cline](../tools/agents/cline.md) | Referenced in docs/tools/providers/deepseek.md |
 | OpenRouter | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/together.md |
 | LLM Trust Boundaries | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/bigswitch.md |
 | Codestral | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/mistral.md |

--- a/docs/tools/providers/deepseek.md
+++ b/docs/tools/providers/deepseek.md
@@ -113,8 +113,8 @@ response = client.chat.completions.create(
 - [Anthropic](anthropic.md)
 - [Model Routing Guide](../../knowledge_base/model_routing_guide.md)
 - [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md)
-- [Roo Code](../development_ops/roo-code.md)
-- [Cline](../development_ops/cline.md)
+- [Roo Code](../agents/roo-code.md)
+- [Cline](../agents/cline.md)
 - [Aider](../development_ops/aider.md)
 
 ## Sources / References

--- a/docs/tools/providers/fireworks.md
+++ b/docs/tools/providers/fireworks.md
@@ -104,8 +104,8 @@ response = fireworks.client.ChatCompletion.create(
 - [SGLang](../infrastructure/sglang.md)
 - [Aphrodite Engine](../infrastructure/aphrodite-engine.md)
 - [ExLlamaV2](../infrastructure/exllamav2.md)
-- [OpenRouter](openrouter.md)
-- [LiteLLM](../infrastructure/litellm.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
+- [LiteLLM](../../services/litellm.md)
 
 ## Sources / References
 - [Official Website](https://fireworks.ai/)

--- a/docs/tools/providers/groq.md
+++ b/docs/tools/providers/groq.md
@@ -97,8 +97,8 @@ The LPU (Language Processing Unit) is designed for sequential processing, which 
 - [Mistral](mistral.md)
 - [vLLM](../infrastructure/vllm.md)
 - [SGLang](../infrastructure/sglang.md)
-- [OpenRouter](openrouter.md)
-- [LiteLLM](../infrastructure/litellm.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
+- [LiteLLM](../../services/litellm.md)
 - [Anthropic](anthropic.md)
 
 ## Sources / References

--- a/docs/tools/providers/huggingface.md
+++ b/docs/tools/providers/huggingface.md
@@ -128,7 +128,7 @@ api.upload_file(
 - [LiteLLM](../../services/litellm.md)
 - [Local LLMs](../ai_knowledge/local_llms.md)
 - [vLLM](../infrastructure/vllm.md)
-- [Unsloth](../frameworks/unsloth.md)
+- [Unsloth](../infrastructure/unsloth.md)
 - [LLaMA-Factory](../frameworks/llama-factory.md)
 - [OpenCompass](../benchmarking/opencompass.md)
 

--- a/docs/tools/providers/mistral.md
+++ b/docs/tools/providers/mistral.md
@@ -156,7 +156,7 @@ Mistral provides a first-class Agents API that goes beyond simple completions:
 - [vLLM](../infrastructure/vllm.md)
 - [Hugging Face](huggingface.md)
 - [Codestral](codestral.md)
-- [OpenRouter](openrouter.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
 
 ## Sources / References
 - [Official Website](https://mistral.ai/)

--- a/docs/tools/providers/together.md
+++ b/docs/tools/providers/together.md
@@ -92,7 +92,7 @@ response = client.chat.completions.create(
 - **Self-hostable**: No (Cloud service), but the models can be hosted elsewhere if needed.
 
 ## Related tools / concepts
-- [OpenRouter](openrouter.md)
+- [OpenRouter](../ai_knowledge/openrouter.md)
 - [Groq](groq.md)
 - [Fireworks AI](fireworks.md)
 - [Mistral](mistral.md)


### PR DESCRIPTION
Integrated Unsloth, OpenRouter, LiteLLM, Roo Code, and Cline from the daily log docs/new-sources/2026-06-01.md. Repaired broken relative links in huggingface.md, groq.md, deepseek.md, fireworks.md, together.md, and mistral.md. Standardized several existing relative links in the intake log to maintain consistency with the repository taxonomy. All changes verified with contract, quality, and consistency scripts.

---
*PR created automatically by Jules for task [11318961052144683672](https://jules.google.com/task/11318961052144683672) started by @joanmarcriera*