### PR TITLE
Ralph-loop Execution: Processing Oldest Documentation Issues

### DIFF
--- a/data/all_tools.json
+++ b/data/all_tools.json
@@ -1669,6 +1669,12 @@
       "doc_path": "docs/tools/benchmarking/mt-bench.md"
     },
     {
+      "id": "multion",
+      "name": "Multi-On",
+      "category": "Agents",
+      "doc_path": "docs/tools/agents/multion.md"
+    },
+    {
       "id": "mycelium",
       "name": "Mycelium",
       "category": "Frameworks",
@@ -2602,6 +2608,12 @@
       "name": "W&B Weave",
       "category": "Process & Understanding",
       "doc_path": "docs/tools/process_understanding/wandb-weave.md"
+    },
+    {
+      "id": "weaviate",
+      "name": "Weaviate",
+      "category": "Infrastructure",
+      "doc_path": "docs/tools/infrastructure/weaviate.md"
     },
     {
       "id": "webhook",

--- a/docs/new-sources/2026-06-01.md
+++ b/docs/new-sources/2026-06-01.md
@@ -149,11 +149,11 @@
 | Paperless-ngx | https://docs.paperless-ngx.com/?ref=caldav | related | integrated | [Paperless-ngx](../services/paperless-ngx.md) | Referenced in docs/tools/intake_storage/caldav.md |
 | Home Assistant | https://www.home-assistant.io/?ref=caldav | related | integrated | [Home Assistant](../services/home-assistant.md) | Referenced in docs/tools/intake_storage/caldav.md |
 | Authentik | https://goauthentik.io/?ref=caldav | related | integrated | [Authentik](../services/authentik.md) | Referenced in docs/tools/intake_storage/caldav.md |
-| Weaviate | https://tbd.com | related | new | TBD | Referenced in docs/tools/intake_storage/verba.md |
-| LangChain | https://tbd.com | related | new | TBD | Referenced in docs/tools/intake_storage/verba.md |
-| Ollama | https://tbd.com | related | new | TBD | Referenced in docs/tools/intake_storage/verba.md |
-| Multi-On | https://tbd.com | related | new | TBD | Referenced in docs/tools/automation_orchestration/stagehand.md |
-| Dify | https://tbd.com | related | new | TBD | Referenced in docs/tools/automation_orchestration/gumloop.md |
+| Weaviate | https://weaviate.io/?ref=2026-06-01 | related | integrated | [Weaviate](../tools/infrastructure/weaviate.md) | Referenced in docs/tools/intake_storage/verba.md |
+| LangChain | https://www.langchain.com/?ref=2026-06-01 | related | integrated | [Langchain](../tools/ai_knowledge/langchain.md) | Referenced in docs/tools/intake_storage/verba.md |
+| Ollama | https://ollama.com/?ref=2026-06-01 | related | integrated | [Ollama](../../services/ollama.md) | Referenced in docs/tools/intake_storage/verba.md |
+| Multi-On | https://www.multion.ai/?ref=2026-06-01 | related | integrated | [Multi-On](../tools/agents/multion.md) | Referenced in docs/tools/automation_orchestration/stagehand.md |
+| Dify | https://dify.ai/?ref=2026-06-01 | related | integrated | [Dify](../tools/ai_knowledge/dify.md) | Referenced in docs/tools/automation_orchestration/gumloop.md |
 | Pipedream | https://tbd.com | related | new | TBD | Referenced in docs/tools/automation_orchestration/make.md |
 | OpenHands | https://github.com/OpenHands/openhands?ref=playwright | related | integrated | [OpenHands](../tools/development_ops/openhands.md) | Referenced in docs/tools/automation_orchestration/playwright-mcp.md |
 | Puppeteer | https://tbd.com | related | new | TBD | Referenced in docs/tools/automation_orchestration/playwright-mcp.md |

--- a/docs/tools/agents/multion.md
+++ b/docs/tools/agents/multion.md
@@ -1,0 +1,99 @@
+# Multi-On
+
+## What it is
+Multi-On is an AI agent framework and API designed specifically for autonomous web navigation and interaction. It acts as a "motor cortex" for AI, allowing agents to perform complex tasks across any website using a combination of vision and DOM-based understanding.
+
+## What problem it solves
+Standard LLMs cannot interact with the live web autonomously. Traditional web scrapers are brittle and cannot handle complex, multi-step workflows (like booking a flight or merging a PR). Multi-On provides the infrastructure to bridge LLMs with the browser, handling authentication, navigation, and interaction reliably.
+
+## Where it fits in the stack
+**Category**: Agents / Web Automation
+
+## Typical use cases
+- **Personal Assistants**: "Book me a table for two at 7 PM tonight."
+- **E-commerce Automation**: "Find the best price for this monitor and add it to my cart."
+- **DevOps Automation**: "Check the status of my latest PR and merge it if the tests passed."
+- **Data Collection**: "Gather all recent news about generative AI from these five sources."
+
+## Strengths
+- **Autonomous Navigation**: Can handle multi-step tasks across multiple domains.
+- **Vision Support**: Uses visual grounding to interact with websites more like a human.
+- **Resilient Interaction**: Self-healing capabilities to recover from navigation errors or UI changes.
+- **Scalable Infrastructure**: Provides a managed API to run many agents in parallel.
+
+## Limitations
+- **Latency**: Complex web interactions can take significant time.
+- **Cost**: Managed API usage incurs costs based on interaction volume.
+- **Privacy**: Requires trust as the agent performs actions on your behalf on the web.
+
+## When to use it
+- When you need an agent to perform actions on the live web (not just read data).
+- For complex, multi-step workflows that require navigating multiple pages.
+- When you want to leverage a managed service for browser-based AI agents.
+
+## When not to use it
+- For simple data extraction where a specialized scraper like Crawl4AI would be faster and cheaper.
+- If you have strict requirements to run everything locally without external API calls.
+
+## Licensing and cost
+- **Open Source**: No (Proprietary API)
+- **Cost**: Paid (Usage-based pricing)
+- **Self-hostable**: No (Managed service)
+
+## Getting started
+
+### Installation
+```bash
+pip install multion
+```
+
+### Basic Usage (Python)
+```python
+from multion.client import MultiOn
+
+client = MultiOn(api_key="YOUR_API_KEY")
+
+# Create a new session and browse to a site
+response = client.browse(
+    cmd="Go to news.ycombinator.com and find the top story about AI",
+    url="https://news.ycombinator.com"
+)
+
+print(response.message)
+```
+
+## API examples
+
+### Continuous Session
+```python
+# Create a session
+session = client.sessions.create(url="https://www.google.com")
+
+# Perform an action in the session
+result = client.sessions.step(
+    session_id=session.session_id,
+    cmd="Search for 'best laptop 2024' and click the first review link"
+)
+
+print(result.message)
+
+# Close the session when done
+client.sessions.close(session_id=session.session_id)
+```
+
+## Related tools / concepts
+- [Stagehand](../automation_orchestration/stagehand.md) — A library for resilient web automation built on Playwright.
+- [Browser Use](../automation_orchestration/browser-use.md) — Another framework for browser-based agents.
+- [Skyvern](../automation_orchestration/skyvern.md) — Open-source alternative for browser automation.
+- [Playwright](../development_ops/playwright.md) — The underlying technology for many web automation tools.
+- [Crawl4AI](../process_understanding/crawl4ai.md) — Optimized for web crawling and data extraction.
+- [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md) — The broader concept of multi-step AI tasks.
+
+## Sources / references
+- [Official Website](https://www.multion.ai/)
+- [MultiOn Documentation](https://docs.multion.ai/)
+- [MultiOn GitHub Examples](https://github.com/multion-ai/multion-python)
+
+## Contribution Metadata
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/tools/automation_orchestration/gumloop.md
+++ b/docs/tools/automation_orchestration/gumloop.md
@@ -72,7 +72,7 @@ print(output)
 - [Agentic Automation Canvas](../agents/agentic-automation-canvas.md)
 - [AirOps](airops.md)
 - [Langflow](../frameworks/langflow.md)
-- [Dify](../frameworks/dify.md)
+- [Dify](../ai_knowledge/dify.md)
 - [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md)
 
 ## Sources / references

--- a/docs/tools/infrastructure/weaviate.md
+++ b/docs/tools/infrastructure/weaviate.md
@@ -1,0 +1,124 @@
+# Weaviate
+
+## What it is
+Weaviate is an open-source vector database that allows you to store data objects and vector embeddings from your favorite ML-models, and scale seamlessly into billions of data objects. It is designed for developers who want to build AI-native applications with high performance and reliability.
+
+## What problem it solves
+Managing and searching through massive amounts of unstructured data (text, images, audio) is challenging. Weaviate provides a scalable infrastructure for vector search, enabling semantic search, recommendation engines, and Retrieval-Augmented Generation (RAG) by converting unstructured data into searchable vectors.
+
+## Where it fits in the stack
+**Category**: Infrastructure / Vector Database
+
+## Typical use cases
+- **Retrieval-Augmented Generation (RAG)**: Providing relevant context to LLMs for more accurate answers.
+- **Semantic Search**: Finding information based on meaning rather than just keywords.
+- **Recommendation Systems**: Suggesting products or content based on visual or textual similarity.
+- **Image Search**: Building applications that can search for images using other images or text descriptions.
+
+## Strengths
+- **Speed & Scalability**: Capable of sub-second search across billions of objects.
+- **Modular Architecture**: Supports various vectorization modules (OpenAI, HuggingFace, Cohere, etc.).
+- **Hybrid Search**: Combines vector search with traditional keyword search (BM25) for better results.
+- **GraphQL API**: Offers a flexible and powerful API for querying data.
+
+## Limitations
+- **Memory Consumption**: Vector indices can be memory-intensive.
+- **Learning Curve**: The GraphQL API and schema configuration might require some time to master for those used to traditional SQL.
+
+## When to use it
+- When you need a production-grade vector database for RAG or semantic search.
+- When you require a self-hostable solution with enterprise-grade features.
+- When you want to leverage hybrid search capabilities out of the box.
+
+## When not to use it
+- For simple applications where a basic full-text search engine (like SQLite FTS) is sufficient.
+- If you have extremely limited RAM and cannot afford the memory overhead of a vector database.
+
+## Licensing and cost
+- **Open Source**: Yes (BSD 3-Clause)
+- **Cost**: Free (Self-hosted) / Paid (Managed Cloud)
+- **Self-hostable**: Yes
+
+## Getting started
+
+### Docker Deployment
+```yaml
+services:
+  weaviate:
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    image: semitechnologies/weaviate:1.24.1
+    ports:
+    - 8080:8080
+    restart: on-failure:0
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      ENABLE_MODULES: ''
+      CLUSTER_HOSTNAME: 'node1'
+```
+
+## API examples
+
+### Schema Creation (Python)
+```python
+import weaviate
+
+client = weaviate.Client("http://localhost:8080")
+
+class_obj = {
+    "class": "Document",
+    "vectorizer": "none",
+    "properties": [
+        {
+            "name": "content",
+            "dataType": ["text"],
+        }
+    ]
+}
+
+client.schema.create_class(class_obj)
+```
+
+### Semantic Search (GraphQL)
+```graphql
+{
+  Get {
+    Document (
+      nearText: {
+        concepts: ["AI infrastructure"]
+      }
+    ) {
+      content
+      _additional {
+        distance
+      }
+    }
+  }
+}
+```
+
+## Related tools / concepts
+- [Verba](../intake_storage/verba.md) — A RAG application built on top of Weaviate.
+- [RAG Pattern](../../knowledge_base/patterns/rag-pattern.md) — The architectural pattern Weaviate often enables.
+- [LangChain](../ai_knowledge/langchain.md) — Frequently used to orchestrate flows involving Weaviate.
+- [Ollama](../../services/ollama.md) — Can provide local embeddings for Weaviate.
+- [Dify](../ai_knowledge/dify.md) — Integrates Weaviate for its RAG features.
+- [Pinecone](pinecone.md) — A managed-only alternative to Weaviate.
+- [Milvus](milvus.md) — Another open-source vector database alternative.
+
+## Sources / references
+- [Official Website](https://weaviate.io/)
+- [GitHub Repository](https://github.com/weaviate/weaviate)
+- [Weaviate Documentation](https://weaviate.io/developers/weaviate)
+
+## Contribution Metadata
+- Last reviewed: 2026-06-05
+- Confidence: high

--- a/docs/tools/intake_storage/verba.md
+++ b/docs/tools/intake_storage/verba.md
@@ -74,8 +74,8 @@ print(response.json()["answer"])
 - [AnyType](anytype.md) — Local-first P2P knowledge base.
 - [RAG Pattern](../../knowledge_base/patterns/rag-pattern.md) — Underlying architectural concept.
 - [Obsidian](../ai_knowledge/obsidian.md) — Can be used as a data source via Markdown export.
-- [LangChain](../frameworks/langchain.md) — Often used in conjunction with Weaviate for custom pipelines.
-- [Ollama](../ai_knowledge/ollama.md) — Supported as a local inference backend.
+- [LangChain](../ai_knowledge/langchain.md) — Often used in conjunction with Weaviate for custom pipelines.
+- [Ollama](../../services/ollama.md) — Supported as a local inference backend.
 
 ## Sources / References
 - [Official Website](https://verba.weaviate.io/)

--- a/find_oldest_issues.py
+++ b/find_oldest_issues.py
@@ -14,7 +14,7 @@ def find_open_tasks():
             with open(filepath, 'r') as f:
                 lines = f.readlines()
                 for line in lines:
-                    if '- [ ]' in line:
+                    if '- [ ]' in line and not '- [x]' in line:
                         batch_match = re.search(r'batch-(\d+)', filename)
                         batch_num = int(batch_match.group(1)) if batch_match else 0
                         tasks.append({'source': filename, 'task': line.strip(), 'priority': batch_num})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -481,6 +481,7 @@ nav:
           - GPT Researcher: tools/agents/gpt-researcher.md
           - Letta: tools/agents/letta.md
           - mem0: tools/agents/mem0.md
+          - Multi-On: tools/agents/multion.md
           - Nvidia NemoClaw: tools/agents/nemoclaw.md
           - NVIDIA NeMo Retriever: tools/agents/nemo-retriever.md
           - Open Agents: tools/agents/open-agents.md
@@ -523,6 +524,7 @@ nav:
           - Ubuntu AI Snaps: tools/infrastructure/ubuntu-ai.md
           - Unsloth: tools/infrastructure/unsloth.md
           - vLLM: tools/infrastructure/vllm.md
+          - Weaviate: tools/infrastructure/weaviate.md
           - ZSE: tools/infrastructure/zse.md
       - Process & Understanding:
           - Overview: tools/process_understanding/index.md


### PR DESCRIPTION
I have processed the five oldest issues from the intake log `docs/new-sources/2026-06-01.md` following the Ralph-loop directive. 

Key accomplishments:
1. **New Documentation**: Created 'High Confidence' documentation for Weaviate (`docs/tools/infrastructure/weaviate.md`) and Multi-On (`docs/tools/agents/multion.md`), including technical examples and proper metadata.
2. **Catalog Registration**: Registered both tools in `data/all_tools.json` and `mkdocs.yml`, maintaining strict alphabetical order.
3. **Source Integration**: Replaced `https://tbd.com` placeholders in the intake log for Weaviate, LangChain, Ollama, Multi-On, and Dify with verified official URLs and correct relative canonical links.
4. **Link Repairs**: Fixed incorrect relative links in `verba.md` (pointing to LangChain and Ollama) and `gumloop.md` (pointing to Dify).
5. **Tool Improvement**: Patched `find_oldest_issues.py` to prevent it from flagging completed items (`- [x]`) as open tasks when they contain the `- [ ]` string.

All modifications were verified using the repository's validation suite (`check_docs_contract.py`, `audit_docs_quality.py`, `check_catalog_consistency.py`, and `validate_new_sources.py`), achieving 100% compliance.

---
*PR created automatically by Jules for task [13920514632156803617](https://jules.google.com/task/13920514632156803617) started by @joanmarcriera*