### PR TITLE
Review-pass fixes: workflow/script bugs + watchlist expansion

### DIFF
--- a/.github/workflows/auto-fix-issues.yml
+++ b/.github/workflows/auto-fix-issues.yml
@@ -85,6 +85,6 @@ jobs:
           set -euo pipefail
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label jules || true
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
-            "OpenRouter auto-fix could not complete this issue in CI. Falling back to Jules (`jules`) for handling."
+            'OpenRouter auto-fix could not complete this issue in CI. Falling back to the Jules pipeline for handling.'
 
       # Auto-merge removed — all PRs require human review

--- a/.github/workflows/coverage-gap-scan.yml
+++ b/.github/workflows/coverage-gap-scan.yml
@@ -46,8 +46,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Validate watchlist JSON
-        run: python3 -c "import json; json.load(open('data/frontier_watchlist.json')); print('watchlist OK')"
+      - name: Validate data JSON (watchlist + catalog)
+        run: |
+          python3 -c "import json; json.load(open('data/frontier_watchlist.json')); print('watchlist OK')"
+          python3 -c "import json; json.load(open('data/all_tools.json')); print('catalog OK')"
 
       - name: Run coverage gap scan
         run: |

--- a/.github/workflows/jules-auto-merge.yml
+++ b/.github/workflows/jules-auto-merge.yml
@@ -80,10 +80,10 @@ jobs:
             --json number,title,body,labels,headRefName,author \
             --jq '[.[] | select(
               (.headRefName != "automation/weekly-rollup") and (
-              (.title | test("daily maintenance|daily knowledge|weekly|cross-link|primer|automated resolution"; "i")) or
+              (.title | test("daily maintenance|daily knowledge|weekly|cross-link|primer|automated resolution|freshness audit"; "i")) or
               ((.body // "") | test("PR created automatically by Jules"; "i")) or
               (.labels[]?.name == "jules") or
-              (.headRefName | test("jules|daily-maintenance|daily-knowledge|jules-sprint|weekly-deepen|cross-link|primer|auto-fix"; "i")) or
+              (.headRefName | test("jules|daily-maintenance|daily-knowledge|jules-sprint|weekly-deepen|cross-link|primer|auto-fix|ralph-loop|freshness-audit|audit-batch|batch-"; "i")) or
               (.author.login == "google-labs-jules[bot]")
             ))] | map(.number) | join(",")')
 

--- a/.github/workflows/jules-sprint-workers.yml
+++ b/.github/workflows/jules-sprint-workers.yml
@@ -82,8 +82,47 @@ jobs:
             echo "⏸️ Non-automation Jules backlog detected ($OPEN_NON_AUTOMATION). Sprint seeding skipped."
           fi
 
-      - name: Seed/maintain sprint worker issues
+      - name: Check for live Jules PRs (throttle)
         if: steps.window.outputs.in_window == 'true' && steps.backlog.outputs.open_non_automation == '0'
