### PR TITLE
Deepen 5 Shortest Docs with Practical Examples

### DIFF
--- a/data/growth-metrics.json
+++ b/data/growth-metrics.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_date": "2026-06-21",
+  "snapshot_date": "2026-06-22",
   "total_docs": 426,
   "tool_docs": 373,
   "service_docs": 53,
@@ -18,8 +18,8 @@
     "process_understanding": 30,
     "providers": 23
   },
-  "docs_with_code_examples": 419,
-  "docs_without_code_examples": 7,
+  "docs_with_code_examples": 420,
+  "docs_without_code_examples": 6,
   "shallow_docs": [],
   "underdeveloped_categories": [],
   "weekly_additions": 0,

--- a/docs/tools/ai_knowledge/gemini-flash-tts.md
+++ b/docs/tools/ai_knowledge/gemini-flash-tts.md
@@ -1,68 +1,146 @@
 # Gemini 3.1 Flash TTS
 
 ## What it is
-Gemini 3.1 Flash TTS is a next-generation text-to-speech model from Google, designed for low latency and high expressiveness. It is part of the Gemini 3.1 model family.
+Gemini 3.1 Flash TTS is a next-generation text-to-speech model from Google, designed for low latency and high expressiveness. It is part of the Gemini 3.1 model family and supports native audio generation without requiring a Live WebSocket connection.
 
 ## What problem it solves
-It provides a way to generate high-quality, expressive AI speech with minimal latency, making it suitable for real-time applications and interactive AI assistants.
+It provides a way to generate high-quality, expressive AI speech with minimal latency, making it suitable for real-time applications, interactive AI assistants, and long-form content narration. It allows for fine-grained control over tone, pace, and emotion using steerable prompts and expressive tags.
 
 ## Where it fits in the stack
 **AI & Knowledge / Generative Audio**. It serves as the speech synthesis layer for multimodal AI applications.
 
 ## Typical use cases
 - **Interactive Assistants**: Real-time voice interaction with LLM-based agents.
-- **Content Creation**: Generating voiceovers for videos or articles.
-- **Accessibility**: Providing high-quality audio versions of text content.
+- **Content Creation**: Generating high-fidelity voiceovers for videos, podcasts, or audiobooks.
+- **Accessibility**: Providing natural-sounding audio versions of text content with emotional depth.
+- **Dynamic Narration**: Games or apps that require context-aware speech.
 
 ## Strengths
-- **Low Latency**: Optimized for fast response times.
-- **Expressiveness**: Capable of generating natural-sounding speech with varied prosody.
-- **Integration**: Part of the broader Google Gemini ecosystem.
+- **Low Latency**: Optimized for fast response times and streaming.
+- **Expressiveness**: Supports emotional tags like `[laughs]`, `[sigh]`, and steerable prompts for style (e.g., "friendly and amused").
+- **Multilingual**: High-quality support for over 70 languages.
+- **Integration**: Uses the standard `generate_content` interface within the Google Gen AI SDK.
 
 ## Limitations
-- **Proprietary**: Access is controlled by Google via their APIs.
-- **Cost**: Usage-based pricing in AI Studio or Vertex AI.
+- **Proprietary**: Access is controlled by Google via their APIs (AI Studio / Vertex AI).
+- **Rate Limits**: Subject to Gemini API quota and usage-based pricing.
+- **Preview Status**: Some features and voices are in preview (as of 2026).
 
 ## When to use it
 - When you need low-latency, high-quality speech synthesis within the Google ecosystem.
-- For interactive voice applications where responsiveness is critical.
+- For interactive voice applications where emotional nuance and responsiveness are critical.
 
 ## When not to use it
 - If your application requires a fully open-source or self-hosted TTS solution.
-- For tasks where simple, non-expressive speech is sufficient and cost is the primary concern.
+- For offline use cases without internet access.
 
 ## Getting started
+Gemini 3.1 Flash TTS is accessible via the Google Gen AI SDK.
 
