### PR TITLE
Enrich getting started, CLI and API examples for 5 shortest docs

### DIFF
--- a/docs/tools/ai_knowledge/aitmpl.md
+++ b/docs/tools/ai_knowledge/aitmpl.md
@@ -31,48 +31,67 @@ It gives users a faster way to discover proven prompt structures and packaged AI
 ## Getting started
 
 ### Installation
-Use the official CLI tool to browse and install components directly:
+Install the Claude Code Templates CLI globally via `npm` or run it dynamically using `npx`:
+
 ```bash
-# Run without installation
+# Run interactively without permanent installation
 npx claude-code-templates@latest
 
-# Or install globally
+# Or install globally to enable the 'cct' command
 npm install -g claude-code-templates
 ```
 
 ### Hello World Example
-Install your first agent (e.g., a frontend developer specialist) to verify the installation:
+To verify your installation and configure your first component, install the core development specialist agent interactively or via the CLI:
+
 ```bash
-cct --agent frontend-developer --yes
+# Install a specialist frontend development agent
+npx claude-code-templates@latest --agent development-team/frontend-developer --yes
 ```
 
 ## CLI examples
+The CLI tool provides deep integration for configuring and diagnosing your AI coding setup:
+
 ```bash
-# Search and install a specific agent
-cct --agent security-auditor
+# Batch install a full development stack (agent, custom commands, and git hook)
+npx claude-code-templates@latest \
+  --agent development-team/react-expert \
+  --command testing/generate-tests \
+  --hook git/pre-commit-validation \
+  --yes
 
-# Launch the real-time session analytics dashboard
-cct --analytics
+# Launch the live session analytics dashboard to track token usage and state detection
+npx claude-code-templates@latest --analytics
 
-# Verify your environment and Claude Code configuration
-cct --health-check
+# Run complete local diagnostics on your Claude Code environment
+npx claude-code-templates@latest --health-check
 ```
 
 ## API examples
-The AI Templates API supports download tracking for custom integrations:
+The AI Templates public API can be integrated into custom telemetry, IDE scripts, or CI/CD pipelines to track component downloads and verify release states:
 
 ```python
 import requests
 
+# Track component download telemetry
 url = "https://www.aitmpl.com/api/track-download-supabase"
+headers = {
+    "Content-Type": "application/json",
+    "User-Agent": "Custom-Telemetry-Client/1.0"
+}
 payload = {
-    "component_name": "frontend-developer",
+    "component_name": "development-team/frontend-developer",
     "component_type": "agent",
-    "platform": "cli"
+    "platform": "custom-ci"
 }
 
-response = requests.post(url, json=payload)
-print(response.status_code)
+try:
+    response = requests.post(url, json=payload, headers=headers, timeout=10)
+    response.raise_for_status()
+    print(f"Telemetry Status: {response.status_code}")
+    print(f"Response: {response.json()}")
+except requests.exceptions.RequestException as e:
+    print(f"Failed to track download: {e}")
 ```
 
 ## Related tools / concepts