+        id: pr_throttle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Like the other Jules lanes: don't seed a sprint while real PRs are in
+          # flight, and ignore CONFLICTING orphans so they can't stall seeding.
+          # Without this, a sprint could flood the Jules daily quota with up to
+          # TARGET_WORKERS issues regardless of how much work is already open.
+          CANDIDATES=$(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --json number,title,body,labels,headRefName,author \
+            --jq '[.[] | select(
+              (.title | test("daily maintenance|daily knowledge|weekly|cross-link|primer|automated resolution|freshness audit"; "i")) or
+              ((.body // "") | test("PR created automatically by Jules"; "i")) or
+              (.labels[]?.name == "jules") or
+              (.headRefName | test("jules|daily-maintenance|daily-knowledge|jules-sprint|weekly-deepen|cross-link|primer|auto-fix|ralph-loop|freshness-audit|audit-batch|batch-"; "i")) or
+              (.author.login == "google-labs-jules[bot]")
+            ) | .number]')
+
+          OPEN_PRS=0
+          for PR in $(echo "$CANDIDATES" | jq -r '.[]'); do
+            STATE=$(gh pr view "$PR" --repo "$REPO" --json mergeable --jq '.mergeable' 2>/dev/null || echo UNKNOWN)
+            if [ "$STATE" = "CONFLICTING" ]; then
+              echo "Ignoring conflicting orphan PR #$PR for throttle."
+              continue
+            fi
+            OPEN_PRS=$((OPEN_PRS + 1))
+          done
+
+          echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
+          if [ "$OPEN_PRS" != "0" ]; then
+            echo "⏸️ Throttled: $OPEN_PRS live Jules PR(s). Sprint seeding skipped."
+          fi
+
+      - name: Seed/maintain sprint worker issues
+        if: steps.window.outputs.in_window == 'true' && steps.backlog.outputs.open_non_automation == '0' && steps.pr_throttle.outputs.open_prs == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/data/frontier_watchlist.json
+++ b/data/frontier_watchlist.json
@@ -92,6 +92,87 @@
       "offline_capable": true,
       "tags": ["emerging", "code-execution", "local"],
       "why": "Local code-executing agent that can drive a machine with local models; relevant to home-automation agent patterns."
+    },
+    {
+      "name": "Qdrant",
+      "aliases": ["qdrant"],
+      "suggested_category": "Infrastructure",
+      "priority": "high",
+      "offline_capable": true,
+      "tags": ["offline-first", "vector-db", "rag"],
+      "why": "De-facto self-hosted vector database for local RAG. The catalog only has heavyweight Milvus/Weaviate and cloud-only Pinecone — the lightweight local vector layer that makes offline RAG work is undocumented."
+    },
+    {
+      "name": "Chroma",
+      "aliases": ["chroma", "chromadb"],
+      "suggested_category": "Infrastructure",
+      "priority": "high",
+      "offline_capable": true,
+      "tags": ["offline-first", "vector-db", "rag"],
+      "why": "Lightweight embedded vector DB, the default for quick local RAG prototypes; pairs with local embeddings to deliver the repo's offline-RAG thesis."
+    },
+    {
+      "name": "LanceDB",
+      "aliases": ["lancedb", "lance db"],
+      "suggested_category": "Infrastructure",
+      "priority": "medium",
+      "offline_capable": true,
+      "tags": ["offline-first", "vector-db", "embedded"],
+      "why": "Embedded, file-based, zero-server vector store ideal for air-gapped single-box home labs."
+    },
+    {
+      "name": "Local embedding models",
+      "aliases": ["nomic-embed-text", "bge-m3", "gte", "sentence-transformers", "local embeddings"],
+      "suggested_category": "Infrastructure",
+      "priority": "high",
+      "offline_capable": true,
+      "tags": ["offline-first", "embeddings", "rag"],
+      "why": "The embedding side of offline RAG (nomic-embed, bge, gte). Nothing in the catalog documents running embeddings locally, leaving the RAG pattern pages without an offline backend."
+    },
+    {
+      "name": "Llama (model family)",
+      "aliases": ["llama", "llama 3", "llama 4", "meta llama", "meta_llama"],
+      "suggested_category": "AI Assistants & Knowledge",
+      "priority": "high",
+      "offline_capable": true,
+      "tags": ["offline-first", "local-llm", "model-family"],
+      "why": "The most-referenced missing page: ~15 inbound 'Related tools' links point to a Llama model-family page that does not exist, despite 10+ Llama-adjacent runtime pages."
+    },
+    {
+      "name": "Gemma (model family)",
+      "aliases": ["gemma", "gemma 3"],
+      "suggested_category": "AI Assistants & Knowledge",
+      "priority": "medium",
+      "offline_capable": true,
+      "tags": ["offline-first", "local-llm", "model-family"],
+      "why": "Google's open local model family, commonly run via Ollama/llama.cpp; referenced by several docs with no canonical page."
+    },
+    {
+      "name": "Inspect AI",
+      "aliases": ["inspect-ai", "inspect ai", "ukaisi inspect"],
+      "suggested_category": "Benchmarking",
+      "priority": "medium",
+      "offline_capable": true,
+      "tags": ["emerging", "evals", "local"],
+      "why": "Open eval framework (UK AISI) gaining adoption; can evaluate local models offline. ~5 inbound links expect a page."
+    },
+    {
+      "name": "llama-swap",
+      "aliases": ["llama swap", "llamaswap"],
+      "suggested_category": "Infrastructure",
+      "priority": "medium",
+      "offline_capable": true,
+      "tags": ["offline-first", "local-llm", "model-routing"],
+      "why": "Hot-swaps local GGUF models behind one OpenAI-compatible endpoint — key for running many local models on constrained home-lab hardware."
+    },
+    {
+      "name": "Ramalama",
+      "aliases": ["ramalama"],
+      "suggested_category": "Infrastructure",
+      "priority": "medium",
+      "offline_capable": true,
+      "tags": ["offline-first", "local-llm", "containers"],
+      "why": "Container-native (Podman/OCI) local model runner; emerging reproducible-serving alternative to Ollama for air-gapped boxes."
     }
   ]
 }