-### API Examples (Google AI Studio)
-
-You can use the `gemini-1.5-flash` (or newer) endpoints for TTS tasks.
-
-#### Python Snippet
-```python
-import os
-import google.generativeai as genai
-
-genai.configure(api_key="YOUR_API_KEY")
-
-model = genai.GenerativeModel('gemini-1.5-flash')
-# Note: Check the latest documentation for specific TTS-dedicated model strings
-# or generative audio parameters.
-
-# Experimental audio generation
-response = model.generate_content("Generate speech for: 'Hello, welcome to the future of TTS.'")
-# Save or stream the response.audio data
+### 1. Installation
+```bash
+pip install google-genai
 ```
 
-#### cURL Example
+### 2. Hello World (Python)
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key="YOUR_API_KEY")
+
+config = types.GenerateContentConfig(
+    response_modalities=["AUDIO"],
+    speech_config={
+        "voice_config": {
+            "prebuilt_voice_config": {"voice_name": "Kore"}
+        }
+    }
+)
+
+response = client.models.generate_content(
+    model="gemini-3.1-flash-tts",
+    contents="Hello! Welcome to the future of text-to-speech.",
+    config=config
+)
+
+# Save the generated audio
+audio_bytes = response.candidates[0].content.parts[0].inline_data.data
+with open("output.wav", "wb") as f:
+    f.write(audio_bytes)
+```
+
+## CLI examples
+Programmatic access is primarily via REST. You can use `curl` to synthesize speech.
+
+### Basic Speech Synthesis
 ```bash
-curl https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=$GOOGLE_API_KEY \
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts:generateContent?key=$GOOGLE_API_KEY" \
     -H 'Content-Type: application/json' \
     -X POST \
     -d '{
-      "contents": [{
-        "parts":[{"text": "Synthesize this text into a warm, professional voice."}]
-      }]
+      "contents": [{"parts": [{"text": "Synthesize this text into a warm, professional voice."}]}],
+      "generationConfig": {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+          "voiceConfig": {"prebuiltVoiceConfig": {"voice_name": "Callirrhoe"}}
+        }
+      }
     }'
+```
+
+### Synthesis with Expressive Tags
+```bash
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts:generateContent?key=$GOOGLE_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -X POST \
+    -d '{
+      "contents": [{"parts": [{"text": "[laughs] I did NOT expect that. [sigh] Can you believe it!"}]}],
+      "generationConfig": {
+        "responseModalities": ["AUDIO"]
+      }
+    }'
+```
+
+### Synthesis with Steerable Prompt
+```bash
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts:generateContent?key=$GOOGLE_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -X POST \
+    -d '{
+      "contents": [
+        {"role": "system", "parts": [{"text": "You are a friendly and amused narrator."}]},
+        {"role": "user", "parts": [{"text": "Tell me a quick joke about bananas."}]}
+      ],
+      "generationConfig": {
+        "responseModalities": ["AUDIO"]
+      }
+    }'
+```
+
+## API examples
+
+### Streaming Speech Generation
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+config = types.GenerateContentConfig(response_modalities=["AUDIO"])
+
+# Use generate_content_stream for low-latency playback
+stream = client.models.generate_content_stream(
+    model="gemini-3.1-flash-tts",
+    contents="This is a long-form content that will be streamed in chunks.",
+    config=config
+)
+
+for chunk in stream:
+    if chunk.candidates[0].content.parts[0].inline_data:
+        # Process audio chunk (e.g., feed to a player)
+        audio_chunk = chunk.candidates[0].content.parts[0].inline_data.data
+        print(f"Received audio chunk of size: {len(audio_chunk)}")
 ```
 
 ## Related tools / concepts
@@ -78,6 +156,7 @@ curl https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:ge
 ## Sources / References
 - [Gemini 3.1 Flash TTS Announcement](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-tts/)
 - [Google AI Studio Audio Documentation](https://ai.google.dev/gemini-api/docs/audio)
+- [Gemini 3.1 Flash TTS Preview Model Card](https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-tts-preview)
 
 ## Contribution Metadata
 - Last reviewed: 2026-06-27

--- a/docs/tools/ai_knowledge/nano-banana.md
+++ b/docs/tools/ai_knowledge/nano-banana.md
@@ -32,6 +32,98 @@ Use Nano Banana when you need quick, high-quality image edits or generations and
 ## When not to use it
 Avoid it for highly sensitive or professional-grade design work that requires absolute precision, or if you require an offline, privacy-first image editing workflow.
 
+## Getting started
+Nano Banana is accessible via the Google AI Studio interface or programmatically through the Google Gen AI SDK.
+
+### 1. Installation
+```bash
+pip install google-genai
+```
+
+### 2. Hello World (Python)
+```python
+from google import genai
+import base64
+
+client = genai.Client(api_key="YOUR_API_KEY")
+
+# Simple image generation
+interaction = client.interactions.create(
+    model="gemini-3.1-flash-image",
+    input="A futuristic city in the style of cyberpunk, with neon lights and flying cars.",
+)
+
+# Save the generated image
+with open("output.png", "wb") as f:
+    f.write(base64.b64decode(interaction.output_image.data))
+```
+
+## CLI examples
+Programmatic access is primarily via REST. You can use `curl` to interact with the models directly.
+
+### Generate Image from Text
+```bash
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/interactions" \
+  -H "x-goog-api-key: $GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-3.1-flash-image",
+    "input": [{"type": "text", "text": "A minimal logo for a tech startup called BananaNano"}]
+  }'
+```
+
+### Edit Existing Image
+```bash
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/interactions" \
+  -H "x-goog-api-key: $GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-3.1-flash-image",
+    "input": [
+      {"type": "text", "text": "Change the color of the shirt to blue"},
+      {"type": "image", "mime_type": "image/png", "data": "'"$(base64 -w 0 image.png)"'"}
+    ]
+  }'
+```
+
+### High-Resolution Generation
+```bash
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/interactions" \
+  -H "x-goog-api-key: $GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-3-pro-image",
+    "input": "A cinematic wide shot of a desert landscape at sunset",
+    "response_format": {"type": "image", "image_size": "4K"}
+  }'
+```
+
+## API examples
+The Interactions API supports multi-turn conversations and advanced "Thinking" processes.
+
+### Multi-turn Image Editing
+```python
+from google import genai
+
+client = genai.Client()
+
+# Step 1: Generate initial image
+interaction = client.interactions.create(
+    model="gemini-3.1-flash-image",
+    input="Create a vibrant infographic about photosynthesis."
+)
+
+# Step 2: Refine the image using the previous interaction ID
+interaction_v2 = client.interactions.create(
+    model="gemini-3.1-flash-image",
+    input="Now translate all text in the image to Spanish.",
+    previous_interaction_id=interaction.id
+)
+
+# Access the refined image
+print(interaction_v2.output_image.mime_type)
+```
+
 ## Related tools / concepts
 - [Gemini](gemini.md)
 - [Runway ML](runwayml.md)

--- a/docs/tools/benchmarking/assistant-bench.md
+++ b/docs/tools/benchmarking/assistant-bench.md
@@ -32,16 +32,57 @@ It addresses the limitation of benchmarks that focus on atomic actions or single
 - For evaluating models in a sandbox without internet access.
 
 ## Getting started
-AssistantBench is supported by the `inspect-ai` framework.
+AssistantBench is integrated into the `inspect-ai` framework via the `inspect-evals` package.
 
 ### 1. Installation
 ```bash
