### PR TITLE
Ralph-loop Batch 172: Decomposition and Phidata Freshness Audit

### DIFF
--- a/docs/reports/task-decomposition-batch-172.md
+++ b/docs/reports/task-decomposition-batch-172.md
@@ -1,0 +1,56 @@
+# Task Decomposition - Batch 172
+
+This report decomposes the next five oldest issues identified in the repository into granular sub-tasks for technical freshness audits.
+
+## Batch Overview
+- **Status**: In Progress
+- **Date**: 2026-07-21
+- **Auditor**: Jules
+
+## Decomposed Issues
+
+### 1. Freshness Audit: Phidata (`docs/tools/agents/phidata.md`)
+**Context**: Python-native framework for building AI assistants with memory, knowledge, and tools.
+- [x] Research and incorporate July 2026 context (Gemma 3 comparison, MCP 3.0 integrations, FastMCP).
+- [x] Upgrade to the exact 13-section 'High Confidence' standard.
+- [x] Ensure 7+ unique relative markdown links to canonical internal pages.
+- [x] Update `Last reviewed` to 2026-07-21.
+- [x] Verify with `scripts/check_docs_contract.py`.
+
+### 2. Freshness Audit: NVIDIA NeMo Claw (`docs/tools/agents/nemoclaw.md`)
+**Context**: NVIDIA's framework for building agentic workflows on the NeMo platform.
+- [ ] Research and incorporate July 2026 context (NVIDIA Rubin architecture support, NIM GA integration).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links to canonical internal pages.
+- [ ] Update `Last reviewed` to 2026-07-21.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 3. Freshness Audit: Agentic Automation Canvas (`docs/tools/agents/agentic-automation-canvas.md`)
+**Context**: Visual framework for designing agentic workflows and automation.
+- [ ] Research and incorporate July 2026 context (MCP 3.0 visual design patterns).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links to canonical internal pages.
+- [ ] Update `Last reviewed` to 2026-07-21.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 4. Freshness Audit: Agno (`docs/tools/agents/agno.md`)
+**Context**: The evolved ecosystem for Phidata v2+.
+- [ ] Research and incorporate July 2026 context (FastMCP 3.0, Gemma 3 support).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links to canonical internal pages.
+- [ ] Update `Last reviewed` to 2026-07-21.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+### 5. Freshness Audit: Symphony (`docs/tools/agents/symphony.md`)
+**Context**: Multi-agent orchestration framework.
+- [ ] Research and incorporate July 2026 context (MCP 3.0 Task Protocol for multi-agent coordination).
+- [ ] Upgrade to the exact 13-section 'High Confidence' standard.
+- [ ] Ensure 7+ unique relative markdown links to canonical internal pages.
+- [ ] Update `Last reviewed` to 2026-07-21.
+- [ ] Verify with `scripts/check_docs_contract.py`.
+
+---
+- **Status**: In Progress
+- **Next Step**: Conduct technical freshness audit for `nemoclaw.md`.
+- **Date**: 2026-07-21
+- **Auditor**: Jules

--- a/docs/tools/agents/phidata.md
+++ b/docs/tools/agents/phidata.md
@@ -1,39 +1,41 @@
 # Phidata
 
 ## What it is
-Phidata is a Python-native framework for building AI assistants with memory, knowledge, and tools. It allows developers to transform standard LLMs into functional agents capable of storing session data in databases, performing RAG across local and remote files, and executing Python functions as tools. As of June 2026, it is widely used for creating stateful, knowledge-enabled agents that integrate with enterprise data stacks.
+Phidata is a Python-native framework for building AI assistants with memory, knowledge, and tools. As of July 2026, Phidata (and its evolved ecosystem, [Agno](agno.md)) serves as a primary bridge for transforming standard LLMs into functional, stateful agents. It enables developers to store session data in relational databases, perform Retrieval-Augmented Generation (RAG) across diverse data sources, and execute complex toolsets via the [Model Context Protocol (MCP)](../automation_orchestration/mcp.md).
 
 ## What problem it solves
-It solves the complexity of building production-grade agents by providing standardized abstractions for session management, vector database integration, and tool-calling. Phidata bridges the gap between raw LLM outputs and actionable software by managing the lifecycle of an agent's memory and ensuring that retrieval-augmented generation (RAG) is both performant and accurate.
+Phidata addresses the "statelessness" of raw LLMs by providing standardized abstractions for session management and long-term memory. It simplifies the integration of [Vector Databases](../infrastructure/pinecone.md) and traditional storage like PostgreSQL, ensuring that retrieval-augmented generation is performant. By supporting native tool-calling and the MCP 3.0 Task Protocol, it reduces the boilerplate required to connect AI agents to enterprise software stacks.
 
 ## Where it fits in the stack
