### PR TITLE
Update Tesseract documentation to High Confidence standard

### DIFF
--- a/docs/tools/process_understanding/tesseract.md
+++ b/docs/tools/process_understanding/tesseract.md
@@ -1,49 +1,64 @@
 # Tesseract CLI
 
 ## What it is
-Tesseract is an open-source Optical Character Recognition (OCR) engine. It can be used directly via the command line (CLI) to extract text from images and PDF files.
+Tesseract is an open-source Optical Character Recognition (OCR) engine (v5.3.0+ as of June 2026). It can be used directly via the command line (CLI) to extract text from images and PDF files. It is the primary engine for [OCRmyPDF](ocrmypdf.md) and serves as a fundamental building block for agentic document ingestion pipelines.
 
 ## What problem it solves
-It converts images containing text (like scans or screenshots) into machine-readable text. This is a critical component for searchable document archives and automated data extraction.
+It converts images containing text (like scans, screenshots, or camera photos) into machine-readable text. This is a critical component for searchable document archives, automated data extraction, and providing vision-impaired accessibility. In the June 2026 stack, it is frequently combined with Claude 4.8 Opus for high-fidelity transcript correction.
 
 ## Where it fits in the stack
-**Tool / Process & Understanding**. It serves as the core OCR engine for higher-level tools like OCRmyPDF and document management systems.
+**Category**: Process & Understanding. It serves as the core OCR engine for higher-level tools like [OCRmyPDF](ocrmypdf.md) and is integrated into services like [Paperless-ngx](../../services/paperless-ngx.md) for automated document organization.
 
 ## Typical use cases
-- Extracting text from scanned documents and images.
-- Powering automated workflows that require text analysis of image-based inputs.
-- Batch processing images for archival and indexing.
+- **Agentic Ingestion**: Powering automated workflows that require text analysis of image-based inputs before passing them to an LLM like Claude 4.8.
+- **Legacy Archival**: Batch processing legacy scanned documents to enable full-text search.
+- **Accessibility**: Converting non-text-based documents into formats compatible with screen readers.
+- **Metadata Extraction**: Extracting specific data fields (dates, amounts) from receipts or forms using [Instructor](../frameworks/instructor.md).
 
 ## Strengths
-- **Language Support**: Supports over 100 languages out of the box.
-- **Accuracy**: Highly accurate for clean, high-resolution scans.
-- **Extensibility**: Can be trained to recognize new fonts or languages.
+- **Language Support**: Supports over 100 languages, including complex scripts like Arabic and Chinese.
+- **Performance**: v5.3.0+ features significant performance improvements via LSTM-based recognition and SIMD optimizations.
+- **Extensibility**: Open-source (Apache 2.0) and highly scriptable; can be trained for custom fonts.
+- **Offline Processing**: Operates entirely locally, ensuring data privacy for sensitive documents.
 
 ## Limitations
-- **Format Support**: Requires external tools (like Leptonica) for many image formats and PDF processing (often handled by wrappers like OCRmyPDF).
-- **Complex Layouts**: Can struggle with multi-column layouts or complex formatting without pre-processing.
-- **Handwriting**: Generally not suited for handwritten text recognition.
+- **Format Support**: Requires external libraries (like Leptonica) and often requires pre-processing (deskewing, denoising) for optimal results.
+- **Handwriting**: While improved, it remains less effective than specialized deep learning models for cursive or messy handwriting.
+- **Layout Complexity**: Can struggle with dense multi-column layouts or nested tables without sophisticated segmentation.
 
 ## When to use it
-- When you need a robust, open-source OCR engine for local processing.
-- When you are building custom automation that needs to "read" images.
+- When you need a robust, open-source OCR engine for high-volume local processing.
+- When building custom automation scripts that need to "read" images without cloud dependencies.
+- When data privacy is paramount and OCR must happen on-premises.
 
 ## When not to use it
-- For handwritten documents (consider specialized AI models).
-- When a higher-level wrapper like OCRmyPDF is available for PDF-specific tasks.
+- For "born-digital" documents that already contain a text layer.
+- When you need high-accuracy handwriting recognition (consider specialized AI models).
+- For complex PDF processing where [OCRmyPDF](ocrmypdf.md) or [Docling](docling.md) provide better high-level abstractions.
 
 ## Getting started
 