-pip install inspect-evals
+pip install inspect-ai inspect-evals
 ```
 
-### 2. Running AssistantBench
+### 2. Basic Usage
+Run the evaluation using the `inspect` CLI:
 ```bash
 inspect eval inspect_evals/assistant_bench_web_browser --model openai/gpt-4o
+```
+
+## CLI examples
+
+### Run with Sample Limit
+Test the agent on a small subset (e.g., 5 tasks) to verify the environment setup:
+```bash
+inspect eval inspect_evals/assistant_bench_web_browser --model anthropic/claude-3-5-sonnet-20240620 --limit 5
+```
+
+### Compare Multiple Models
+Run AssistantBench across different models to compare performance:
+```bash
+inspect eval inspect_evals/assistant_bench_web_browser --model openai/gpt-4o,anthropic/claude-3-5-sonnet-20240620
+```
+
+### Visualize Results
+Launch the Inspect log viewer to inspect the agent's step-by-step trajectories:
+```bash
+inspect view
+```
+
+## API examples
+You can also trigger AssistantBench evaluations programmatically using the Inspect Python API.
+
+### Minimal Evaluation Script
+```python
+from inspect_ai import eval
+from inspect_evals import assistant_bench_web_browser
+
+# Run AssistantBench on a specific model
+results = eval(
+    assistant_bench_web_browser(),
+    model="openai/gpt-4o",
+    limit=10  # Optional: limit to 10 samples for testing
+)
+
+# Output the accuracy and scores
+for result in results:
+    print(f"Model: {result.model}, Accuracy: {result.metrics['accuracy'].value}")
 ```
 
 ## Related tools / concepts

--- a/docs/tools/benchmarking/gaia.md
+++ b/docs/tools/benchmarking/gaia.md
@@ -33,16 +33,61 @@ Existing benchmarks often focus on narrow tasks or synthetic reasoning. GAIA tar
 - For lightweight testing where a simpler benchmark (like MMLU) suffices.
 
 ## Getting started
-GAIA evaluations are often run using frameworks like `inspect-ai`.
+GAIA evaluations are primarily executed using the `inspect-ai` framework, which provides a standardized environment for agentic benchmarks.
 
 ### 1. Installation
 ```bash
-pip install inspect-evals[gaia]
+pip install inspect-ai inspect-evals
 ```
 
-### 2. Running GAIA with Inspect
+### 2. Basic Evaluation
+Run the full GAIA validation set against a model:
 ```bash
 inspect eval inspect_evals/gaia --model openai/gpt-4o
