### PR TITLE
Decompose 5 oldest issues into Batch 160 task report

### DIFF
--- a/docs/reports/task-decomposition-batch-160.md
+++ b/docs/reports/task-decomposition-batch-160.md
@@ -1,0 +1,53 @@
+# Task Decomposition - Batch 160
+
+This report decomposes the next five oldest issues identified in the repository into granular sub-tasks for technical freshness audits.
+
+## Batch Overview
+- **Status**: In Progress
+- **Date**: 2026-06-30
+- **Auditor**: Jules
+
+## Decomposed Issues
+
+### 1. Freshness Audit: Claude Code Router (`docs/tools/development_ops/claude-code-router.md`)
+**Context**: Proxy and routing layer for Claude Code CLI.
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Research and incorporate June 2026 updates (Claude 4.8, GPT-5.5, MCP 3.0).
+- [ ] Ensure 7+ unique relative markdown links (specifically fix MCP link).
+- [ ] Update `Last reviewed` to 2026-06-30.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 2. Freshness Audit: Firebase Studio (`docs/tools/development_ops/firebase-studio.md`)
+**Context**: AI-assisted development environment for Firebase.
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Research and incorporate June 2026 context (Claude 4.8, GPT-5.5, MCP 3.0).
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-06-30.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 3. Freshness Audit: Symbolic MCP (`docs/tools/development_ops/symbolic-mcp.md`)
+**Context**: Symbolic execution engine for MCP.
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Research and incorporate June 2026 context (MCP 3.0 Task Protocol, Z3 updates).
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-06-30.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 4. Freshness Audit: GitHub Copilot CLI (`docs/tools/development_ops/github-copilot-cli.md`)
+**Context**: Terminal interface for GitHub Copilot.
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Research and incorporate June 2026 context (GPT-5.5, Claude 4.8 support).
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-06-30.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 5. Freshness Audit: Claude Cookbooks (`docs/tools/development_ops/claude-cookbooks.md`)
+**Context**: Anthropic's reference repository for Claude integration.
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Research and incorporate June 2026 context (Claude 4.8, MCP 3.0).
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-06-30.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+## Next Steps
+Address the decomposed tasks sequentially to maintain repository freshness and compliance.


### PR DESCRIPTION
I have decomposed the five oldest issues in the repository into a new task report: `docs/reports/task-decomposition-batch-160.md`. This follows the repository's 'Sequential Issue Processing Rule' by breaking down larger maintenance tasks into granular, focused sub-tasks. Each issue will now be addressed sequentially according to the new report. 

As per the project's 'Action C: Decomposition' policy, this step effectively closes the initial meta-issues while ensuring that the actual work is tracked with more context and detail. 

Mandatory June 2026 technical context and 'High Confidence' documentation standards have been incorporated into the sub-task definitions.

---
*PR created automatically by Jules for task [16752439982786184109](https://jules.google.com/task/16752439982786184109) started by @joanmarcriera*