### PR TITLE
skills.md: capture automation pipeline + coverage self-evolution learnings

### DIFF
--- a/skills.md
+++ b/skills.md
@@ -16,6 +16,8 @@ Pick the skill that matches your task. Execute its steps in order. Apply the lis
 | **Workflow Maintainer** | Adjusting schedules, issue automation, CI behavior. | `.github/workflows/**`, optional `scripts/**` | Validate YAML, confirm workflow logic via `gh run` |
 | **Issue-to-PR Resolver** | Converting open issues into merged fixes. | Issue-specific files + branch/PR metadata | Relevant repo checks + green PR status checks |
 | **Branch Janitor** | Post-merge cleanup of remote/local branches and stale PR refs. | Git branches/PR state | Verify open PR list and branch list after cleanup |
+| **Unattended Pipeline Triage** | Board piled up or Jules pipeline stalled (conflicting orphan PRs, stale control issues). | `.github/workflows/**`, open PRs/issues | `gh pr list` mergeable states; confirm throttles + pr-hygiene |
+| **Coverage Self-Evolution** | Expanding coverage toward the frontier; clearing dangling links. | `data/frontier_watchlist.json`, `data/all_tools.json`, `docs/**` | `coverage_gap_scan.py`, `fix_internal_links.py`, `check_catalog_consistency` |
 | **Superpowers** | High-level agent orchestration and skill management. | `.claude/skills/`, `.claude/agents/` | Verify skill discovery and execution. |
 | **Documentation Writer** | Automated generation and maintenance of project docs. | `docs/**`, `README.md` | Run `check_docs_contract`. |
 | **Grill-me** | Rigorous cross-examination and verification of plans. | Issue/Task context | Confirm robust plan before execution. |
@@ -56,7 +58,28 @@ Pick the skill that matches your task. Execute its steps in order. Apply the lis
 1. Keep workflow steps idempotent.
 2. Add duplicate-prevention guards for scheduled issue creation.
 3. Ensure minimum required permission scopes.
-4. Trigger and verify a run when practical.
+4. Trigger and verify a run when practical. To exercise an edited version of an
+   already-registered workflow without merging, dispatch it on the branch:
+   `gh workflow run "<name>" --ref <branch>` (a `workflow_dispatch` workflow that
+   exists *only* on a feature branch is NOT triggerable until it lands on the
+   default branch).
+5. **Bot-PR detection must have ONE definition.** The "is this a Jules/automation
+   PR" heuristic (title/body/label/branch-regex) is duplicated across
+   `jules-auto-merge`, `pr-hygiene`, and the three throttle lanes
+   (`process-jules-backlog`, `daily-jules-knowledge`, `daily-jules-maintenance`,
+   `jules-sprint-workers`). If you change one, change ALL of them — drift means
+   PRs get throttle-counted but never auto-merged (a silent pileup). Current token
+   set includes `jules|...|ralph-loop|freshness-audit|audit-batch|batch-`.
+6. **Throttles must ignore CONFLICTING PRs.** Counting an un-mergeable orphan
+   stalls the lane forever. Count only live PRs (fetch `mergeable` per-PR; skip
+   `CONFLICTING`). `pr-hygiene.yml` closes the orphans in parallel.
+7. **Bash gotchas that bit us:** never put backticks in a double-quoted `--body`
+   string (command substitution → step fails under `set -euo pipefail`; single-quote
+   it). A `while read` loop after a pipe runs in a subshell, so counters don't
+   survive — use process substitution `done < <(...)`.
+8. PRs opened by the default `GITHUB_TOKEN` do NOT trigger `on: pull_request`
+   checks. For `peter-evans/create-pull-request`, pass
+   `token: ${{ secrets.AUTOMATION_PAT || secrets.GITHUB_TOKEN }}`.
 
 ### 5) Issue-to-PR Resolver
 
@@ -90,7 +113,43 @@ Pick the skill that matches your task. Execute its steps in order. Apply the lis
 3. Implement changes surgically, matching the surrounding style exactly.
 4. Verify no regressions using existing test suites.
 
-### 10) Automation Health Triage
+### 10) Unattended Pipeline Triage
+
+Use when the issue/PR board has piled up or the Jules pipeline looks stalled.
+
+1. **Diagnose, don't bulk-act.** List open PRs with `mergeable` state. The classic
+   failure is parallel batch branches editing overlapping docs → only one merges,
+   the rest become permanently `CONFLICTING` orphans. Before closing, confirm the
+   target file already got an equivalent change on `main` (same-day sibling branch).
+2. Close superseded orphans with an explanatory comment. Do NOT `--delete-branch`
+   without explicit owner authorization (it's destructive); `pr-hygiene.yml` handles
+   branch deletion going forward.
+3. Fix the *cause*, not just the symptom: ensure `pr-hygiene` runs, all throttles are
+   conflict-aware, and the bot-PR regex is consistent (see Workflow Maintainer #5–6).
+4. The repo is PUBLIC → Actions minutes are free; the real free-tier ceiling is the
+   **Jules daily task quota**. The pipeline is sequential & self-throttling (a lane
+   creates work only when no live PR and no same-type issue is open; a merge triggers
+   the next issue). Preserve that pacing — don't add unthrottled issue-creating lanes.
+5. Stale singleton control issues (`Daily Maintenance Run -`, etc.) expire by age via
+   `cleanup-automation-issues.yml`; don't close them by hand unless clearly abandoned.
+
+### 11) Coverage Self-Evolution
+
+Use to make the bots EXPAND coverage toward the industry frontier, not just re-audit.
+
+1. `data/frontier_watchlist.json` is the offline, in-repo "where the industry is going"
+   signal. Add entries (with `aliases` to avoid false gaps) as the landscape shifts.
+2. `scripts/coverage_gap_scan.py` diffs the watchlist against `data/all_tools.json` and
+   reports frontier gaps + dangling `Related tools` links + thin categories;
+   `--create-issue` opens ONE throttled gap-fill issue. Runs weekly via
+   `coverage-gap-scan.yml`. An entry stops being flagged once it's catalogued.
+3. For broken internal links, run `scripts/fix_internal_links.py` (dry-run first; it
+   only rewrites unambiguous unique-basename matches). `lychee` runs `fail: false`, so
+   internal link rot is otherwise silent.
+4. Route large content work (playbooks, missing hub pages) through `jules`-labelled
+   issues / the watchlist rather than hand-authoring — that's what the pipeline is for.
+
+### 12) Automation Health Triage
 
 The watchdog (`automation-health.yml`, daily 05:40 UTC) scans every scheduled
 lane, auto-reruns a failed run's failed jobs once, and maintains ONE


### PR DESCRIPTION
Documents the reusable patterns learned this session so future agents inherit them:

- **Workflow Maintainer** playbook hardened: one-source bot-PR detection, conflict-aware throttles, backtick/subshell bash gotchas, branch-ref `gh workflow run`, and the `AUTOMATION_PAT` requirement for create-pull-request.
- New **Unattended Pipeline Triage** playbook: diagnose conflicting-orphan pileups, fix the cause not the symptom, preserve Jules free-tier pacing.
- New **Coverage Self-Evolution** playbook: frontier watchlist → coverage_gap_scan → gap-fill issues; fix_internal_links for link rot.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)