### PR TITLE
Integrate Codestral and resolve intake log placeholders

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -474,6 +474,12 @@
       "doc_path": "docs/tools/development_ops/codex.md"
     },
     {
+      "id": "codestral",
+      "name": "Codestral",
+      "category": "Providers",
+      "doc_path": "docs/tools/providers/codestral.md"
+    },
+    {
       "id": "cohere",
       "name": "Cohere (Enterprise RAG)",
       "category": "Providers",

--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -131,12 +131,12 @@
 | LiteLLM | https://docs.litellm.ai/ | related | integrated | [LiteLLM](../../services/litellm.md) | Referenced in docs/tools/providers/groq.md |
 | Roo Code | https://github.com/RooCodeInc/Roo-Code | related | integrated | [Roo Code](../tools/agents/roo-code.md) | Referenced in docs/tools/providers/deepseek.md |
 | Cline | https://cline.bot/ | related | integrated | [Cline](../tools/agents/cline.md) | Referenced in docs/tools/providers/deepseek.md |
-| OpenRouter | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/together.md |
-| LLM Trust Boundaries | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/bigswitch.md |
-| Codestral | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/mistral.md |
-| OpenRouter | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/mistral.md |
-| OpenRouter | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/fireworks.md |
-| LiteLLM | https://tbd.com | related | new | TBD | Referenced in docs/tools/providers/fireworks.md |
+| OpenRouter | https://openrouter.ai | related | integrated | [OpenRouter](../ai_knowledge/openrouter.md) | Referenced in docs/tools/providers/together.md |
+| LLM Trust Boundaries | https://github.com/OpenClaw/OpenClaw/blob/main/docs/knowledge_base/patterns/llm-trust-boundaries.md | related | integrated | [LLM Trust Boundaries](../../knowledge_base/patterns/llm-trust-boundaries.md) | Referenced in docs/tools/providers/bigswitch.md |
+| Codestral | https://mistral.ai/news/codestral/ | related | integrated | [Codestral](../tools/providers/codestral.md) | Referenced in docs/tools/providers/mistral.md |
+| OpenRouter | https://openrouter.ai | related | integrated | [OpenRouter](../ai_knowledge/openrouter.md) | Referenced in docs/tools/providers/mistral.md |
+| OpenRouter | https://openrouter.ai | related | integrated | [OpenRouter](../ai_knowledge/openrouter.md) | Referenced in docs/tools/providers/fireworks.md |
+| LiteLLM | https://litellm.ai | related | integrated | [LiteLLM](../../services/litellm.md) | Referenced in docs/tools/providers/fireworks.md |
 | Logseq | https://tbd.com | related | new | TBD | Referenced in docs/tools/calendar_tasks/google_calendar.md |
 | Obsidian | https://tbd.com | related | new | TBD | Referenced in docs/tools/calendar_tasks/google_calendar.md |
 | Google Tasks | https://tbd.com | related | new | TBD | Referenced in docs/tools/calendar_tasks/any-do.md |

--- a/docs/tools/providers/bigswitch.md
+++ b/docs/tools/providers/bigswitch.md
@@ -101,7 +101,7 @@ resource "hcloud_server" "sovereign_node" {
 - [Mistral](mistral.md) — Premier European LLM provider.
 - [DeepSeek](deepseek.md) — High-performance alternative for diverse routing.
 - [Replicate](replicate.md) — Managed hosting for open-source models.
-- [LLM Trust Boundaries](../development_ops/llm-trust-boundaries.md) — Critical for sovereignty audits.
+- [LLM Trust Boundaries](../../knowledge_base/patterns/llm-trust-boundaries.md) — Critical for sovereignty audits.
 - [Automated Contributions](../../architecture/automated_contributions.md) — How to contribute to this directory.
 - [Hugging Face](huggingface.md) — European-headquartered AI community hub.
 - [AWS Bedrock](aws-bedrock.md) — For cross-jurisdictional comparison of cloud provider trust boundaries.

--- a/docs/tools/providers/codestral.md
+++ b/docs/tools/providers/codestral.md
@@ -1,0 +1,99 @@
+# Codestral
+
+## What it is
+Codestral is an open-weight generative AI model explicitly designed for code generation tasks. Developed by [Mistral AI](mistral.md), it is a 22B parameter model optimized for over 80 programming languages, including Python, Java, C++, and JavaScript.
+
+## What problem it solves
+It provides a high-performance, specialized model for coding tasks that can be run locally or via API, offering an alternative to general-purpose LLMs that may lack deep proficiency in niche programming languages or complex code structures.
+
+## Where it fits in the stack
+**Inference Provider / Specialized Model**. It acts as a specialized backend for IDE extensions, autonomous coding agents, and CI/CD pipelines.
+
+## Typical use cases
+- **Code Completion**: Providing real-time FIM (Fill-In-the-Middle) suggestions in IDEs.
+- **Test Generation**: Automatically writing unit tests and integration tests for existing codebases.
+- **Code Translation**: Porting legacy code from one language (e.g., Fortran) to modern environments.
+- **Autonomous Coding Agents**: Powering agents that can plan, execute, and debug code.
+
+## Getting started
+Codestral is available via Mistral AI's **La Plateforme** or can be run locally using [Ollama](../../services/ollama.md).
+
+### Using Mistral SDK (Python)
+```python
+from mistralai import Mistral
+import os
+
+client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+
+response = client.chat.complete(
+    model="codestral-latest",
+    messages=[
+        {"role": "user", "content": "Write a Python function to calculate the Fibonacci sequence using recursion."}
+    ]
+)
+print(response.choices[0].message.content)
+```
+
+### Local Execution (Ollama)
+```bash
+ollama run codestral
+```
+
+## Technical examples
+
+### Fill-In-the-Middle (FIM)
+Codestral supports FIM, allowing it to complete code based on both preceding and following context.
+
+```python
+# API example for FIM (using raw completion or specialized endpoint)
+# Prefix: def fib(n):
+# Suffix: return a
+# Codestral completes the middle logic.
+```
+
+### Multilingual Code Generation
+Codestral's strength lies in its ability to handle multiple languages simultaneously, such as writing a Python wrapper for a C++ library.
+
+```python
+# Example prompt: "Write a Python C-extension for the following C++ function..."
+```
+
+## Strengths
+- **Performance**: High accuracy in code generation and debugging across 80+ languages.
+- **Open Weights**: Can be self-hosted for maximum privacy and data security.
+- **Specialization**: Better at complex coding tasks than many general-purpose models of similar size.
+- **Efficiency**: 22B parameters offer a good balance between performance and hardware requirements.
+
+## Limitations
+- **Focus**: While it can handle general conversation, its primary optimization is for code.
+- **Hardware**: Local hosting requires significant VRAM (ideally 24GB+ for 4-bit quantization).
+
+## When to use it
+- When building specialized coding tools or agents (e.g., [Cline](../agents/cline.md), [Roo Code](../agents/roo-code.md)).
+- When you need high-quality code generation with the privacy of local hosting.
+- When working with less common programming languages where general models fail.
+
+## When not to use it
+- For general creative writing or non-technical tasks.
+- If you lack the hardware for local hosting and prefer the convenience of proprietary frontier models like Claude 3.5 Sonnet.
+
+## Licensing and cost
+- **Open Weights**: Released under the **Mistral AI Non-Commercial License** (MNCL) for research and non-commercial use. Commercial use requires a separate agreement or usage via Mistral's API.
+- **API Cost**: Paid (Usage-based on Mistral AI La Plateforme).
+
+## Related tools / concepts
+- [Mistral AI](mistral.md)
+- [Ollama](../../services/ollama.md)
+- [vLLM](../infrastructure/vllm.md)
+- [Cline](../agents/cline.md)
+- [Roo Code](../agents/roo-code.md)
+- [Continue](../development_ops/continue_dev.md)
+
+## Sources / References
+- [Mistral AI Codestral Announcement](https://mistral.ai/news/codestral/)
+- [Mistral Documentation](https://docs.mistral.ai/models/codestral/)
+- [Hugging Face - Codestral-22B-v0.1](https://huggingface.co/mistralai/Codestral-22B-v0.1)
+
+## Contribution Metadata
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -430,6 +430,7 @@ nav:
           - Anthropic: tools/providers/anthropic.md
           - Azure OpenAI: tools/providers/azure-openai.md
           - BigSwitch: tools/providers/bigswitch.md
+          - Codestral: tools/providers/codestral.md
           - Cohere: tools/providers/cohere.md
           - DeepSeek: tools/providers/deepseek.md
           - Exa AI: tools/providers/exa_ai.md


### PR DESCRIPTION
Processed the next set of placeholders from the intake log `docs/new-sources/2026-06-01.md` as part of the Ralph-loop directive.
- **Codestral**: Created a new documentation file following 'High Confidence' standards, including technical examples and metadata. Registered it in the tool manifest and site navigation.
- **OpenRouter & LiteLLM**: Replaced `https://tbd.com` placeholders with verified official URLs and internal relative links to existing documentation.
- **LLM Trust Boundaries**: Fixed an incorrect relative link in `bigswitch.md` and updated the corresponding entry in the intake log.
All modifications were validated using the repository's audit and consistency scripts.

---
*PR created automatically by Jules for task [505564880279982554](https://jules.google.com/task/505564880279982554) started by @joanmarcriera*