--- a/scripts/check_catalog_consistency.py
+++ b/scripts/check_catalog_consistency.py
@@ -38,7 +38,7 @@ def canonical_nav_paths() -> set[str]:
 
 def tool_catalog_paths() -> set[str]:
     payload = json.loads(TOOLS_JSON_PATH.read_text(encoding="utf-8"))
-    return {entry["doc_path"] for entry in payload.get("tools", [])}
+    return {entry["doc_path"] for entry in payload.get("tools", []) if entry.get("doc_path")}
 
 
 def main() -> int:

--- a/scripts/check_doc_freshness.py
+++ b/scripts/check_doc_freshness.py
@@ -35,7 +35,9 @@ def expand_paths(raw_paths: list[str]) -> list[str]:
 
 
 def extract_last_reviewed(path: Path) -> dt.date | None:
-    text = path.read_text(encoding="utf-8")
+    # errors="ignore": a single doc with invalid UTF-8 must not crash the whole
+    # freshness gate (this runs with --fail-on-stale in generated-content-gates).
+    text = path.read_text(encoding="utf-8", errors="ignore")
     match = LAST_REVIEWED_RE.search(text)
     if not match:
         return None

--- a/scripts/coverage_gap_scan.py
+++ b/scripts/coverage_gap_scan.py
@@ -56,10 +56,19 @@ def normalize(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", name.lower())
 
 
+def _load_json(path: Path) -> dict:
+    """Load JSON, degrading to {} with a warning instead of crashing a scheduled run."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"WARNING: could not parse {path}: {exc}", file=sys.stderr)
+        return {}
+
+
 def load_catalog() -> tuple[list[dict], set[str], dict[str, int]]:
     if not CATALOG_PATH.exists():
         return [], set(), {}
-    data = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    data = _load_json(CATALOG_PATH)
     tools = data.get("tools", [])
     names = {normalize(t.get("name", "")) for t in tools if t.get("name")}
     category_counts: dict[str, int] = {}
@@ -71,8 +80,7 @@ def load_catalog() -> tuple[list[dict], set[str], dict[str, int]]:
 def load_watchlist() -> list[dict]:
     if not WATCHLIST_PATH.exists():
         return []
-    data = json.loads(WATCHLIST_PATH.read_text(encoding="utf-8"))
-    return data.get("entries", [])
+    return _load_json(WATCHLIST_PATH).get("entries", [])
 
 
 def find_frontier_gaps(watchlist: list[dict], catalog_names: set[str]) -> list[dict]:
@@ -147,7 +155,7 @@ def build_report(frontier: list[dict], thin: list[dict], dangling: list[dict]) -
             tags = ", ".join(e.get("tags", []))
             offline = "🔌 offline" if e.get("offline_capable") else "☁️ cloud"
             lines.append(
-                f"- **{e['name']}** ({e.get('suggested_category', '?')}, {e.get('priority', 'medium')} priority, {offline})"
+                f"- **{e.get('name', '?')}** ({e.get('suggested_category', '?')}, {e.get('priority', 'medium')} priority, {offline})"
                 f" — {e.get('why', '')}" + (f" _[{tags}]_" if tags else "")
             )
     else:
@@ -187,7 +195,7 @@ def create_issue(report: str, frontier: list[dict]) -> bool:
         print("No frontier gaps to fill. Skipping issue creation.")
         return False
 
-    top = ", ".join(e["name"] for e in frontier[:5])
+    top = ", ".join(e.get("name", "?") for e in frontier[:5])
     title = f"Coverage gap fill: {top}"
     body = (
         report

--- a/scripts/cross_link_report.py
+++ b/scripts/cross_link_report.py
@@ -32,7 +32,10 @@ def load_tool_pages() -> dict[str, str]:
     tools = {}
     for tool in data.get("tools", []):
         name = tool.get("name", "").strip()
-        page = tool.get("page", "").strip()
+        # Catalog uses "doc_path" (e.g. "docs/services/ollama.md"); the old "page"
+        # key no longer exists, which silently emptied this map and made the whole
+        # scanner a no-op.
+        page = tool.get("doc_path", "").strip()
         if name and page:
             tools[name.lower()] = page
     return tools


### PR DESCRIPTION
Findings from a multi-agent full-repo audit (workflows, scripts, docs integrity, offline-first coverage). This PR fixes the verified bugs and expands the self-evolution backlog; larger content work is routed to the automation pipeline (see companion gap issue).

## Bug fixes (verified)
**Workflows**
- `auto-fix-issues.yml` — backticked `` `jules` `` in a double-quoted comment triggered shell command substitution, red-failing every OpenRouter-fallback run. **HIGH**
- `jules-auto-merge.yml` — bot-PR regex had drifted from the throttles/`pr-hygiene`: `ralph-loop-batch-*` / `audit-batch-*` / `freshness-audit-*` PRs were throttle-counted but never auto-merged (slow pileup). Aligned title + branch tests. **HIGH**
- `jules-sprint-workers.yml` — no PR throttle (only an issue-backlog check) → a re-enabled sprint could flood the Jules daily quota. Added the same conflict-aware live-PR throttle. **MED**
- `coverage-gap-scan.yml` — now validates `all_tools.json` too.

**Scripts (silent-failure / robustness)**
- `cross_link_report.py` — read the nonexistent `page` field → silently no-opped the entire scanner. Now reads `doc_path` (verified: now sees 446 tools). **HIGH**
- `check_doc_freshness.py` — `errors="ignore"` so one bad-UTF-8 file can't crash the freshness gate.
- `coverage_gap_scan.py` — guard JSON parsing (skip+warn), stop hard-indexing `e['name']`.
- `check_catalog_consistency.py` — skip catalog entries with no `doc_path` instead of `KeyError`.

## Data
- `frontier_watchlist.json` +9 entries for the missing **local-data layer** and frontier (Qdrant, Chroma, LanceDB, local embeddings, Llama/Gemma families, Inspect AI, llama-swap, Ramalama). The coverage-gap scan now surfaces 12 prioritized gaps for the bots to fill.

## Deferred (documented; not unattended-operation risks)
- `growth_tracker.py` metric column — low-impact vanity metric; the table format differs from the audit's assumption, so a blind fix would be wrong.
- `docs-link-health.yml` `fail: false` — intentional; flipping to `fail: true` now would jam every doc PR on the existing ~118-link backlog. Revisit once the backlog is cleared via the gap issue.

## Validation
All changed workflow YAML loads; Python syntax OK; catalog consistency + contract checks still pass; coverage-gap scanner runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)