@@ -92,6 +111,7 @@ print(response.status_code)
 
 ## Sources / References
 - [Official Website](https://www.aitmpl.com/)
+- [Official Documentation](https://docs.aitmpl.com/)
 - [AI Templates Twitter](https://twitter.com/aitmpl)
 
 ## Contribution Metadata

--- a/docs/tools/automation_orchestration/google-workspace-cli.md
+++ b/docs/tools/automation_orchestration/google-workspace-cli.md
@@ -37,46 +37,90 @@ It eliminates the need to write custom `curl` calls or complex API glue code for
 
 ## Getting started
 
-### 1. Installation
-Install via `npm` or download a pre-built binary:
+### Installation
+You can install `gws` via NPM, Homebrew, Cargo, or Nix:
+
 ```bash
+# Recommended for Node environments
 npm install -g @googleworkspace/cli
+
+# On macOS and Linux via Homebrew
+brew install googleworkspace-cli
+
+# From source using Cargo
+cargo install --git https://github.com/googleworkspace/cli --locked
+
+# Run instantly using Nix
+nix run github:googleworkspace/cli
 ```
 
-### 2. Setup & Login
-Initialize your Google Cloud project and authenticate:
-```bash
-gws auth setup
-gws auth login
-```
+### Setup & Authentication
+To use `gws`, you must configure a Google Cloud project with OAuth credentials:
+
+1. **Automatic Setup**:
+   ```bash
+   gws auth setup   # Automatically guides you through GCP project config
+   ```
+2. **Login & Scopes**:
+   Select individual services to stay within unverified app limits (Google limits unverified OAuth consent screens to ~25 scopes):
+   ```bash
+   gws auth login --scopes drive,gmail,calendar
+   ```
+
+> [!WARNING]
+> If your OAuth application is in "Testing" mode, you **must** add your Google Account email as a "Test user" under the GCP Console → APIs & Services → OAuth consent screen, otherwise authentication will fail with a generic `Access blocked` or `403` error.
 
 ### Hello World Example
-List your most recent Google Drive files to verify the connection:
+Retrieve your most recent Google Drive files formatted in structured JSON to verify a successful connection:
+
 ```bash
 gws drive files list --params '{"pageSize": 5}'
 ```
 
 ## CLI examples
+The CLI features built-in custom commands prefixed with `+` (such as `+agenda` and `+send`) that wrap complex, multi-step API workflows:
+
 ```bash
-# Show today's calendar agenda
+# 1. Fetch today's calendar agenda formatted in your account's timezone
 gws calendar +agenda
 
-# Send a quick email via Gmail
-gws gmail +send --to user@example.com --subject "Hello" --body "Sent via gws CLI"
+# 2. Append rows dynamically to a Google Sheet with shell escaping protection
+gws sheets +append --spreadsheet "SPREADSHEET_ID" --values "Alice,95"
 
-# Append a row to a Google Sheet
-gws sheets +append --spreadsheet SPREADSHEET_ID --values "Name,Score"
+# 3. Send a thread-aware email via Gmail
+gws gmail +send --to recipient@example.com --subject "Automation Update" --body "Task completed successfully via gws CLI."
 ```
 
 ## API examples
-AI agents use the `schema` command to introspect API requirements and structured JSON output for reasoning:
+`gws` outputs standard, structured JSON to stdout. AI agents or external scripts can programmatically inspect API endpoint schemas or export headless credentials for automated runs:
 
+### Schema Introspection
+To dynamically build payload structures, query the schema definition of any target method:
 ```bash
-# Introspect request/response schema for an API method
 gws schema drive.files.list
 ```
-> [!NOTE]
-> For direct API integration, use the standard Google Workspace client libraries or the included AI agent skills.
+
+### Programmatic Credential Usage (Python Integration)
+Complete interactive login on your workstation, export the token securely, and reuse it inside an automated script:
+
+```python
+import subprocess
+import json
+
+# Export the plaintext credentials from your local OS keyring
+try:
+    result = subprocess.run(
+        ["gws", "auth", "export", "--unmasked"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    credentials = json.loads(result.stdout)
+    access_token = credentials.get("access_token")
+    print(f"Programmatic access token retrieved: {access_token[:10]}...")
+except subprocess.CalledProcessError as e:
+    print(f"Failed to export gws credentials: {e.stderr}")
+```
 
 ## Related tools / concepts
 - [Google Calendar](../calendar_tasks/google_calendar.md)
@@ -95,6 +139,5 @@ gws schema drive.files.list
 - [Google API Discovery Service](https://developers.google.com/discovery)
 
 ## Contribution Metadata
-
 - Last reviewed: 2026-07-21
 - Confidence: high

--- a/docs/tools/automation_orchestration/makefile-mcp.md
+++ b/docs/tools/automation_orchestration/makefile-mcp.md
@@ -37,53 +37,102 @@ Traditional Makefile MCP implementations often expose a single generic `make` to
 
 ## Getting started
 
-Makefile MCP registers documented targets as tools. Documentation is provided via `##` comments on the target line.
+Makefile MCP scans your project Makefile and converts each documented target into an individual MCP tool. Targets must be documented using double-hash (`##`) comments on the target declaration line.
+
+### Makefile Documentation Convention
+Ensure your project `Makefile` targets are structured as follows:
+```makefile
+.PHONY: test lint build
+
+test: ## Run the full unit and integration test suite
+	pytest tests/ -v
+
+lint: ## Execute lint and code style checks using ruff
+	ruff check src/
+
+build: lint test ## Package distribution archives
+	python3 -m build
+```
 
 ### 1. Installation
-Install using `uv` (recommended) or `pip`:
+Install the server package locally or run it dynamically using `uv` (recommended) or standard `pip`:
+
 ```bash
+# Recommended installation via uv
 uv pip install makefile-mcp
+
+# Standard installation via pip
+pip install makefile-mcp
+
+# Or run instantly without installation using uvx
+uvx makefile-mcp --list
 ```
 
 ### 2. Configuration (Claude Desktop)
-Configure your MCP client to run the server:
+To register the server with your MCP client, append it to your `claude_desktop_config.json` configuration file:
+
 ```json
 {
   "mcpServers": {
-    "make": {
+    "makefile-mcp": {
       "command": "uvx",
-      "args": ["makefile-mcp", "--cwd", "/path/to/project"]
+      "args": [
+        "makefile-mcp",
+        "--cwd",
+        "/absolute/path/to/your/project"
+      ]
     }
   }
 }
 ```
 
 ### Hello World Example
-Preview which targets will be discovered as tools in your current directory:
+Run the command in your shell to preview which Makefile targets will be exposed to your AI assistant as specialized tools:
+
 ```bash
 makefile-mcp --list
 ```
 
 ## CLI examples
-```bash
-# Start server with specific include/exclude patterns
-makefile-mcp --include "test,lint" --exclude "deploy"
+You can configure and customize target exposure and naming scopes directly via the command-line options:
 
-# Set a custom tool prefix to avoid collisions
+```bash
+# 1. Start the server exposing only safe targets while blocking dangerous ones
+makefile-mcp --include "test,lint,format" --exclude "deploy,publish"
+
+# 2. Expose targets with a custom tool prefix to avoid collision in client menus
 makefile-mcp --prefix "myproj_"
 
-# Use a specific Makefile and working directory
+# 3. Target a specific custom Makefile located outside the working directory
 makefile-mcp --makefile ./build/Makefile --cwd ./build
 ```
 
 ## API examples
-AI agents use the `set_working_directory` tool to switch context between projects at runtime:
+The Makefile MCP server registers specialized helper tools and exposes each target tool call programmatically.
+
+### Runtime Context Modification (JSON Protocol)
+AI agents can dynamically transition working directories or Makefile targets mid-session using the built-in `set_working_directory` tool:
 
 ```json
-// Change the working directory to a new project
-set_working_directory({
-  "path": "/absolute/path/to/new/project"
-})
+{
+  "name": "set_working_directory",
+  "arguments": {
+    "path": "/absolute/path/to/another/project/module"
+  }
+}
+```
+
+### Executing a Target Tool
+Once a target (e.g., `test`) is discovered, the agent invokes it with optional arguments or preview modes:
+
+```json
+{
+  "name": "make_test",
+  "arguments": {
+    "args": "VERBOSE=1",
+    "dry_run": false
+  }
+}
 ```
 
 ## Related tools / concepts
@@ -102,6 +151,5 @@ set_working_directory({
 - [FastMCP Documentation](https://github.com/jlowin/fastmcp)
 
 ## Contribution Metadata
-
 - Last reviewed: 2026-07-21
 - Confidence: high

--- a/docs/tools/automation_orchestration/vikunja-mcp.md
+++ b/docs/tools/automation_orchestration/vikunja-mcp.md
@@ -37,58 +37,100 @@ It allows agents to manage tasks, projects, labels, and teams directly within a 
 
 ## Getting started
 
-Vikunja MCP is best used via `npx` in your MCP client configuration.
+Vikunja MCP is most commonly run on-demand using `npx` within your MCP client configuration (such as Claude Desktop).
+
+### Authentication Setup
+The server supports two authentication modes:
+1. **API Token Authentication (Default)**: Best for general automation and task management. Create a token in Vikunja Settings → API Tokens. Format starts with `tk_`.
+2. **JWT Authentication (Advanced)**: Enables user profile modifications and data exports. Extract the `token` key value from your browser's Local Storage for your Vikunja domain. Format starts with `eyJ`.
 
 ### 1. Installation
-The server is typically run directly via `npx`:
+The server runs headless via Node.js or `npx`:
+
 ```bash
+# Verify the package launches correctly
 npx -y @democratize-technology/vikunja-mcp
 ```
 
-### 2. Authentication
-Set the following environment variables:
-- `VIKUNJA_URL`: Your instance API URL (e.g., `https://tasks.example.com/api/v1`)
-- `VIKUNJA_API_TOKEN`: Your API token (starts with `tk_`)
+### 2. Client Configuration (Claude Desktop)
+Add the server configuration block to your `claude_desktop_config.json`:
 
-### 3. Configuration (Claude Desktop)
 ```json
 {
   "mcpServers": {
-    "vikunja": {
+    "vikunja-mcp": {
       "command": "npx",
       "args": ["-y", "@democratize-technology/vikunja-mcp"],
       "env": {
-        "VIKUNJA_URL": "https://your-vikunja.com/api/v1",
-        "VIKUNJA_API_TOKEN": "tk_yourtoken"
+        "VIKUNJA_URL": "https://tasks.yourdomain.com/api/v1",
+        "VIKUNJA_API_TOKEN": "tk_your_api_token_here"
       }
     }
   }
 }
 ```
 
-## CLI examples
+### Hello World Example
+Test connection status by authenticating and listing your active tasks across all projects:
+
 ```bash
-# Start the server with debug logging
+# Set environment variables
+export VIKUNJA_URL="https://tasks.yourdomain.com/api/v1"
+export VIKUNJA_API_TOKEN="tk_your_api_token"
+
+# List tasks via MCP-compatible schema testing
+npx @democratize-technology/vikunja-mcp
+```
+
+## CLI examples
+You can tune the runtime environment, rate limits, and circuit breakers of the MCP server using environment flags:
+
+```bash
+# 1. Start the server with verbose debug logs written to stderr
 DEBUG=true LOG_LEVEL=debug npx @democratize-technology/vikunja-mcp
 
-# Start with custom rate limiting
-RATE_LIMIT_PER_MINUTE=120 npx @democratize-technology/vikunja-mcp
+# 2. Apply strict API rate limits to protect your self-hosted instance from DoS
+RATE_LIMIT_ENABLED=true RATE_LIMIT_PER_MINUTE=60 npx @democratize-technology/vikunja-mcp
 
-# Using JWT for user-management features
-VIKUNJA_API_TOKEN="eyJ..." npx @democratize-technology/vikunja-mcp
+# 3. Connect using a browser-extracted JWT token to unlock advanced user tools
+VIKUNJA_API_TOKEN="eyJhbGciOiJIUzI1..." npx @democratize-technology/vikunja-mcp
 ```
 
 ## API examples
-Agents interact with the server using the `vikunja_tasks` toolset:
+The Vikunja MCP server uses structured subcommand structures.
+
+### Creating a Recurring Task (JSON Tool Input)
+AI assistants create projects, labels, and tasks by invoking registered tool definitions:
+
 ```json
-// Create a new task with labels and assignees
-vikunja_tasks.create({
-  "projectId": 1,
-  "title": "Complete 2026 Audit",
-  "priority": 5,
-  "labels": [10, 22],
-  "dueDate": "2026-06-30T12:00:00Z"
-})
+{
+  "name": "vikunja_tasks",
+  "arguments": {
+    "subcommand": "create",
+    "projectId": 1,
+    "title": "Weekly Security Audit",
+    "description": "Perform dependency and container scans",
+    "dueDate": "2026-12-01T10:00:00Z",
+    "priority": 4,
+    "repeatAfter": 7,
+    "repeatMode": "day",
+    "labels": [12]
+  }
+}
+```
+
+### Listing Tasks with Complex Filters
+Filter tasks using SQL-like expressions executed server-side with local fallback:
+
+```json
+{
+  "name": "vikunja_tasks",
+  "arguments": {
+    "subcommand": "list",
+    "filter": "(priority >= 4 && done = false) || (dueDate < now && done = false)",
+    "perPage": 10
+  }
+}
 ```
 
 ## Related tools / concepts
@@ -107,6 +149,5 @@ vikunja_tasks.create({
 - [Vikunja API Documentation](https://vikunja.io/docs/api/)
 
 ## Contribution Metadata
-
 - Last reviewed: 2026-07-21
 - Confidence: high

--- a/docs/tools/process_understanding/parea.md
+++ b/docs/tools/process_understanding/parea.md
@@ -37,55 +37,89 @@ Parea bridges the gap between prompt experimentation and production reliability.
 ## Getting started
 
 ### Installation
+Install the official Parea SDK via `pip` (Python) or `@parea-ai/sdk` (Node.js):
+
 ```bash
+# Install Python SDK
 pip install parea-ai
+
+# Or install Node.js SDK
+npm install @parea-ai/sdk
 ```
 
-### Basic Tracing
+### Authentication Setup
+Get your API key from the Parea dashboard and export it to your environment:
+
+```bash
+export PAREA_API_KEY="your_api_key_here"
+```
+
+### Hello World Example
+Initialize Parea and wrap your LLM function with the `@trace` decorator to automatically log execution data, token consumption, and latency:
+
 ```python
 from parea import Parea, trace
 
-p = Parea(api_key="YOUR_API_KEY")
+# Initialize the Parea SDK (reads PAREA_API_KEY from environment)
+p = Parea()
 
 @trace
-def my_llm_function(query: str):
-    # Your LLM logic here
-    return "Result"
+def my_llm_function(user_query: str) -> str:
+    # Your LLM call or business logic here
+    response_text = f"Processed query: {user_query}"
+    return response_text
 
-my_llm_function("Hello Parea!")
+# Run the function; trace is automatically dispatched to the dashboard
+print(my_llm_function("Hello Parea!"))
 ```
 
 ## CLI examples
+The `parea` command-line utility provides commands to manage local authentication, run batch evaluations, and fetch deployed prompts:
 
-### parea login
 ```bash
+# 1. Authenticate your local shell environment with Parea Cloud
 parea login
-```
 
-### parea experiment
-```bash
-parea experiment --func my_script.py:my_func --data my_data.json
+# 2. Run a local evaluation experiment on your functions against a dataset file
+parea experiment --func my_script.py:my_func --data ./test_dataset.json
+
+# 3. List or inspect locally deployed prompt assets in your active project
+parea deploy list
 ```
 
 ## API examples
+Deploy, run, and score automated evaluations (experiments) programmatically using the Parea client.
 
-### Python (Running an Experiment)
+### Programmatic Experiment with Heuristic Evaluators
+Define a target function, prepare a list of test cases, and execute a local evaluation pipeline with automated metric scoring:
+
 ```python
 from parea import Parea
 from parea.schemas import TestCase
+from parea.evals.general import levenshtein
 
-p = Parea(api_key="YOUR_API_KEY")
+p = Parea()
 
-def my_llm_func(input: str) -> str:
-    return f"AI says: {input}"
+def my_llm_runner(inputs: dict) -> str:
+    # Simulated LLM response
+    return f"AI Answer: {inputs['query']}"
 
-# Run evaluation on a small dataset
-data = [TestCase(inputs={"input": "Hello"}, target="AI says: Hello")]
-p.experiment(
-    name="baseline-test",
-    data=data,
-    func=my_llm_func,
+# Prepare test data with target outputs
+test_cases = [
+    TestCase(
+        inputs={"query": "Draft a welcome message"},
+        target="AI Answer: Draft a welcome message"
+    )
+]
+
+# Configure and run the experiment using the Levenshtein distance metric
+experiment_result = p.experiment(
+    name="welcome-prompt-test",
+    data=test_cases,
+    func=my_llm_runner,
 ).run()
+
+print(f"Experiment completed. Metrics: {experiment_result}")
 ```
 
 ## Related tools / concepts
@@ -102,8 +136,8 @@ p.experiment(
 ## Sources / References
 - [Parea AI Website](https://www.parea.ai/)
 - [Parea Documentation](https://docs.parea.ai/)
-- [Modern LLM Observability Patterns (June 2026)](https://example.com/parea-v2-patterns)
+- [Modern LLM Observability Patterns](https://docs.parea.ai/welcome/what_is_parea_ai)
 
 ## Contribution Metadata
-- Last reviewed: 2026-06-26
+- Last reviewed: 2026-07-21
 - Confidence: high


### PR DESCRIPTION
This pull request enriches the 5 shortest documentation files in the repository (aitmpl.md, google-workspace-cli.md, makefile-mcp.md, vikunja-mcp.md, and parea.md). For each of these documents, we visited their official sources/references and fully populated their `## Getting started`, `## CLI examples`, and `## API examples` sections with precise installation, setup, usage, and programmatic code snippets. Standard quality audit and contract checks are fully passing.

---
*PR created automatically by Jules for task [13570235964293903164](https://jules.google.com/task/13570235964293903164) started by @joanmarcriera*