-**Framework / Agent / Knowledge**. It sits as a development layer that orchestrates LLMs (OpenAI, Anthropic, etc.) with storage backends (PostgreSQL, Pinecone) and tool execution environments.
+**Agent Orchestration Framework**. It sits between the model layer (e.g., [OpenAI](../ai_knowledge/openai.md), [Anthropic](../providers/anthropic.md)) and the infrastructure layer, coordinating how agents retrieve data, use tools, and persist state.
 
 ## Typical use cases
-- **Knowledge-Based Assistants**: Building agents that can answer questions based on a massive internal library of PDFs, CSVs, or SQL databases.
-- **Stateful Chatbots**: Creating customer support agents that remember user preferences and past interactions across multiple sessions.
-- **Autonomous Researchers**: Agents that can search the web (via DuckDuckGo or Tavily), summarize findings, and write reports into a local filesystem.
-- **Enterprise Tool-Callers**: Integrating AI into existing Python business logic to automate workflows like invoice processing or system monitoring.
+- **Enterprise Knowledge Assistants**: Building agents that query internal documentation stored in PDF, CSV, or SQL formats.
+- **Autonomous Research Agents**: Utilizing tools like [Tavily](../providers/tavily.md) to browse the web, summarize findings, and generate reports.
+- **Stateful Support Chatbots**: Maintaining user context across multiple sessions using persistent SQL-backed storage.
+- **Developer Tooling Agents**: Automating software workflows by integrating with [GitHub](../development_ops/github-pages.md) and local development environments.
 
 ## Strengths
-- **Pythonic Design**: Extremely intuitive for Python developers, with minimal boilerplate required to start a new agent.
-- **Persistent Memory**: Out-of-the-box support for database-backed memory (SQLite, PostgreSQL, MongoDB).
-- **Flexible RAG**: Built-in connectors for various vector databases and file formats.
-- **Model Agnostic**: Supports a wide range of models, including Claude 4.8 Opus and GPT-5.5.
-- **Local Development**: Optimized for running and testing agents locally before cloud deployment.
+- **Pythonic Design**: Offers a clean, object-oriented API that feels natural to Python developers.
+- **Native MCP 3.0 Support**: Seamlessly integrates with MCP servers using FastMCP for rapid tool discovery and execution.
+- **Optimized for Gemma 3**: Includes specialized prompts and handling for [Gemma 3](../ai_knowledge/local_llms.md) to maximize reasoning capabilities in open-weights environments.
+- **Robust Observability**: Standard integration with [AgentOps](../process_understanding/agentops.md) for execution graphs and [ClickHouse](../process_understanding/clickhouse.md) for high-volume session telemetry.
+- **Persistence Flexibility**: Out-of-the-box support for PostgreSQL, SQLite, and MongoDB.
 
 ## Limitations
-- **Orchestration Complexity**: While great for single agents, very complex multi-agent graphs may require additional logic compared to specialized graph frameworks.
-- **Ecosystem Size**: Smaller community compared to legacy frameworks like LangChain, though it is rapidly growing in the agent-centric era.
+- **Ecosystem Transition**: Users must navigate the rebranding and feature migration from Phidata v1 to the Agno ecosystem.
+- **Orchestration Overhead**: For extremely simple, one-off scripts, the framework's abstractions may introduce unnecessary complexity.
+- **Multi-Agent Scaling**: While capable, managing massive swarms of 50+ agents may require more manual tuning compared to specialized multi-agent kernels.
 
 ## When to use it
-- When you want to build a single, highly-capable agent with RAG and long-term memory quickly.
-- If you prefer a Python-native framework with a clean, object-oriented API.
-- For projects where persistent session storage in a standard SQL/NoSQL database is a requirement.
+- When building production-ready agents that require persistent, database-backed memory.
+- If you are leveraging the [Model Context Protocol (MCP)](../automation_orchestration/mcp.md) to connect agents to external tools.
+- When working in a Python-centric environment and seeking a framework with minimal boilerplate for RAG.
 
 ## When not to use it
-- For extremely complex multi-agent "swarms" that require low-level control over message passing (consider specialized multi-agent frameworks).
-- If your primary focus is on a lightweight, no-config setup for a single-user agent.
+- For projects requiring non-Python implementations (e.g., pure TypeScript or Rust environments).
+- If your agent requires low-level, custom message-passing protocols that bypass standard orchestration abstractions.
+- When building extremely lightweight "hello world" scripts where raw API calls to [OpenAI](../ai_knowledge/openai.md) suffice.
 
 ## Getting started
 ### Installation
