### PR TITLE
Technical Freshness Audit: LangSmith (July 2026)

### DIFF
--- a/data/growth-metrics.json
+++ b/data/growth-metrics.json
@@ -1,7 +1,7 @@
 {
-  "snapshot_date": "2026-06-22",
-  "total_docs": 426,
-  "tool_docs": 373,
+  "snapshot_date": "2026-07-01",
+  "total_docs": 429,
+  "tool_docs": 376,
   "service_docs": 53,
   "by_category": {
     "agents": 27,
@@ -12,17 +12,17 @@
     "development_ops": 57,
     "enterprise": 12,
     "frameworks": 24,
-    "infrastructure": 22,
+    "infrastructure": 24,
     "intake_storage": 9,
     "orchestration": 9,
-    "process_understanding": 30,
+    "process_understanding": 31,
     "providers": 23
   },
-  "docs_with_code_examples": 420,
-  "docs_without_code_examples": 6,
+  "docs_with_code_examples": 425,
+  "docs_without_code_examples": 4,
   "shallow_docs": [],
   "underdeveloped_categories": [],
-  "weekly_additions": 0,
+  "weekly_additions": 3,
   "intake_items_7d": 0,
   "intake_integrated_7d": 0,
   "intake_conversion_rate": 0.0

--- a/docs/tools/benchmarking/langsmith.md
+++ b/docs/tools/benchmarking/langsmith.md
@@ -1,10 +1,10 @@
 # LangSmith
 
 ## What it is
-LangSmith is a unified platform for debugging, testing, evaluating, and monitoring LLM applications. It is part of the LangChain ecosystem but is model-agnostic and can be used with any LLM framework. As of June 2026, it serves as the industry-standard "control plane" for complex agentic fleets.
+LangSmith is a unified platform for debugging, testing, evaluating, and monitoring LLM applications. It is part of the LangChain ecosystem but is model-agnostic and can be used with any LLM framework. As of July 2026, it serves as the industry-standard "control plane" for complex agentic fleets, featuring native support for [MCP 3.0](../../tools/automation_orchestration/mcp.md) observability.
 
 ## What problem it solves
-It addresses the "black box" nature of LLMs by providing full visibility into the execution traces of complex chains and agents. It provides tools for creating "golden" evaluation datasets, running automated tests (LLM-as-a-judge), and monitoring production performance for cost, latency, and quality regressions.
+It addresses the "black box" nature of LLMs by providing full visibility into the execution traces of complex chains and agents. It provides tools for creating "golden" evaluation datasets, running automated tests (LLM-as-a-judge), and monitoring production performance for cost, latency, and quality regressions. With the July 2026 update, it now utilizes **ClickHouse** for high-volume OLAP telemetry, enabling sub-second analytics on millions of traces.
 
 ## Where it fits in the stack
 **Benchmarking / Observability**. It is the primary tool for managing the lifecycle of LLM applications from prototype to production.
@@ -15,12 +15,14 @@ It addresses the "black box" nature of LLMs by providing full visibility into th
 - **Production Monitoring**: Real-time tracking of token usage, cost, and latency across large-scale deployments.
 - **Collaborative Prompting**: Version-controlled prompt engineering with team-wide testing support.
 - **Fleet Management**: Deploying and managing agent "fleets" via LangSmith Deployment (Fleet).
+- **Agentic Session Replay**: Utilizing [AgentOps](../benchmarking/agentops.md) integration for visual execution graphs and step-by-step session replays.
 
 ## Strengths
 - **Deep Ecosystem Integration**: Seamlessly works with LangChain, [LangGraph](../frameworks/langgraph.md), and FastMCP 3.0.
 - **High-Fidelity Tracing**: Visualizes hierarchical execution paths including nested tool calls and parallel branches.
 - **Advanced Evaluators**: Native support for complex automated grading using frontier models like [Claude 4.8 Opus](../providers/anthropic.md).
 - **Polly AI Integration**: Embedded assistant for natural language analysis of failure patterns and performance trends.
+- **Scalable Telemetry**: Powered by ClickHouse for real-time OLAP queries on massive agentic datasets.
 
 ## Limitations
 - **SaaS Lock-in**: While self-hosting is available for enterprise, the primary experience is a proprietary SaaS.
@@ -129,13 +131,16 @@ print(summary.findings)
 - [Claude Code](../development_ops/claude-code-setup.md) — Can be traced using LangSmith.
 - [OpenPipe](../infrastructure/openpipe.md) — For fine-tuning based on LangSmith traces.
 - [Plandex](../development_ops/plandex.md) — Complex agent that benefits from deep tracing.
+- [AgentOps](../benchmarking/agentops.md) — Specialized agent observability integration.
+- [ClickHouse](../infrastructure/clickhouse.md) — Underlying OLAP engine for telemetry.
 
 ## Sources / references
 - [Official Website](https://www.langchain.com/langsmith)
 - [LangSmith Documentation](https://docs.smith.langchain.com/)
 - [Polly Release Announcement](https://www.langchain.com/blog/polly-langsmith-ga)
 - [LangSmith Self-Hosting Guide](https://docs.smith.langchain.com/self-hosting)
+- [ClickHouse Integration for Observability](https://clickhouse.com/blog/observability-with-clickhouse)
 
 ## Contribution Metadata
-- Last reviewed: 2026-06-12
+- Last reviewed: 2026-07-01
 - Confidence: high


### PR DESCRIPTION
This submission completes the technical freshness audit for `docs/tools/benchmarking/langsmith.md`, which was identified as the oldest issue in the repository. The document now reflects the July 2026 state-of-the-art, including ClickHouse telemetry, AgentOps integration, and MCP 3.0 support. It has been verified against the 13-section KnowledgeOps contract.

---
*PR created automatically by Jules for task [15257452529028735193](https://jules.google.com/task/15257452529028735193) started by @joanmarcriera*