### PR TITLE
Integrate Gemini 3.6 Flash and triage Batch 254

### DIFF
--- a/docs/new-sources/2026-07-23.md
+++ b/docs/new-sources/2026-07-23.md
@@ -2,7 +2,7 @@
 
 | Title | URL | Tags | Status | Canonical Page | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Gemini 3.6 Flash | [https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/](https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/) | provider | new | - | New high-efficiency model variants from Google DeepMind. |
+| Gemini 3.6 Flash | [https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/](https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/) | provider | integrated | [Gemini](../tools/ai_knowledge/gemini.md) | New high-efficiency model variants from Google DeepMind. |
 | GS1-1T | [https://www.reddit.com/r/LocalLLaMA/comments/1v3q47x/genesisscience1_gs1_1t_openweight_model_later/](https://www.reddit.com/r/LocalLLaMA/comments/1v3q47x/genesisscience1_gs1_1t_openweight_model_later/) | tool | new | - | Open-weight model released by GenesisScience. |
 | G9V-33B | [https://www.reddit.com/r/LocalLLaMA/comments/1v46ay5/ai9stars_released_g9v33b/](https://www.reddit.com/r/LocalLLaMA/comments/1v46ay5/ai9stars_released_g9v33b/) | tool | new | - | LLM released by AI9Stars. |
 | Fara-1527B | [https://www.reddit.com/r/LocalLLaMA/comments/1v3ny84/microsoftfara1527b_hugging_face/](https://www.reddit.com/r/LocalLLaMA/comments/1v3ny84/microsoftfara1527b_hugging_face/) | tool | new | - | Microsoft model available on Hugging Face. |

--- a/docs/reports/task-decomposition-batch-254.md
+++ b/docs/reports/task-decomposition-batch-254.md
@@ -1,0 +1,53 @@
+# Task Decomposition: Batch 254 (Late July 2026 Daily Intake Logs)
+
+This report implements **Action C** (Work Decomposition) for the outstanding daily intake issues identified on July 23, 24, 25, and 26, 2026.
+
+## Batch 254 Overview
+- **Objective**: Organize, group, and triage outstanding daily log items from late July 2026 into logical, high-confidence sub-batches for future Ralph-loop execution.
+- **Decomposition Action**: Structuring 17 new external models, generative platforms, runtime optimizers, and compilers into thematic categories.
+
+---
+
+## Sub-Batch 254.1: Google Gemini Models & Ecosystem (integrated)
+These tasks track deep integrations of Google's flagship multimodal models into our canonical pages.
+
+| Title | URL | Tags | Status | Canonical Page (Target) | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| Gemini 3.6 Flash | [https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/](https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/) | provider | **integrated** | `docs/tools/ai_knowledge/gemini.md` | Fully integrated the July 21, 2026 Gemini 3.6 Flash, 3.5 Flash-Lite, and 3.5 Flash Cyber (CodeMender) updates. |
+
+---
+
+## Sub-Batch 254.2: Frontier & Local Open-Weight Models (Pending)
+These tasks track new local open-weights model families, providers, and image/audio generators.
+
+| Title | URL | Tags | Status | Canonical Page (Target) | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| GS1-1T | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v3q47x/genesisscience1_gs1_1t_openweight_model_later/) | tool | **Pending** | `docs/tools/providers/genesisscience.md` | Document the 1T parameter open-weights model released by GenesisScience. |
+| G9V-33B | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v46ay5/ai9stars_released_g9v33b/) | tool | **Pending** | `docs/tools/providers/ai9stars.md` | Add specifications for the 33B model released by AI9Stars. |
+| Fara-1527B | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v3ny84/microsoftfara1527b_hugging_face/) | tool | **Pending** | `docs/tools/providers/microsoft.md` | Document Microsoft's extremely large open-weights Fara model family. |
+| Antling-30B-Flash | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v4m5cr/antling30flash_is_now_live_on_openrouter_and_free/) | tool | **Pending** | `docs/tools/providers/antling.md` | Document the Antling 30B Flash model available on OpenRouter. |
+| SwissAI Apertus v1.5 | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v539p8/swissaiapertusv15_70b8b/) | tool | **Pending** | `docs/tools/providers/swissai.md` | Create documentation for the SwissAI Apertus open-source model series. |
+| FLUX.1 | [Link](https://www.latent.space/p/ainews-black-forest-labs-flux-3-multimodal) | tool | **Pending** | `docs/tools/ai_knowledge/flux.md` | Document Black Forest Labs' multimodal image generation and refinement workflows. |
+| Higgs Audio v3 | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v4w5cj/audiocpp_release_04_higgs_audio_v3_tts_4b_10x/) | tool | **Pending** | `docs/tools/ai_knowledge/higgs-audio.md` | Document the Higgs Audio v3 TTS model and high-speed audio integration. |
+| Inflect v2 | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v5ve6v/i_released_inflect_v2_two_ultratiny_complete_tts/) | tool | **Pending** | `docs/tools/ai_knowledge/inflect-tts.md` | Add specifications for the ultra-tiny complete text-to-speech (TTS) model series. |
+
+---
+
+## Sub-Batch 254.3: Infrastructure, Optimization & Frameworks (Pending)
+These tasks track low-level hardware optimizations, serving backends, enterprise platforms, and prompt datasets.
+
+| Title | URL | Tags | Status | Canonical Page (Target) | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| OpenAI Presence | [Link](https://openai.com/index/introducing-openai-presence) | provider | **Pending** | `docs/tools/enterprise/openai-presence.md` | Create enterprise agent platform documentation for OpenAI Presence. |
+| MindControl | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v3ms3c/mindcontrol_llamacpp_fork_to_guide_the_reasoning/) | tool, framework | **Pending** | `docs/tools/infrastructure/mindcontrol.md` | Document the llama.cpp fork designed to guide reasoning paths. |
+| Nunchaku Diffusers | [Link](https://huggingface.co/blog/nunchaku-diffusers) | framework | **Pending** | `docs/tools/frameworks/nunchaku.md` | Add details for the optimization library for diffusion model inference. |
+| MLIR | [Link](https://hiraditya.github.io/posts/mlir-dialect-stack-for-ml/) | framework | **Pending** | `docs/tools/frameworks/mlir.md` | Document Multi-Level Intermediate Representation compilation stacks for ML compilers. |
+| The Stack v3 | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v59aek/hugging_face_releases_the_stack_v3_largest_open/) | provider | **Pending** | `docs/tools/providers/the-stack.md` | Document Hugging Face's code-centric dataset standard for model training. |
+| cachyllamas | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v5k08a/cachyllamas_llamacpp_fork_with_persistent_kv/) | tool | **Pending** | `docs/tools/infrastructure/cachyllamas.md` | Document the llama.cpp fork featuring persistent host KV caching. |
+| DKV | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v5wviz/dkv_opensource_kvcache_compression_framework_for/) | framework | **Pending** | `docs/tools/frameworks/dkv.md` | Document the open-source KV-cache compression and management framework. |
+| TensorSharp | [Link](https://www.reddit.com/r/LocalLLaMA/comments/1v6ect8/benchmarks_tensorsharp_vs_llamacpp/) | tool, framework | **Pending** | `docs/tools/frameworks/tensorsharp.md` | Document the .NET-based tensor library for local LLM operations. |
+
+---
+- Status: Batch 254 Triage Complete (Action C Executed).
+- Date: 2026-07-27
+- Created by: Jules

--- a/docs/tools/ai_knowledge/gemini.md
+++ b/docs/tools/ai_knowledge/gemini.md
@@ -1,42 +1,46 @@
 # Gemini
 
 ## What it is
-Gemini is Google's most capable and general family of AI models, built to be natively multimodal from the ground up. By late July 2026, the series has matured into the **Gemini 3.5** family, including **Gemini 3.5 Ultra**, **Gemini 3.5 Pro**, **Gemini 3.5 Flash**, and the speed-optimized **Gemini 3.1 Flash-Lite**.
+Gemini is Google's most capable and general family of AI models, built to be natively multimodal from the ground up. By late July 2026, the series has matured into the **Gemini 3.5 and 3.6** families, representing Google's most advanced AI ecosystem. This includes the highly capable workhorse **Gemini 3.6 Flash**, the high-throughput speed champion **Gemini 3.5 Flash-Lite**, the secure specialized **Gemini 3.5 Flash Cyber** (deployed within the CodeMender code security agent), and the frontier-class **Gemini 3.5 Ultra** and **Gemini 3.5 Pro**.
 
 ## What problem it solves
-Gemini provides a highly integrated AI experience across the Google ecosystem, solving the "Multimodal Gap" by processing text, code, audio, image, and video within a single native reasoning engine. Its massive context window (up to 2 million tokens) addresses the limitation of traditional RAG systems by allowing entire codebases or hours of video to be processed in-context, coupled with late July 2026 structured caching to minimize latency and token overhead.
+Gemini solves the "Multimodal Gap" by processing text, code, audio, image, and video within a single native reasoning engine. It addresses the overhead, high costs, and latency of traditional LLM pipelines in agentic workflows by:
+- **Reducing Output Token Verbosity**: Gemini 3.6 Flash consumes 17% fewer output tokens compared to Gemini 3.5 Flash on Artificial Analysis, and up to 65% on coding tasks like DeepSWE.
+- **Extreme Speed/Throughput**: Gemini 3.5 Flash-Lite runs at 350 output tokens per second, making real-time high-volume processing highly viable.
+- **Native Computer Use**: Simplifies automated desktop/browser interaction by exposing "computer use" as a native client-side tool.
+- **Cybersecurity Vulnerability Mitigation**: Gemini 3.5 Flash Cyber addresses the slow turnaround of vulnerability patching by detecting, validating, and patching flaws in secure environments.
 
 ## Where it fits in the stack
-**AI Model / Multimodal Foundation**. It serves as the primary intelligence layer for Google-integrated agentic workflows, available via Google AI Studio, Vertex AI, and as the engine behind [Antigravity Agent](antigravity-agent.md).
+**AI Model / Multimodal Foundation**. It serves as the primary intelligence layer for Google-integrated agentic workflows, available via Google AI Studio, Vertex AI, and Google Antigravity (AGY), often working in tandem with [Antigravity Agent](antigravity-agent.md).
 
 ## Typical use cases
-- **Multimodal analysis**: Analyzing video, audio, and images natively (e.g., "Summarize the events in this security footage").
-- **Large-scale codebase analysis**: Refactoring and documenting massive repositories using the 2M token context window.
-- **Agentic Workflows**: Using Gemini 3.5 Flash for high-speed tool use and autonomous reasoning via the **Antigravity Agent** platform.
-- **Production RAG**: High-efficiency retrieval augmented generation with Flash-tier models, utilizing native vector indexing.
-- **Agentic Search**: Powering [Google Search](google-search.md) synthesis and multi-step research tasks.
+- **Multi-Agent Orchestration**: Coordinating complex, multi-turn reasoning steps with 3.6 Flash serving as a master router and 3.5 Flash-Lite as subagents generating rapid concepts.
+- **High-Throughput Ingestion**: Powering large-scale translation, receipt scanning, and product metadata extraction at minimal cost.
+- **Autonomous Agentic Coding**: Running code migrations and complex refactoring with 3.6 Flash (MLE Bench rating: 63.9%, DeepSWE: 49%).
+- **Interactive Visual Studios**: Building visual theme builders or mockups using real-time image understanding coupled with tldraw.
+- **Automated Security Patching**: Deploying 3.5 Flash Cyber within CodeMender to automatically generate secure pull requests on compromised codebases.
 
 ## Strengths
-- **Native Multimodality**: Built from the ground up to handle text, images, video, and audio simultaneously without separate encoders.
-- **Industry-Leading Context Window**: 2M tokens standard across the 3.5 series, enabling "Long-Context as a Service".
-- **Structured Caching**: (July 2026) Allows persistent in-memory caching of large context blocks (repos, manuals), reducing prompt cost by 90% and response latency for multi-turn runs.
-- **Managed Agents**: Support for stateful, autonomous agents running in secure sandboxes (Antigravity).
-- **Speed**: Gemini 3.5 Flash offers 4x output speed compared to previous generation Pro models while maintaining frontier-level intelligence.
-- **MCP 3.1 Support**: Native integration with the Model Context Protocol (MCP 3.1) for seamless, secure tool calling.
+- **Reduced Output Costs**: Gemini 3.6 Flash is priced cost-effectively at $1.50 per 1M input tokens and $7.50 per 1M output tokens.
+- **Blazing Speed**: Gemini 3.5 Flash-Lite leads the industry with 350 output tokens/s.
+- **Fine-grained Control**: 3.5 Flash-Lite allows developers to configure minimal, low, or high thinking levels depending on workload complexity.
+- **Fewer Execution Loops**: Substantial reduction in unwanted code edits and infinite tool-calling loops.
+- **Native Tool Integration**: Built-in native support for Computer Use and Code Execution.
+- **Frontier Safety**: Shipped with advanced safeguards against Chemical, Biological, Radiological, and Nuclear (CBRN) risks, and robust resistance to adversarial jailbreaks.
 
 ## Limitations
-- **Ecosystem Lock-in**: Deepest integration is limited to Google Cloud/Workspace services.
-- **Privacy**: Proprietary models with data handling policies that may not suit local-first or highly regulated requirements.
-- **Context Latency**: While throughput is high, very large context prompts (1M+ tokens) still incur significant time-to-first-token (TTFT) delays if not cached.
+- **Ecosystem Lock-in**: Deepest integration is limited to Google Cloud/Workspace and Google Antigravity platforms.
+- **Restricted Access**: Gemini 3.5 Flash Cyber is restricted to governments and trusted partners in a limited pilot program.
+- **Privacy**: Proprietary cloud processing is required for full multimodal, large-scale workflows (though small local tasks can offload to Gemma).
 
 ## When to use it
+- When building production-scale autonomous agents requiring low-cost, low-latency execution (using 3.5 Flash-Lite and 3.6 Flash).
 - When you need to process extremely long documents, multiple hours of video, or entire codebases in a single prompt.
-- When building autonomous agents that require high-speed tool calling and native web browsing (via Antigravity).
-- For native video-to-image or video-to-text generation tasks where alignment between frames is critical.
+- For tasks requiring robust, native client-side computer use capabilities.
 
 ## When not to use it
 - If you require a fully local, air-gapped solution (use Gemma or Llama 3/4 via [Ollama](../../services/ollama.md) instead).
-- If your workload is primarily small-context, high-reasoning text where [Claude](claude.md) may have an edge in logical precision.
+- If your workload does not benefit from multimodal inputs or token/caching optimization.
 
 ## Getting started
 1. **API Key**: Obtain a Gemini API key from [Google AI Studio](https://aistudio.google.com/).
@@ -53,7 +57,7 @@ client = genai.Client(api_key="YOUR_API_KEY")
 4. **First Prompt**:
 ```python
 response = client.models.generate_content(
-    model='gemini-3.5-flash',
+    model='gemini-3.6-flash',
     contents="What is the current state of agentic RAG?"
 )
 print(response.text)
@@ -63,14 +67,14 @@ print(response.text)
 Using the [Gemini CLI](gemini-cli.md) for terminal-based interaction:
 
 ```bash
-# Basic text generation
-gemini-cli "Summarize the latest trends in MCP 3.1"
+# Basic text generation using 3.6 Flash
+gemini-cli --model gemini-3.6-flash "Summarize the latest trends in MCP 3.1"
 
-# Multimodal input (sending a screenshot)
-gemini-cli --image screenshot.png "Explain this UI layout"
+# Multimodal input (sending a screenshot to Flash-Lite)
+gemini-cli --model gemini-3.5-flash-lite --image screenshot.png "Explain this UI layout"
 
 # Processing a video file
-gemini-cli --video meeting_recording.mp4 "What were the action items?"
+gemini-cli --model gemini-3.6-flash --video meeting_recording.mp4 "What were the action items?"
 ```
 
 ## API examples
@@ -85,7 +89,7 @@ client = genai.Client(api_key="YOUR_API_KEY")
 video_file = client.files.upload(file="large_codebase_walkthrough.mp4")
 
 response = client.models.generate_content(
-    model='gemini-3.5-pro',
+    model='gemini-3.6-flash',
     contents=[
         video_file,
         "Based on this video, write a technical specification for the authentication module."
@@ -95,16 +99,25 @@ response = client.models.generate_content(
 print(response.text)
 ```
 
-### Managed Agents (Antigravity Preview)
+### Configurable Thinking Levels (Python)
 ```python
 from google import genai
+from google.genai import types
 
 client = genai.Client(api_key="YOUR_API_KEY")
-# Utilizing the Antigravity agentic platform via unified client
-response = client.models.generate_content(
-    model='antigravity-preview',
-    contents="Research the latest developments in Blackwell GPUs and write a 500-word report."
+
+# Setting thinking levels for high-throughput subagent tasks with Gemini 3.5 Flash-Lite
+config = types.GenerateContentConfig(
+    thinking_level="high",  # Can be minimal, low, or high
+    temperature=0.2
 )
+
+response = client.models.generate_content(
+    model='gemini-3.5-flash-lite',
+    contents="Synthesize e-commerce product features across 10,000 product rows.",
+    config=config
+)
+
 print(response.text)
 ```
 
@@ -122,10 +135,9 @@ print(response.text)
 - [Antigravity Agent](antigravity-agent.md)
 - [Model Context Protocol (MCP) 3.1](../../knowledge_base/patterns/tool-calling-and-mcp.md)
 
-## Sources / References
-- [Official Website](https://gemini.google.com/)
+## Sources / references
+- [Introducing Gemini 3.6 Flash, 3.5 Flash-Lite, and 3.5 Flash Cyber](https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/)
 - [Gemini API Release Notes (July 2026)](https://ai.google.dev/gemini-api/docs/changelog)
-- [Announcing Gemini 3.5](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5-announcement/)
 - [Google AI Studio](https://aistudio.google.com/)
 - [Antigravity Agent Guide](https://ai.google.dev/gemini-api/docs/antigravity)
 - [Managed Agents Overview](https://aistudio.google.com/managed-agents)

--- a/docs/tools/ai_knowledge/google-gemini.md
+++ b/docs/tools/ai_knowledge/google-gemini.md
@@ -1,40 +1,44 @@
 # Google Gemini
 
 ## What it is
-Google Gemini is a family of multimodal large language models developed by Google DeepMind. As of July 2026, it represents Google's most capable AI ecosystem, featuring Gemini 2.0 Pro and Flash models. It is uniquely characterized by its massive context window, native multimodal reasoning, and seamless integration with [Gemma 3](local_llms.md) for hybrid cloud-local workflows.
+Google Gemini is a family of multimodal large language models developed by Google DeepMind. As of late July 2026, the ecosystem features the cutting-edge **Gemini 3.6** and **Gemini 3.5** model families, which include the highly capable **Gemini 3.6 Flash**, the high-throughput **Gemini 3.5 Flash-Lite**, the secure specialized **Gemini 3.5 Flash Cyber** (integrated within CodeMender for vulnerability patching), and the enterprise-tier **Gemini 3.5 Pro** and **Gemini 3.5 Ultra**.
 
 ## What problem it solves
-It provides state-of-the-art reasoning across text, code, images, audio, and video. Notably, Gemini 2.0 Pro features an expanded 4-million token context window, solving the problem of analyzing massive data lakes, entire repositories, or long-form video archives in a single pass. It also leverages [Model Context Protocol (MCP)](../automation_orchestration/mcp.md) 3.0 for advanced tool orchestration.
+It provides state-of-the-art native multimodal reasoning across text, code, images, audio, and video, addressing performance bottlenecks and high operating costs of agentic workflows by:
+- **Increasing Token Efficiency**: Gemini 3.6 Flash reduces overall output token usage by 17% compared to 3.5 Flash, and by up to 65% in execution benchmarks like Datacurve's DeepSWE.
+- **Minimizing Latency**: Gemini 3.5 Flash-Lite generates a blistering 350 output tokens per second, making it the fastest model in the 3.5 class.
+- **Automating Code Security**: Gemini 3.5 Flash Cyber automates the identification and fixing of critical vulnerabilities under CodeMender.
+- **Simplifying UI Interactivity**: Native computer use capabilities remove the need for custom scraping and manual browser automation setups.
 
 ## Where it fits in the stack
-**Provider / LLM**. It serves as a primary reasoning engine for agents and applications requiring deep multimodal understanding, extremely large context processing, or integration with the Google Cloud (Vertex AI) ecosystem, often working in tandem with [FastMCP 3.0](../automation_orchestration/mcp.md).
+**Provider / LLM**. It serves as a primary reasoning engine for agents and applications requiring deep multimodal understanding, high-throughput context processing, or integration with the Google Cloud (Vertex AI) ecosystem, working in tandem with [Model Context Protocol (MCP)](../automation_orchestration/mcp.md) 3.1.
 
 ## Typical use cases
-- **Ultra-Long Context Analysis**: Processing massive repositories or hour-long videos (up to 4M tokens) in one prompt.
-- **Multimodal Workflows**: Extracting information from complex visual and auditory data without intermediate steps.
-- **Cost-Efficient RAG**: Using context caching to store large, frequently accessed datasets for low-cost querying.
-- **Agentic Automation**: Leveraging Gemini's native tool-use capabilities integrated with [MCP 3.0](../automation_orchestration/mcp.md) servers.
+- **Multi-Agent Coding Pipelines**: Running codebase migrations and automated debugging using Gemini 3.6 Flash's high-precision coding abilities (MLE Bench: 63.9%, DeepSWE: 49%).
+- **High-Throughput Translation and Data Extraction**: Querying massive datasets cost-effectively with Gemini 3.5 Flash-Lite.
+- **Real-Time Interactive Workspace Simulation**: Building interactive UI mockups and canvas tools leveraging real-time vision capabilities.
+- **Secure Code Patching**: Executing closed-loop vulnerability identification and repair via Gemini 3.5 Flash Cyber managed agents.
 
 ## Strengths
-- **Massive Context Window**: Industry-leading 4-million token context window for Gemini 2.0 Pro.
-- **Context Caching**: Significantly reduces costs for tasks that reuse the same large token sets across multiple prompts.
-- **Native Multimodality**: Built from the ground up to reason across different modalities simultaneously.
-- **Gemini Omni Multimodal Integration**: (July 2026) Features support for Gemini Omni personal avatars, enabling real-time multimodal system analysis and highly contextual interactive workspace simulations.
-- **Integrated Code Execution**: Can generate, run, and learn from Python code natively within the model loop.
+- **Reduced Pricing**: Gemini 3.6 Flash costs $1.50/1M input tokens and $7.50/1M output tokens, cutting overall cost per agentic task.
+- **Ultra-High Speed**: Gemini 3.5 Flash-Lite runs at 350 output tokens/s.
+- **Configurable Intelligence**: Flash-Lite features multiple "thinking levels" (minimal/low/high) to trade off speed for logical depth.
+- **Fewer Loop Refusals**: Highly precise instructions prevent unnecessary tool-calling loops and unwanted file edits.
+- **Frontier Safeguards**: Includes top-tier defenses against Chemical, Biological, Radiological, and Nuclear (CBRN) misuses.
 
 ## Limitations
-- **Privacy Constraints**: As a proprietary cloud model, data is processed on Google's infrastructure (managed via Vertex AI or AI Studio).
-- **Over-Filtering**: Safety guardrails can sometimes be aggressive, potentially impacting certain technical workflows.
-- **Cost of Large Context**: While caching helps, un-cached multi-million token prompts can be expensive for high-volume applications.
+- **Ecosystem Lock-in**: Deepest integration is limited to Google Cloud/Workspace and Google Antigravity platforms.
+- **Restricted Pilot Access**: Gemini 3.5 Flash Cyber is strictly limited to governments and approved enterprise partners.
+- **Proprietary Cloud Infrastructure**: Requires external API calls, which may not satisfy local data residency laws.
 
 ## When to use it
-- When your task requires processing contexts larger than 200k tokens (e.g., analyzing a 5,000-page PDF).
-- For complex multimodal tasks involving video, audio, or multi-image reasoning.
-- When you need a highly efficient, low-latency model with significant reasoning power (Gemini 2.0 Flash).
+- When building enterprise agents requiring rapid multi-agent collaboration with a master router model (3.6 Flash) and low-latency subagents (3.5 Flash-Lite).
+- When you require native computer use client tools out of the box.
+- For high-volume e-commerce or metadata extraction workflows where speed and cost-per-token are key constraints.
 
 ## When not to use it
 - For strictly local or air-gapped tasks requiring 100% data sovereignty; use [Gemma 3](local_llms.md) instead.
-- For simple, low-token text tasks where a cheaper or specialized local model would be more efficient.
+- If your workflow is strictly single-modality and does not require low-latency or high-throughput optimizations.
 
 ## Getting started
 1. **Access**: Visit [Google AI Studio](https://aistudio.google.com/) for a developer-friendly playground and API access.
@@ -46,19 +50,16 @@ It provides state-of-the-art reasoning across text, code, images, audio, and vid
 The `gcloud` CLI and specialized SDK wrappers provide terminal-based interaction with Gemini models.
 
 ```bash
-# Generate content via curl using your API key (2.0 Flash example)
-curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$GOOGLE_API_KEY" \
+# Generate content via curl using your API key (3.6 Flash example)
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent?key=$GOOGLE_API_KEY" \
     -H 'Content-Type: application/json' \
     -X POST \
     -d '{ "contents": [{ "parts":[{"text": "Analyze these logs for July 2026 security anomalies."}]}] }'
 
-# List available Gemini models via gcloud
-gcloud ai models list --region=us-central1 --project=$PROJECT_ID
-
-# Use context caching for a large dataset
+# Use context caching for a large dataset on Gemini 3.6 Flash
 curl -X POST "https://generativelanguage.googleapis.com/v1beta/cachedContents?key=$GOOGLE_API_KEY" \
     -H 'Content-Type: application/json' \
-    -d '{ "model": "models/gemini-2.0-pro-exp", "contents": [...] }'
+    -d '{ "model": "models/gemini-3.6-flash", "contents": [...] }'
 ```
 
 ## API examples
@@ -70,9 +71,9 @@ import os
 
 genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
 
-# Initialize the model with code execution enabled
+# Initialize the 3.6 Flash model with code execution enabled
 model = genai.GenerativeModel(
-    model_name='gemini-2.0-pro',
+    model_name='gemini-3.6-flash',
     tools='code_execution'
 )
 
@@ -93,11 +94,11 @@ print(response.text)
 - [NotebookLM](./notebooklm.md) — Google's AI-powered research and note-taking tool built on Gemini.
 
 ## Sources / references
-- [Google DeepMind: Gemini 2.0](https://deepmind.google/technologies/gemini/v2-0/)
+- [Introducing Gemini 3.6 Flash, 3.5 Flash-Lite, and 3.5 Flash Cyber](https://deepmind.google/blog/introducing-gemini-36-flash-35-flash-lite-and-35-flash-cyber/)
 - [Gemini Omni Personal Avatars in Workspace](https://blog.google/products-and-platforms/products/workspace/gemini-omni-personal-avatars/)
 - [Gemini API: Context Caching and 4M Token Window](https://ai.google.dev/gemini-api/docs/caching)
 - [Google Developers Blog: Gemini API New Features July 2026](https://developers.googleblog.com/en/july-2026-updates/)
 
 ## Contribution Metadata
-- Last reviewed: 2026-07-21
+- Last reviewed: 2026-07-27
 - Confidence: high


### PR DESCRIPTION
This submission resolves the oldest outstanding issues from the daily intake logs of late July 2026. Specifically, it integrates Gemini 3.6 Flash, Gemini 3.5 Flash-Lite, and Gemini 3.5 Flash Cyber into the canonical documentation pages (Action A & B). It also triages and decomposes the remaining 16 outstanding items into thematic pending categories inside a newly created task-decomposition report `docs/reports/task-decomposition-batch-254.md` (Action C). All changes were verified and passed 100% compliance on the KnowledgeOps quality suite.

---
*PR created automatically by Jules for task [9577832547950723657](https://jules.google.com/task/9577832547950723657) started by @joanmarcriera*