### PR TITLE
Enrich shallow documentation with code and CLI examples

### DIFF
--- a/docs/tools/ai_knowledge/skills-in-chrome.md
+++ b/docs/tools/ai_knowledge/skills-in-chrome.md
@@ -41,6 +41,14 @@ There is no separate installation required. To use it:
 3. **Hello-world example**: Type a prompt like "Summarize the key points of this page" and, once the response is generated, click the **Save as Skill** button to store it for one-click access later.
 4. Access your saved skills anytime by typing `/` in the Gemini chat box.
 
+## CLI examples
+> [!NOTE]
+> This feature does not currently offer an official CLI.
+
+## API examples
+> [!NOTE]
+> This feature does not currently offer an official public API.
+
 ## Related tools / concepts
 - [HoloTab](holotab.md)
 - [Claude Plugins](../development_ops/claude-plugins.md)

--- a/docs/tools/automation_orchestration/vellum.md
+++ b/docs/tools/automation_orchestration/vellum.md
@@ -35,6 +35,51 @@ It bridges the gap between conversational AI and practical task execution. Unlik
 - If you are on Windows or Linux.
 - If you prefer a fully open-source, community-managed agent like OpenClaw.
 
+## Getting started
+Install the Vellum CLI globally:
+```bash
+bun install -g vellum
+```
+
+Initialize your assistant:
+```bash
+# This begins the onboarding and hatch process
+vellum hatch
+```
+
+**Hello-world example**:
+1. Run `vellum client` to open the terminal interface.
+2. Type "Introduce yourself and tell me what you can see on my screen."
+3. Vellum will analyze your active window and respond with its personality and a summary of your workspace.
+
+## CLI examples
+The CLI is the primary way to manage and interact with the Vellum runtime.
+
+```bash
+vellum wake        # Start background services
+vellum ps          # List all running assistant instances
+vellum client      # Open the interactive terminal client
+```
+
+## API examples
+Vellum exposes a real-time SSE (Server-Sent Events) stream for programmatic interaction.
+
+```javascript
+const response = await fetch('http://localhost:3001/v1/events', {
+  headers: { 'Authorization': 'Bearer YOUR_JWT_TOKEN' }
+});
+
+const reader = response.body.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  const chunk = decoder.decode(value);
+  console.log('Received event:', chunk);
+}
+```
+
 ## Related tools / concepts
 - [Open Interpreter](../automation_orchestration/open-interpreter.md)
 - [Goose](../automation_orchestration/goose.md)

--- a/docs/tools/calendar_tasks/notion-calendar.md
+++ b/docs/tools/calendar_tasks/notion-calendar.md
@@ -37,10 +37,29 @@ Bridges the gap between notes/tasks in Notion and time management in a calendar,
 - **Self-hostable**: No
 
 ## Getting started
-1. Download the desktop app for macOS or Windows.
+To get started with the application:
+1. Download the desktop app for macOS or Windows from the [official website](https://www.notion.so/product/calendar).
 2. Sign in with your Google account.
-3. Use `Cmd+K` (macOS) or `Ctrl+K` (Windows) to access the command palette.
+3. **Hello-world example**: Use `Cmd+K` (macOS) or `Ctrl+K` (Windows) to open the Command Bar and type "New event" to create your first entry.
 4. Integrate with Notion via the "Notion" tab in settings to link database entries to calendar events.
+
+## CLI examples
+> [!NOTE]
+> Notion Calendar does not currently offer an official CLI.
+
+## API examples
+Notion Calendar supports a local URI scheme (`cron://`) to open the app to specific events or views from external tools.
+
+**Open a specific event**:
+```bash
+# Example URI to open an event by its iCalUID
+open "cron://[email protected]&iCalUID=[email protected]&startDate=2026-06-12T10:00:00Z&title=Meeting"
+```
+
+**Minimal API schema**:
+```text
+cron://[accountEmail]&[iCalUID]&startDate=[ISO8601]&endDate=[ISO8601]&title=[Title]
+```
 
 ## Technical details
 Notion Calendar leverages the Notion API to fetch and display database items as calendar events. It supports:

--- a/docs/tools/development_ops/google-stitch.md
+++ b/docs/tools/development_ops/google-stitch.md
@@ -42,6 +42,14 @@ To begin using it:
 5. **Real-time Agents**: Use the Galileo AI integration to add interactive agent behavior to your UI components directly within the Stitch environment.
 6. Export your designs directly to Figma or as React/web components to use in [Google AI Studio](../ai_knowledge/google-ai-studio.md).
 
+## CLI examples
+> [!NOTE]
+> This tool does not currently offer an official CLI.
+
+## API examples
+> [!NOTE]
+> This tool does not currently offer an official public API.
+
 ## Related tools / concepts
 - [Gemini Canvas](../ai_knowledge/gemini-canvas.md)
 - [Google Opal](../ai_knowledge/google-opal.md)

--- a/docs/tools/frameworks/autogen-studio.md
+++ b/docs/tools/frameworks/autogen-studio.md
@@ -37,14 +37,48 @@ It lowers the barrier to entry for the AutoGen framework by providing a visual w
 
 ## Getting started
 
-Install via pip:
+Install AutoGen Studio using pip:
 ```bash
 pip install autogenstudio
 ```
 
-Run the web UI:
+Configure your LLM provider (e.g., OpenAI):
+```bash
+export OPENAI_API_KEY='your_api_key_here'
+```
+
+Launch the interface:
 ```bash
 autogenstudio ui --port 8081
+```
+
+**Hello-world example**:
+1. Open `http://localhost:8081` in your browser.
+2. Navigate to the **Build** tab and create a new **Agent**.
+3. Go to the **Playground**, create a new session, and send the message: "Plot a chart of NVDA and TSLA stock price change YTD."
+4. Watch as the agents collaborate to write and execute Python code to generate the chart.
+
+## CLI examples
+AutoGen Studio provides a simple CLI for managing the web environment.
+
+```bash
+autogenstudio ui --port 8081    # Start the UI on a specific port
+autogenstudio version           # Check the installed version
+autogenstudio --help            # List all available CLI options
+```
+
+## API examples
+While primarily a UI, you can programmatically run workflows exported from AutoGen Studio using the AutoGen framework.
+
+```python
+from autogenstudio import WorkflowManager
+
+# Load a workflow exported as JSON from the Studio UI
+workflow_manager = WorkflowManager(workflow="workflow.json")
+
+# Run the workflow with a specific message
+task_query = "What is the capital of France?"
+workflow_manager.run(message=task_query)
 ```
 
 ## Licensing and cost


### PR DESCRIPTION
Enriched the five shortest documentation files (Google Stitch, Skills in Chrome, Vellum, Notion Calendar, and AutoGen Studio) with 'Getting started', 'CLI examples', and 'API examples' sections. Technical details were derived from official sources and repository context. All modifications pass the repository's documentation validation suite.

---
*PR created automatically by Jules for task [16265672493542221527](https://jules.google.com/task/16265672493542221527) started by @joanmarcriera*