-### Installation
+### Installation (Local)
 ```bash
 # macOS
 brew install tesseract
 
 # Ubuntu
+sudo apt-get update
 sudo apt-get install tesseract-ocr
 
 # Verify installation
 tesseract --version
+```
+
+### Installation (Docker)
+Docker is the preferred method for consistent environments and dependency management:
+```bash
+# Pull the Tesseract Docker image
+docker pull tesseractocr/tesseract:latest
+
+# Run Tesseract via Docker
+docker run --rm -v "$(pwd):/home" tesseractocr/tesseract:latest /home/image.png /home/output -l eng
 ```
 
 ## CLI examples
@@ -54,23 +69,36 @@ tesseract image.png output_file -l eng
 # List available/installed languages
 tesseract --list-langs
 
-# Extract text from an image and output to standard output (stdout)
-tesseract image.png stdout -l eng
+# Extract text and output as HOCR (HTML-based OCR)
+tesseract image.png output hocr
+
+# Run on a multi-page TIFF
+tesseract input.tiff output -l eng
 ```
 
 ## API examples
 
-### Python (via pytesseract wrapper)
+### Python (via pytesseract)
+The most common way to integrate Tesseract into Python-based agentic workflows:
 ```python
 import pytesseract
 from PIL import Image
 
-# Open an image file
-img = Image.open('image.png')
+# Integration with Claude 4.8 Opus for correction
+def agentic_ocr(image_path):
+    img = Image.open(image_path)
+    raw_text = pytesseract.image_to_string(img, lang='eng')
 
-# Convert image to string
-text = pytesseract.image_to_string(img, lang='eng')
-print(text)
+    # Example: Pass to Claude for post-processing/correction
+    # processed_text = claude_client.messages.create(
+    #     model="claude-4.8-opus",
+    #     system="Correct OCR errors in the following text...",
+    #     messages=[{"role": "user", "content": raw_text}]
+    # )
+    return raw_text
+
+if __name__ == "__main__":
+    print(agentic_ocr('scan.png'))
 ```
 
 ## Licensing and cost
@@ -79,16 +107,22 @@ print(text)
 - **Self-hostable**: Yes
 
 ## Related tools / concepts
-- [OCRmyPDF](ocrmypdf.md)
-- [Docling](docling.md)
-- [Firecrawl](firecrawl.md)
-- [PageIndex](pageindex.md)
-- [RAGFlow](ragflow.md)
+- [OCRmyPDF](ocrmypdf.md) — Advanced PDF wrapper for Tesseract.
+- [Paperless-ngx](../../services/paperless-ngx.md) — Document management system using Tesseract.
+- [Docling](docling.md) — High-performance document parser for RAG.
+- [Firecrawl](firecrawl.md) — Web extraction engine for agentic workflows.
+- [RAGFlow](ragflow.md) — Evaluation platform for OCR and RAG pipelines.
+- [Unstructured](../intake_storage/unstructured.md) — Data partitioning library for multi-modal ingestion.
+- [LlamaParse](../intake_storage/llamaparse.md) — Cloud-based document parsing and optimization.
+- [Instructor](../frameworks/instructor.md) — Structured data extraction from OCR-processed text.
+- [Paperless-AI](../../services/paperless-ai.md) — AI-driven document processing for Paperless-ngx.
+- [Claude](../ai_knowledge/claude.md) — Frontier model for post-OCR text correction.
 
-## Sources / References
+## Sources / references
 - [Tesseract OCR GitHub](https://github.com/tesseract-ocr/tesseract)
 - [Tesseract Documentation](https://tesseract-ocr.github.io/)
+- [v5.3.0 Release Notes](https://github.com/tesseract-ocr/tesseract/releases)
 
 ## Contribution Metadata
-- Last reviewed: 2026-05-27
+- Last reviewed: 2026-06-20
 - Confidence: high


### PR DESCRIPTION
This PR upgrades the Tesseract CLI documentation to the 13-section 'High Confidence' standard. It incorporates June 2026 technical context, including version 5.3.0+ and integration with Claude 4.8 Opus. It also adds Docker installation instructions and expands the 'Related tools / concepts' section with 10 relative links for better repository-wide connectivity.

---
*PR created automatically by Jules for task [17448159352801282183](https://jules.google.com/task/17448159352801282183) started by @joanmarcriera*