### PR TITLE
Wire automation PRs to AUTOMATION_PAT (fix action_required checks)

### DIFF
--- a/.github/automation-token-setup.md
+++ b/.github/automation-token-setup.md
@@ -1,0 +1,62 @@
+# Automation token setup (`AUTOMATION_PAT`)
+
+## Why
+PRs opened with the default `GITHUB_TOKEN` do **not** trigger `on: pull_request`
+workflows — a deliberate GitHub guard against recursive runs. That leaves the
+shared `automation/weekly-rollup` PR's checks stuck in **`action_required`**, so
+they never report and the PR can't merge on checks alone.
+
+The three PR-creating workflows (`weekly-planner.yml`, `daily-digest.yml`,
+`monthly-reddit-openclaw-intake.yml`) now open their PR with a real-identity
+token:
+
+```yaml
+token: ${{ secrets.AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
+```
+
+- **Secret present** → the PR is authored by that identity, so check workflows
+  run automatically and the PR can auto-merge.
+- **Secret absent** → falls back to `GITHUB_TOKEN` (today's behaviour: an inert
+  PR whose checks are dispatched manually by the "Trigger PR gate workflows"
+  step and re-run by `weekly-automation-rollup-merge.yml`). Nothing breaks.
+
+## Option A — fine-grained PAT (simplest, recommended for a solo repo)
+1. GitHub → **Settings → Developer settings → Fine-grained personal access
+   tokens → Generate new token**.
+2. **Resource owner:** your account. **Repository access:** *Only select
+   repositories* → `Home-office-automations`.
+3. **Repository permissions:** `Contents` = Read and write, `Pull requests` =
+   Read and write, `Issues` = Read and write, `Workflows` = Read and write.
+4. Set an expiry you're comfortable with (e.g. 1 year) and **Generate**. Copy
+   the token (`github_pat_…`).
+5. Add it as a repo secret:
+   ```bash
+   gh secret set AUTOMATION_PAT --repo joanmarcriera/Home-office-automations
+   # paste the token when prompted
+   ```
+   (or GitHub → repo **Settings → Secrets and variables → Actions → New
+   repository secret**, name `AUTOMATION_PAT`).
+
+> Note: a fine-grained PAT expires. Set a calendar reminder to rotate it, or use
+> Option B for a non-expiring, identity-independent setup.
+
+## Option B — GitHub App token (more durable, no personal expiry)
+1. Create a GitHub App (Settings → Developer settings → GitHub Apps) with
+   **Contents: R/W, Pull requests: R/W, Issues: R/W, Workflows: R/W**; install
+   it on this repo.
+2. Store its **App ID** and **private key** as secrets `APP_ID` /
+   `APP_PRIVATE_KEY`.
+3. Mint a token per run and pass it as `AUTOMATION_PAT`:
+   ```yaml
+   - uses: actions/create-github-app-token@v1
+     id: app-token
+     with:
+       app-id: ${{ secrets.APP_ID }}
+       private-key: ${{ secrets.APP_PRIVATE_KEY }}
+   # then use steps.app-token.outputs.token where AUTOMATION_PAT is referenced
+   ```
+
+## Verify
+After adding the secret, manually run **Weekly Growth Planner** (Actions →
+Run workflow). The refreshed `automation/weekly-rollup` PR should show its checks
+**running automatically** instead of `action_required`.

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -48,6 +48,10 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
+          # Real-identity token so the PR triggers on:pull_request checks; falls
+          # back to GITHUB_TOKEN (inert PR) when the secret is absent. See
+          # weekly-planner.yml for the full rationale.
+          token: ${{ secrets.AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
           branch: automation/weekly-rollup
           delete-branch: true
           title: "chore: automation rollup"

--- a/.github/workflows/monthly-reddit-openclaw-intake.yml
+++ b/.github/workflows/monthly-reddit-openclaw-intake.yml
@@ -98,6 +98,10 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
+          # Real-identity token so the PR triggers on:pull_request checks; falls
+          # back to GITHUB_TOKEN (inert PR) when the secret is absent. See
+          # weekly-planner.yml for the full rationale.
+          token: ${{ secrets.AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
           branch: automation/weekly-rollup
           delete-branch: true
           title: "chore: automation rollup"

--- a/.github/workflows/weekly-planner.yml
+++ b/.github/workflows/weekly-planner.yml
@@ -50,6 +50,13 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
+          # Use a real-identity PAT (or GitHub App token) so the resulting PR
+          # TRIGGERS the on:pull_request check workflows. PRs opened with the
+          # default GITHUB_TOKEN are intentionally inert (GitHub recursion guard),
+          # which leaves checks stuck in "action_required". Falls back to
+          # GITHUB_TOKEN when the secret is absent (PR still opens; the
+          # "Trigger PR gate workflows" step below dispatches checks manually).
+          token: ${{ secrets.AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
           branch: automation/weekly-rollup
           delete-branch: true
           title: "chore: automation rollup"


### PR DESCRIPTION
## Summary
Makes the automation PRs' checks run automatically instead of getting stuck in `action_required`.

PRs opened with the default `GITHUB_TOKEN` don't trigger `on: pull_request` workflows (GitHub's recursion guard), so the shared `automation/weekly-rollup` PR's checks never report and it can't merge on checks alone.

The three PR-creating workflows now open their PR with a real-identity token, with graceful fallback:
```yaml
token: ${{ secrets.AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
```
- **Secret present** → PR triggers checks automatically and can auto-merge.
- **Secret absent** → unchanged behaviour (inert PR + manual check dispatch). Nothing breaks before you add the secret.

Workflows updated: `weekly-planner.yml`, `daily-digest.yml`, `monthly-reddit-openclaw-intake.yml`.

## Action required by you (one-time)
The token itself must be created in your GitHub account — I can't mint it. Steps are in **`.github/automation-token-setup.md`** (fine-grained PAT, recommended; or a GitHub App for a non-expiring setup). Then add it as the `AUTOMATION_PAT` repo secret — I can run `gh secret set AUTOMATION_PAT` for you if you paste the value, or you can add it in the repo settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)