### PR TITLE
feat(digest): add 10 verified information sources

### DIFF
--- a/ai-daily-digest/sources.yaml
+++ b/ai-daily-digest/sources.yaml
@@ -84,3 +84,56 @@
   type: reddit
   url: https://www.reddit.com/r/LLMDevs/.rss
   tags: [llm, tools, development]
+
+# --- Expansion 2026-07: research analysis, self-hosting, core stack ---
+# Every feed below was verified to return valid RSS/Atom before being added.
+
+- name: Google DeepMind Blog
+  type: rss
+  url: https://deepmind.google/blog/rss.xml
+  tags: [llm, research, industry]
+
+- name: Import AI (Jack Clark)
+  type: rss
+  url: https://importai.substack.com/feed
+  tags: [research, policy, llm]
+
+- name: Interconnects (Nathan Lambert)
+  type: rss
+  url: https://www.interconnects.ai/feed
+  tags: [research, open-source, llm]
+
+- name: Ahead of AI (Sebastian Raschka)
+  type: rss
+  url: https://magazine.sebastianraschka.com/feed
+  tags: [research, llm, education]
+
+- name: Eugene Yan
+  type: rss
+  url: https://eugeneyan.com/rss/
+  tags: [llm, engineering, applied]
+
+- name: Lobsters — AI tag
+  type: rss
+  url: https://lobste.rs/t/ai.rss
+  tags: [engineering, curated, discussion]
+
+- name: InfoQ — AI, ML & Data Engineering
+  type: rss
+  url: https://feed.infoq.com/ai-ml-data-eng/
+  tags: [engineering, industry, ai]
+
+- name: Self-Host Weekly (selfh.st)
+  type: rss
+  url: https://selfh.st/rss/
+  tags: [self-hosted, infrastructure, tools]
+
+- name: n8n Blog
+  type: rss
+  url: https://blog.n8n.io/rss/
+  tags: [automation, orchestration, tools]
+
+- name: r/homeassistant
+  type: reddit
+  url: https://www.reddit.com/r/homeassistant/.rss
+  tags: [home-automation, self-hosted]


### PR DESCRIPTION
Expands `ai-daily-digest/sources.yaml` from 16 to 26 feeds.

## Added (all curl-verified to return valid RSS/Atom)
| Source | Why |
|---|---|
| Google DeepMind Blog | frontier-lab research announcements |
| Import AI (Jack Clark) | weekly research + policy digest, high signal |
| Interconnects (Nathan Lambert) | open-model / RLHF research analysis |
| Ahead of AI (Sebastian Raschka) | LLM research explainers |
| Eugene Yan | applied LLM engineering patterns |
| Lobsters — AI tag | curated engineering discussion |
| InfoQ AI/ML/Data Eng | industry engineering coverage |
| Self-Host Weekly (selfh.st) | weekly self-hosting roundup — core repo theme |
| n8n Blog | core stack tool |
| r/homeassistant | home-automation stack coverage |

## Rejected (no working feed)
Ollama blog, Meta AI, Mistral, LangChain blog, hnrss.org, vLLM blog, r/paperlessngx.

Volume impact is bounded: `digest.py` ingests only entries newer than the cutoff, truncates summaries to 800 chars, and permanently dedups processed links, so OpenRouter load grows modestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017F8ckjPiv7EZeKLfnPykFy