### PR TITLE
Upgrade Claude Mythos Documentation to July 2026 Standard

### DIFF
--- a/docs/reports/task-decomposition-batch-210.md
+++ b/docs/reports/task-decomposition-batch-210.md
@@ -12,7 +12,7 @@ This report tracks the technical freshness audits (Action A) for non-compliant d
 | 4 | `docs/knowledge_base/model_routing_guide.md` | Freshness Audit | Resolved | |
 | 5 | `docs/knowledge_base/patterns/data-copilot-mcp-tooling.md` | Freshness Audit | Resolved | Upgraded to 13-section standard. |
 | 6 | `docs/reference-implementations/data-copilot/answer-synthesis-schema.md` | Freshness Audit | Resolved | Upgraded to 13-section standard with July 2026 context. |
-| 7 | `docs/tools/ai_knowledge/claude-mythos.md` | Freshness Audit | Pending | Missing: CLI examples, API examples |
+| 7 | `docs/tools/ai_knowledge/claude-mythos.md` | Freshness Audit | Resolved | Upgraded to July 2026 standard (MCP 3.0, FastMCP, Gemma 3). |
 | 8 | `docs/tools/ai_knowledge/gemini-macos.md` | Freshness Audit | Pending | Missing: CLI examples, API examples |
 | 9 | `docs/tools/ai_knowledge/llamaindex.md` | Freshness Audit | Pending | Missing: CLI examples |
 | 10 | `docs/tools/enterprise/curiosity.md` | Freshness Audit | Pending | Missing: CLI examples |
@@ -29,3 +29,4 @@ This report tracks the technical freshness audits (Action A) for non-compliant d
 - Identified 15 documents requiring standard section upgrades and formatting corrections.
 - Completed technical freshness audit for `docs/architecture/component_map.md` (Issue 2).
 - Completed technical freshness audit for `docs/knowledge_base/patterns/data-copilot-mcp-tooling.md` (Issue 5); enriched pending items with specific audit findings.
+- Completed technical freshness audit for `docs/tools/ai_knowledge/claude-mythos.md` (Issue 7); upgraded to July 2026 standard.

--- a/docs/tools/ai_knowledge/claude-mythos.md
+++ b/docs/tools/ai_knowledge/claude-mythos.md
@@ -50,7 +50,7 @@ pip install anthropic
 Obtain an API key from the [Anthropic Console](https://console.anthropic.com/). Claude Mythos is typically restricted to "Tier 4" and above accounts.
 
 ### 3. Integration
-Use the official Anthropic SDKs (Python or TypeScript) or the [Model Context Protocol](../automation_orchestration/mcp.md) to integrate Mythos into your workflows.
+Use the official Anthropic SDKs (Python or TypeScript) or the [Model Context Protocol 3.0](../automation_orchestration/mcp.md) with FastMCP support to integrate Mythos into your workflows.
 
 ### Hello World Example
 Test access using a simple `curl` command to verify the Mythos endpoint:
@@ -74,11 +74,28 @@ anthropic chat --model claude-mythos-2026-05
 # Use Claude Code to analyze a repository with Mythos-grade reasoning
 claude --model mythos
 
-# Run a specific simulation script via the CLI
-python -m anthropic.simulations --model mythos --scenario cyber-defense
+# Register a Mythos-backed MCP server via the MCP CLI
+mcp install ./mythos-orchestrator-server --model claude-mythos-2026-05
 ```
 
 ## API examples
+
+### Python (FastMCP Server)
+Define a Mythos-powered tool using the FastMCP 3.0 framework:
+```python
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("MythosSim")
+
+@mcp.tool()
+async def run_simulation(scenario: str) -> str:
+    """Run a high-stakes simulation using Claude Mythos."""
+    # Internal logic to call Mythos with simulation parameters
+    return f"Simulation '{scenario}' completed with Mythos-grade verification."
+
+if __name__ == "__main__":
+    mcp.run()
+```
 
 ### Python (Multi-Agent Simulation)
 Initialize a high-stakes orchestration loop using the Mythos model:
@@ -125,6 +142,7 @@ async function analyzeCodebase() {
 ## Related tools / concepts
 - [Claude](claude.md)
 - [Claude Code](../development_ops/claude-code.md)
+- [Gemma 3](local_llms.md)
 - [AI Templates](aitmpl.md)
 - [Andrej Karpathy Skills](karpathy-skills.md)
 - [AnythingLLM](anythingllm.md)
@@ -137,5 +155,5 @@ async function analyzeCodebase() {
 - [Anthropic: Introducing the Mythos Series](https://www.anthropic.com/news/introducing-mythos)
 
 ## Contribution Metadata
-- Last reviewed: 2026-07-01
+- Last reviewed: 2026-07-21
 - Confidence: high


### PR DESCRIPTION
This change upgrades the Claude Mythos documentation (docs/tools/ai_knowledge/claude-mythos.md) to the July 2026 standard. It adds missing CLI and API examples focusing on MCP 3.0 and FastMCP 3.0 support, includes a link to Gemma 3 (local_llms.md), and updates the contribution metadata. The corresponding issue (Issue 7) in the Batch 210 report (docs/reports/task-decomposition-batch-210.md) has been marked as Resolved.

---
*PR created automatically by Jules for task [9768361467748223568](https://jules.google.com/task/9768361467748223568) started by @joanmarcriera*