### PR TITLE
Ralph-loop Batch 169: Decompose 5 issues and audit makefile-mcp.md

### DIFF
--- a/docs/reports/task-decomposition-batch-169.md
+++ b/docs/reports/task-decomposition-batch-169.md
@@ -1,0 +1,54 @@
+# Task Decomposition - Batch 169
+
+This report decomposes the next five oldest issues identified in the repository into granular sub-tasks for technical freshness audits.
+
+## Batch Overview
+- **Status**: In Progress
+- **Date**: 2026-07-02
+- **Auditor**: Jules
+
+## Decomposed Issues
+
+### 1. Freshness Audit: Makefile MCP (`docs/tools/automation_orchestration/makefile-mcp.md`)
+**Context**: MCP server that auto-discovers Makefile targets.
+- [x] Research and incorporate July 2026 context (Gemma 3, MCP 3.0, GPT-5.5).
+- [x] Upgrade to the exact 13-section 'High Confidence' standard.
+- [x] Ensure 7+ unique relative markdown links.
+- [x] Update `Last reviewed` to 2026-07-02.
+- [x] Verify with `scripts/check_docs_contract.py`.
+
+### 2. Freshness Audit: Vikunja MCP (`docs/tools/automation_orchestration/vikunja-mcp.md`)
+**Context**: MCP server for interacting with Vikunja task management.
+- [ ] Research and incorporate July 2026 context (Gemma 3, MCP 3.0, Vikunja API v1).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-07-02.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 3. Freshness Audit: Playwright MCP (`docs/tools/automation_orchestration/playwright-mcp.md`)
+**Context**: MCP implementation providing a headless browser interface.
+- [ ] Research and incorporate July 2026 context (Gemma 3, MCP 3.0, Playwright v1.50+).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-07-02.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 4. Freshness Audit: Picnic (`docs/tools/automation_orchestration/picnic.md`)
+**Context**: Project-centered GUI built on OpenClaw for AI workflows.
+- [ ] Research and incorporate July 2026 context (Gemma 3, MCP 3.0, OpenClaw updates).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-07-02.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 5. Freshness Audit: Google Workspace CLI (`docs/tools/automation_orchestration/google-workspace-cli.md`)
+**Context**: Dynamic CLI for Google Workspace services.
+- [ ] Research and incorporate July 2026 context (Gemma 3, MCP 3.0, Google Discovery API updates).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links.
+- [ ] Update `Last reviewed` to 2026-07-02.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+## Next Steps
+1. Complete the technical freshness audit for `docs/tools/automation_orchestration/makefile-mcp.md`.
+2. Proceed with the remaining audits in this batch sequentially.

--- a/docs/tools/automation_orchestration/makefile-mcp.md
+++ b/docs/tools/automation_orchestration/makefile-mcp.md
@@ -1,29 +1,30 @@
 # Makefile MCP
 
 ## What it is
-An MCP server that auto-discovers Makefile targets and exposes them as individual, documented tools for AI assistants like Claude 4.8 Opus and GPT-5.5.
+An MCP server that auto-discovers Makefile targets and exposes them as individual, documented tools for AI assistants like Claude 4.8 Opus, GPT-5.5, and Gemma 3. It leverages the [Model Context Protocol](../../tools/automation_orchestration/mcp.md) 3.0 to provide granular tool registration.
 
 ## What problem it solves
-Traditional Makefile MCP implementations often expose a single generic `make` tool, which prevents LLMs from "seeing" available targets in their tool list. `makefile-mcp` parses the Makefile to register each documented target as its own tool with descriptions, improving discoverability and ease of use in agentic workflows.
+Traditional Makefile MCP implementations often expose a single generic `make` tool, which prevents LLMs from "seeing" available targets in their tool list. `makefile-mcp` parses the Makefile to register each documented target as its own tool with descriptions, improving discoverability and ease of use in [agentic workflows](../../knowledge_base/patterns/agentic-workflows.md).
 
 ## Where it fits in the stack
-**Tool / Automation**. It provides a discovery and execution layer for project-specific automation, bridging the gap between local build systems and frontier models.
+**Tool / Automation**. It provides a discovery and execution layer for project-specific automation, bridging the gap between local build systems and frontier models. It is a key component for [development ops](../development_ops/index.md) when using AI agents.
 
 ## Typical use cases
-- Exposing build, test, lint, and deploy workflows to coding agents.
+- Exposing build, test, lint, and deploy workflows to coding agents like [Aider](../development_ops/aider.md).
 - Managing multi-project workflows by dynamically switching working directories.
 - Documenting available automation targets for AI assistants in complex monorepos.
+- Integrating with [Claude Code](../development_ops/claude-code.md) for terminal-based automation.
 
 ## Strengths
 - **Target Discovery**: Automatically parses `##` comments to provide tool descriptions.
 - **Dynamic Configuration**: Allows changing the working directory at runtime via a dedicated tool.
 - **Security**: No shell expansion used; supports strict inclusion/exclusion of targets.
-- **Built with FastMCP**: High compatibility and performance for Claude 4.8 and GPT-5.5 environments.
+- **Built with FastMCP**: High compatibility and performance for [MCP 3.0](../../tools/automation_orchestration/mcp.md) environments.
 
 ## Limitations
 - Requires targets to be documented with `##` to be exposed as tools.
 - Commands run in a specified working directory only.
-- Limited to GNU Make compatible Makefiles.
+- Limited to [GNU Make](gnu-make.md) compatible Makefiles.
 
 ## When to use it
 - When you want your AI assistant to have direct, visible access to your project's `make` targets.
@@ -78,7 +79,7 @@ makefile-mcp --prefix "myproj_"
 ```
 
 ## API examples
-AI agents can interact with the server's configuration tool:
+AI agents can interact with the server's configuration tool using [MCP 3.0](../../tools/automation_orchestration/mcp.md) JSON-RPC:
 ```json
 // Change the working directory at runtime
 set_working_directory({
@@ -88,19 +89,20 @@ set_working_directory({
 
 ## Related tools / concepts
 - [GNU Make](gnu-make.md)
-- [Model Context Protocol](../../knowledge_base/agent_protocols.md)
+- [Model Context Protocol](../../tools/automation_orchestration/mcp.md)
 - [Aider](../development_ops/aider.md)
 - [Plandex](../development_ops/plandex.md)
 - [Zapier](zapier.md)
-- [FastMCP](https://github.com/jlowin/fastmcp)
 - [MCP Registry](mcp-registry.md)
 - [Claude Code](../development_ops/claude-code.md)
+- [Agentic Workflows](../../knowledge_base/patterns/agentic-workflows.md)
 
 ## Sources / References
 - [Makefile MCP GitHub](https://github.com/democratize-technology/makefile-mcp)
 - [FastMCP Documentation](https://github.com/jlowin/fastmcp)
+- [MCP 3.0 Specification](https://modelcontextprotocol.io)
 
 ## Contribution Metadata
 
-- Last reviewed: 2026-06-12
+- Last reviewed: 2026-07-02
 - Confidence: high


### PR DESCRIPTION
Initiated Ralph-loop Batch 169 by decomposing the 5 oldest issues into granular tasks in `docs/reports/task-decomposition-batch-169.md`. Completed the technical freshness audit for `docs/tools/automation_orchestration/makefile-mcp.md`, upgrading it to the 13-section 'High Confidence' standard with July 2026 context (Gemma 3, MCP 3.0). Verified compliance using validation scripts.

---
*PR created automatically by Jules for task [13581082752996196935](https://jules.google.com/task/13581082752996196935) started by @joanmarcriera*