+```
+
+## CLI examples
+
+### Run Specific Difficulty Levels
+GAIA is divided into levels 1, 2, and 3. You can run them individually:
+```bash
+# Run only Level 1 (easiest)
+inspect eval inspect_evals/gaia_level1 --model anthropic/claude-3-5-sonnet-20240620
+
+# Run only Level 3 (hardest)
+inspect eval inspect_evals/gaia_level3 --model anthropic/claude-3-5-sonnet-20240620
+```
+
+### Limit Samples and Parallelism
+For faster testing, limit the number of samples and control connection limits:
+```bash
+inspect eval inspect_evals/gaia --limit 10 --max-connections 5 --model openai/gpt-4o
+```
+
+### Use Custom Prompts
+Override the default prompt template to test different agent instructions:
+```bash
+inspect eval inspect_evals/gaia --model openai/gpt-4o -K input_prompt="Answer this: {question} using the provided file: {file}"
+```
+
+## API examples
+You can integrate GAIA into your own Python evaluation pipelines using the Inspect API.
+
+### Minimal Evaluation Script
+```python
+from inspect_ai import eval
+from inspect_evals.gaia import gaia
+
+# Run GAIA validation set
+results = eval(
+    gaia(split="validation", subset="2023_all"),
+    model="openai/gpt-4o",
+    limit=5
+)
+
+# Access results
+for result in results:
+    print(f"Task ID: {result.sample_id}, Score: {result.scores['accuracy'].value}")
 ```
 
 ## Related tools / concepts

--- a/docs/tools/infrastructure/k3s.md
+++ b/docs/tools/infrastructure/k3s.md
@@ -31,17 +31,18 @@ It simplifies the operation of Kubernetes by bundling necessary components into 
 - In extremely large enterprise environments where a managed service (EKS, GKE) or a full distribution (RKE, OpenShift) is preferred.
 
 ## Getting started
+K3s is designed for easy installation and low overhead.
 
-### Installation
-The simplest way to install K3s on a Linux host:
+### 1. Installation
+The simplest way to install K3s on a Linux host is via the official install script:
 ```bash
 curl -sfL https://get.k3s.io | sh -
 # Check node status
 sudo k3s kubectl get node
 ```
 
-### Deploying a Simple Workload
-Create a file named `whoami.yaml`:
+### 2. Hello World (Deploying a Workload)
+Create a file named `whoami.yaml` to deploy a simple web service:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -77,6 +78,43 @@ spec:
 Apply the manifest:
 ```bash
 sudo k3s kubectl apply -f whoami.yaml
+```
+
+## CLI examples
+
+### Check Cluster Configuration
+Verify if your host meets the requirements for running K3s:
+```bash
+k3s check-config
+```
+
+### Manage Nodes
+List all nodes in the cluster with additional details:
+```bash
+sudo k3s kubectl get nodes -o wide
+```
+
+### View Server Logs
+Monitor the K3s server process logs for troubleshooting:
+```bash
+sudo journalctl -u k3s -f
+```
+
+## API examples
+K3s is fully compatible with the standard Kubernetes API. You can use any Kubernetes client, such as the official Python client.
+
+### List Pods (Python)
+```python
+from kubernetes import client, config
+
+# Load config from the default K3s location
+config.load_kube_config(config_file="/etc/rancher/k3s/k3s.yaml")
+
+v1 = client.CoreV1Api()
+print("Listing pods with their IPs:")
+ret = v1.list_pod_for_all_namespaces(watch=False)
+for i in ret.items:
+    print(f"{i.status.pod_ip}\t{i.metadata.namespace}\t{i.metadata.name}")
 ```
 
 ## Licensing and cost


### PR DESCRIPTION
I have deepened the documentation for the 5 shortest documents in the knowledge base that required content updates. Although the `shallow_docs` list in `data/growth-metrics.json` was empty, I manually identified the shortest files and enriched them with the requested sections.

Key updates:
1.  **AssistantBench**: Added instructions for `inspect-ai` integration, including CLI examples for limited runs and multi-model comparison, and a Python API snippet.
2.  **Nano Banana**: Added details for the new Interactions API (Beta) for image generation and multi-turn editing using the `gemini-3.1-flash-image` and `gemini-3-pro-image` models.
3.  **Gemini 3.1 Flash TTS**: Standardized the Getting Started section and added expressive tag and steerable prompt examples via `curl` and the Python SDK.
4.  **K3s**: Added common administrative CLI commands (`check-config`, `journalctl`) and a Python API example using the `kubernetes` client.
5.  **GAIA**: Added `inspect-ai` CLI commands for difficulty-specific runs and custom prompt templates, along with a programmatic evaluation script.

All changes were verified using the repository's validation scripts (`check_docs_contract.py` and `audit_docs_quality.py`) and follow the 13-section documentation standard.

---
*PR created automatically by Jules for task [7774493775852262532](https://jules.google.com/task/7774493775852262532) started by @joanmarcriera*