@@ -41,72 +43,73 @@ It solves the complexity of building production-grade agents by providing standa
 pip install phidata openai duckduckgo-search
 ```
 
-### Basic Usage
-Initialize an agent with tools and a model (e.g., GPT-5.5):
+### Hello-World Example
+Initialize a basic research agent using GPT-5.5:
 
 ```python
 from phi.agent import Agent
 from phi.model.openai import OpenAIChat
 from phi.tools.duckduckgo import DuckDuckGo
 
-# 1. Create the assistant with a tool
+# Create the assistant
 agent = Agent(
     model=OpenAIChat(id="gpt-5.5-preview"),
     tools=[DuckDuckGo()],
-    description="You are a research assistant that can search the web.",
+    description="You are a research assistant.",
     show_tool_calls=True,
     markdown=True,
 )
 
-# 2. Run a query
-agent.print_response("What are the latest breakthroughs in fusion energy as of June 2026?", stream=True)
+# Run a query
+agent.print_response("Summarize the impact of MCP 3.0 on AI agent interoperability.", stream=True)
 ```
 
 ## CLI examples
 ```bash
-# Initialize a new phidata project structure
+# Initialize a new Phidata project structure
 phi init
 
-# Start the agent environment (e.g., if using Docker-based resources)
+# Start Phidata-managed resources (e.g., PostgreSQL for memory)
 phi start
 
-# Stop all phidata-managed resources
-phi stop
-
-# Check the status of your running agents and storage
+# Check the status of active agents and storage backends
 phi status
+
+# Stop all local Phidata services
+phi stop
 ```
 
 ## API examples
-Phidata excels at adding persistent memory to agents via SQL storage:
+Implementing an agent with persistent SQLite memory:
 
 ```python
 from phi.agent import Agent
 from phi.storage.agent.sqlite import SqlAgentStorage
 
-# Create an agent that persists its conversation history
+# Define an agent with persistent storage
 agent = Agent(
-    storage=SqlAgentStorage(table_name="support_agent", db_file="memory.db"),
+    storage=SqlAgentStorage(table_name="customer_support", db_file="agents.db"),
     add_history_to_messages=True,
-    num_history_responses=5,
+    num_history_responses=3,
 )
 
-# This information will be remembered in future runs
-agent.print_response("My user ID is 9876. Please remember this for my future queries.")
+# The agent will remember the user ID across different script executions
+agent.print_response("My user ID is 'AGENT-X'. Remember this for my next visit.")
 ```
 
 ## Related tools / concepts
-- [Agno](agno.md) (The evolved ecosystem for Phidata v2+)
-- [LlamaIndex](../ai_knowledge/llamaindex.md) (Specialized in data indexing)
-- [LangChain](../ai_knowledge/langchain.md)
-- [CrewAI](../frameworks/crewai.md)
-- [Model Context Protocol (MCP)](../automation_orchestration/mcp.md)
+- [Agno](agno.md) (The v2 evolution of Phidata)
+- [LlamaIndex](../ai_knowledge/llamaindex.md) (Specialized in advanced data indexing for RAG)
+- [LangChain](../ai_knowledge/langchain.md) (The industry-standard agent framework)
+- [CrewAI](../frameworks/crewai.md) (Multi-agent workflow orchestration)
+- [Model Context Protocol (MCP)](../automation_orchestration/mcp.md) (The standard for tool-LLM communication)
 
 ## Sources / references
 - [Official Phidata Website](https://www.phidata.com/)
 - [Phidata GitHub Repository](https://github.com/agno-agi/phidata)
-- [Phidata Documentation](https://docs.phidata.com/)
+- [Agno Documentation](https://docs.agno.com/)
+- [MCP 3.0 Specification](https://modelcontextprotocol.io/)
 
 ## Contribution Metadata
-- Last reviewed: 2026-06-15
+- Last reviewed: 2026-07-21
 - Confidence: high


### PR DESCRIPTION
I have initiated Ralph-loop Batch 172 by decomposing the five oldest issues into granular tasks and completing the technical freshness audit for Phidata.

Key changes:
- **Task Decomposition**: Created `docs/reports/task-decomposition-batch-172.md` for `phidata.md`, `nemoclaw.md`, `agentic-automation-canvas.md`, `agno.md`, and `symphony.md`.
- **Phidata Audit**: Rewrote `docs/tools/agents/phidata.md` to strictly follow the 13-section 'High Confidence' standard.
- **July 2026 Context**: Added support and comparisons for MCP 3.0, FastMCP tool discovery, Gemma 3 optimization, and enterprise observability via AgentOps and ClickHouse.
- **Verification**: Confirmed 13 unique relative markdown links and passed `scripts/check_docs_contract.py`.

The next step in the batch is the audit for `nemoclaw.md`.

---
*PR created automatically by Jules for task [11969993965801736573](https://jules.google.com/task/11969993965801736573) started by @joanmarcriera*